### PR TITLE
docs(alice): integrate operator bootstrap and boundary docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -153,6 +153,16 @@
         "tab": "Advanced",
         "groups": [
           {
+            "group": "Operators",
+            "pages": [
+              "operators/alice-operator-bootstrap",
+              "operators/alice-system-boundary",
+              "operators/stack-lifecycle-glossary",
+              "agents/runtime-and-lifecycle",
+              "deployment"
+            ]
+          },
+          {
             "group": "Plugins",
             "pages": [
               "plugins/overview",

--- a/docs/operators/alice-operator-bootstrap.md
+++ b/docs/operators/alice-operator-bootstrap.md
@@ -1,0 +1,83 @@
+# Alice Operator Bootstrap
+
+## Purpose
+
+Provide one correct bootstrap path for an operator who needs to stand up Alice
+with the right runtime, knowledge, boundaries, and deploy order.
+
+## When to use
+
+Use this document when:
+
+- creating a fresh Alice environment
+- rebuilding an operator workstation
+- validating that Milady and `555-bot` still agree on Alice ownership and setup
+
+## Prereqs
+
+- access to `milaidy`
+- access to `555-bot` if you intend to use the production deploy path
+- model/provider credentials
+- required plugin credentials for the surfaces you will enable
+
+## Steps
+
+1. Read the current platform context:
+   - `README.md`
+   - `architecture`
+   - `what-you-can-build`
+   - `configuration`
+2. Install and configure Milady using:
+   - `installation`
+   - `quickstart`
+   - `configuration`
+3. Confirm runtime and lifecycle expectations:
+   - `agents/runtime-and-lifecycle`
+   - `architecture`
+4. Seed or validate the Milady runtime corpus:
+   - `guides/knowledge`
+5. If you are preparing Alice production, switch to `555-bot` and validate:
+   - deployment path
+   - webhook path
+   - runtime validation gates
+6. Ask boundary questions before going live:
+   - What is Milady responsible for?
+   - What is Alice responsible for?
+   - What is `555-bot` responsible for?
+7. Run the first-use validation:
+   - fresh install to first useful response
+   - boundary answer check
+   - provider/config sanity check
+
+## Decision points
+
+- Local-only operator usage:
+  stop after Milady runtime validation.
+- Alice production usage:
+  continue into `555-bot` deploy and validation docs.
+
+## Failure modes
+
+- runtime starts but cannot answer boundary questions
+- provider configuration is incomplete
+- corpus exists but production corpus is stale
+- deploy docs reference an older path than the live system
+
+## Recovery
+
+- use `doctor` and configuration docs for provider/runtime failures
+- resync corpus ownership using `guides/knowledge`
+- defer to `555-bot` deployment canon when deploy documents conflict
+
+## Evidence
+
+- install/start output
+- first successful boundary-response transcript
+- links to the exact docs used for setup
+
+## Related tickets/docs
+
+- `deployment`
+- `agents/runtime-and-lifecycle`
+- `guides/knowledge`
+- `Render-Network-OS/555-bot: docs/ALICE_DEPLOYMENT_DOCS_INDEX.md`

--- a/docs/operators/alice-system-boundary.md
+++ b/docs/operators/alice-system-boundary.md
@@ -1,0 +1,82 @@
+# Alice System Boundary
+
+## Purpose
+
+Make the Alice boundary explicit across Milady, `555-bot`, stream, arcade, and
+SW4P so operators and maintainers can tell where truth and responsibility live.
+
+## Boundary diagram
+
+```mermaid
+flowchart LR
+    subgraph M["milaidy"]
+        E["packages/agent/src/runtime/eliza.ts\nRuntime bootstrap"]
+        C["milady.json / provider config\nOperator setup + local runtime"]
+        P["Plugin loading + operator UX\nDashboard, CLI, docs"]
+    end
+
+    subgraph B["555-bot"]
+        D["Production deploy path\nWebhook deploy, rollout, validation"]
+        K["alice_knowledge/\nProduction knowledge and release canon"]
+    end
+
+    subgraph S["stream-plugin / stream"]
+        SP["Stream operator actions\nInstall, auth, go-live, recovery"]
+        SE["555stream evidence\nAcceptance, readiness, proof"]
+    end
+
+    subgraph A["555-arcade-plugin"]
+        AP["Arcade actions + gameplay surfaces"]
+        AM["Mastery dossiers + progression/operator docs"]
+    end
+
+    subgraph W["sw4p"]
+        SI["Transfer routes, fee model, chain register"]
+        SO["Technical canon, threat model, operator handbook"]
+    end
+
+    E --> P
+    C --> E
+    P --> SP
+    P --> AP
+    P --> SI
+    D --> E
+    K --> E
+    SP --> SE
+    AP --> AM
+    SI --> SO
+```
+
+## Ownership map
+
+| Surface | Canonical owner | What it owns | What it does not own |
+| --- | --- | --- | --- |
+| Milady host/runtime | `milaidy` | local install, `milady.json`, runtime bootstrap, plugin loading, operator UX, provider setup | production Alice deploy orchestration |
+| Alice production deployer | `555-bot` | release assembly, webhook deploy, runtime validation gates, deploy/recovery canon | general Milady install flow |
+| Stream operator surface | `stream-plugin` and `Render-Network-OS/stream` | stream actions, auth/session model, go-live path, stream recovery, stream evidence | Milady runtime bootstrap |
+| Arcade operator surface | `555-arcade-plugin` | gameplay control, progression/admin actions, mastery docs, operator examples | Alice deployment |
+| SW4P technical/economic rail | `sw4p-pro` / `sw4p` | routes, wallets, fees, chains, bridge truth, SW4P operator docs | stream/arcade UI control |
+
+## Code anchors
+
+- `packages/agent/src/runtime/eliza.ts`
+  Milady runtime bootstrap and initialization order.
+- `packages/app-core/src/runtime/core-plugins.ts`
+  core plugin lists and loading assumptions.
+- `packages/app-core/src/services/plugin-installer.ts`
+  installed and dynamic plugin behavior.
+- `plugins.json`
+  plugin registry surface.
+- `Render-Network-OS/555-bot: docs/ALICE_DEPLOYMENT_DOCS_INDEX.md`
+  deploy canon and evidence hierarchy.
+
+## Operator rules
+
+- If the question is about install, config, runtime lifecycle, or plugin
+  loading, start in `milaidy`.
+- If the question is about Alice production rollout or recovery, defer to
+  `555-bot`.
+- If the question is about stream or arcade actions, use the plugin repo docs
+  first and treat Milady as the host, not the canonical feature owner.
+- If the question is about chains, routes, fees, or transfer troubleshooting,
+  use `sw4p`.

--- a/docs/operators/stack-lifecycle-glossary.md
+++ b/docs/operators/stack-lifecycle-glossary.md
@@ -1,0 +1,53 @@
+# Stack Lifecycle Glossary
+
+## Purpose
+
+Normalize the operator vocabulary across Milady, stream, and arcade so runtime
+state can be reasoned about without translating product-specific terms.
+
+## Canonical stack vocabulary
+
+| Canonical term | Meaning | Milady mapping | Stream mapping | Arcade mapping |
+| --- | --- | --- | --- | --- |
+| Installed | package or runtime is present but not necessarily usable | CLI/app installed, config directory exists | plugin package present | plugin package present |
+| Enabled | host intends to load the surface | plugin configured in character/runtime | plugin enabled in host | plugin enabled in host |
+| Loaded | runtime/service started successfully | `startEliza()` completed bootstrap and plugin resolution | `loaded` in `STATES_AND_TRANSITIONS.md` | session/runtime ready after plugin load |
+| Authenticated | external credentials are accepted | provider and connector credentials validate | `authenticated` after auth verify/token exchange | `ARCADE555_AUTH_VERIFY` succeeds |
+| Session Bound | operator is attached to an active working session | active runtime/workspace context | `sessionBound` after `STREAM555_BOOTSTRAP_SESSION` | `ARCADE555_SESSION_BOOTSTRAP` succeeds |
+| Ready | safe to execute normal actions | runtime initialized and action-capable | `ready` after auth + session bind | health, auth, and session bootstrap complete |
+| Live | an externally visible operation is actively running | interactive runtime is answering/acting | active stream is broadcasting | active play/live gameplay flow is running |
+| Degraded | partially functioning but not operator-safe without intervention | provider/plugin/runtime issue | explicit `degraded` stream state | session/play state is inconsistent or partially failed |
+| Recovering | operator is executing a repair path | restart/reload/reconfigure path | fallback/reconnect/stop-start cycle | stop/rebind/re-enter gameplay/session path |
+| Stopped | deliberately offline or disposed | process exited or runtime disposed | stream stopped | game/session stopped |
+
+## Product-specific notes
+
+### Milady
+
+- The runtime lifecycle is defined in `docs/agents/runtime-and-lifecycle.md`.
+- `Starting`, `Running`, `Restarting`, and `Stopped` are the lower-level runtime
+  states.
+- For operator docs, prefer the shared terms above when speaking across repos.
+
+### Stream
+
+- The canonical stream state reference is
+  `stream-plugin/docs/STATES_AND_TRANSITIONS.md`.
+- `ready` must mean action-capable, not merely installed.
+- Channel readiness is separate from session readiness.
+
+### Arcade
+
+- Public operator docs should treat health/auth/session bootstrap as the path to
+  `Ready`.
+- Gameplay states like `MENU`, `PLAYING`, `PAUSED`, `GAME_OVER`, and `WIN`
+  describe in-game progress, not installation or auth lifecycle.
+
+## Translation rules
+
+- Do not use `configured` as a synonym for `loaded`.
+- Do not use `authenticated` as a synonym for `ready`.
+- Do not use a game state like `PLAYING` to imply the overall arcade surface is
+  healthy.
+- When a doc mixes host lifecycle with product lifecycle, split them into
+  separate state descriptions.


### PR DESCRIPTION
Summary:
- port the operator bootstrap, boundary, and lifecycle docs onto main
- wire the operator docs into the current Mintlify navigation
- keep the broader CEO knowledge-base work out of this integration PR
