### PR TITLE
feat(cloud): wire 555stream into the child agent image

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "miladyai",
@@ -50,6 +49,7 @@
         "@noble/curves": "^2.0.1",
         "@opinion-labs/opinion-clob-sdk": "0.5.2",
         "@pixiv/three-vrm": "^3.5.1",
+        "@rndrntwrk/plugin-555stream": "0.1.1",
         "@stwd/eliza-plugin": "0.2.0",
         "@stwd/sdk": "^0.3.0",
         "@whiskeysockets/baileys": "7.0.0-rc.9",
@@ -361,6 +361,7 @@
         "@elizaos/core": "2.0.0-alpha.98",
         "@elizaos/plugin-elizacloud": "2.0.0-alpha.7",
         "@elizaos/plugin-sql": "2.0.0-alpha.17",
+        "@rndrntwrk/plugin-555stream": "0.1.1",
         "tsx": "4.21.0",
       },
     },
@@ -1413,6 +1414,8 @@
     "@reflink/reflink-win32-arm64-msvc": ["@reflink/reflink-win32-arm64-msvc@0.1.19", "", { "os": "win32", "cpu": "arm64" }, "sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ=="],
 
     "@reflink/reflink-win32-x64-msvc": ["@reflink/reflink-win32-x64-msvc@0.1.19", "", { "os": "win32", "cpu": "x64" }, "sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w=="],
+
+    "@rndrntwrk/plugin-555stream": ["@rndrntwrk/plugin-555stream@0.1.1", "", { "dependencies": { "ws": "^8.18.0" }, "peerDependencies": { "@elizaos/core": "^1.7.0" } }, "sha512-53/kbTZz5ireB8vAhTrsmzcJP8kCFD24lXRlMTjZJd/yxir47Fc74BkKZ8S1OfI3qLBZiNBzfg001JPvDW0D5g=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.3", "", { "os": "android", "cpu": "arm64" }, "sha512-0T1k9FinuBZ/t7rZ8jN6OpUKPnUjNdYHoj/cESWrQ3ZraAJ4OMm6z7QjSfCxqj8mOp9kTKc1zHK3kGz5vMu+nQ=="],
 

--- a/deploy/Dockerfile.cloud-agent
+++ b/deploy/Dockerfile.cloud-agent
@@ -30,11 +30,15 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-# Copy the entrypoint (standalone Node.js script, no build step needed)
-COPY deploy/cloud-agent-entrypoint.ts ./entrypoint.ts
+# Install the child-agent runtime dependencies from the template contract.
+COPY deploy/cloud-agent-template/package.json ./package.json
+# CLOUD-01 verified that plugin-555stream runs against elizaOS v2 even though
+# the published package still advertises a ^1.7.0 peer range.
+RUN npm install --omit=dev --no-package-lock --legacy-peer-deps
 
-# Install tsx for running TypeScript directly
-RUN npm install -g tsx@4
+# Copy the cloud-agent entrypoint pair.
+COPY deploy/cloud-agent-entrypoint.ts ./cloud-agent-entrypoint.ts
+COPY deploy/cloud-agent-shared.ts ./cloud-agent-shared.ts
 
 ENV NODE_ENV=production
 # PORT is used by cloud platforms (Railway, Fly.io); maps to MILADY_PORT locally
@@ -52,4 +56,4 @@ EXPOSE ${BRIDGE_PORT}
 RUN useradd -m agent
 USER agent
 
-CMD ["tsx", "entrypoint.ts"]
+CMD ["./node_modules/.bin/tsx", "cloud-agent-entrypoint.ts"]

--- a/deploy/cloud-agent-shared.ts
+++ b/deploy/cloud-agent-shared.ts
@@ -54,6 +54,58 @@ interface AgentRuntime {
   getConfig: () => Record<string, unknown>;
 }
 
+type OptionalPluginLoader = (
+  specifier: string,
+) => Promise<Record<string, unknown>>;
+
+async function loadOptionalPlugin(
+  specifier: string,
+  namedExport: string,
+  loadPlugin: OptionalPluginLoader,
+): Promise<unknown | null> {
+  return loadPlugin(specifier)
+    .then((module) => module.default ?? module[namedExport] ?? null)
+    .catch(() => null);
+}
+
+export function shouldEnableStream555Plugin(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return Boolean(env.STREAM555_BASE_URL?.trim());
+}
+
+export async function loadCloudAgentPlugins(
+  env: NodeJS.ProcessEnv = process.env,
+  loadPlugin: OptionalPluginLoader = async (specifier) => import(specifier),
+): Promise<unknown[]> {
+  const plugins: unknown[] = [];
+
+  const cloudPlugin = await loadOptionalPlugin(
+    "@elizaos/plugin-elizacloud",
+    "elizaOSCloudPlugin",
+    loadPlugin,
+  );
+  if (cloudPlugin) plugins.push(cloudPlugin);
+
+  const sqlPlugin = await loadOptionalPlugin(
+    "@elizaos/plugin-sql",
+    "sqlPlugin",
+    loadPlugin,
+  );
+  if (sqlPlugin) plugins.push(sqlPlugin);
+
+  if (shouldEnableStream555Plugin(env)) {
+    const stream555Plugin = await loadOptionalPlugin(
+      "@rndrntwrk/plugin-555stream",
+      "stream555Plugin",
+      loadPlugin,
+    );
+    if (stream555Plugin) plugins.push(stream555Plugin);
+  }
+
+  return plugins;
+}
+
 // ─── Main entry ─────────────────────────────────────────────────────────
 
 export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
@@ -151,17 +203,7 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
         },
       });
 
-      const plugins = [];
-
-      const cloudPlugin = await import("@elizaos/plugin-elizacloud")
-        .then((m) => m.default ?? m.elizaOSCloudPlugin)
-        .catch(() => null);
-      if (cloudPlugin) plugins.push(cloudPlugin);
-
-      const sqlPlugin = await import("@elizaos/plugin-sql")
-        .then((m) => m.default ?? m.sqlPlugin)
-        .catch(() => null);
-      if (sqlPlugin) plugins.push(sqlPlugin);
+      const plugins = await loadCloudAgentPlugins();
 
       const runtime = new AgentRuntimeCtor({ character, plugins });
       await runtime.initialize();

--- a/deploy/cloud-agent-template/package.json
+++ b/deploy/cloud-agent-template/package.json
@@ -9,6 +9,7 @@
     "@elizaos/core": "2.0.0-alpha.98",
     "@elizaos/plugin-sql": "2.0.0-alpha.17",
     "@elizaos/plugin-elizacloud": "2.0.0-alpha.7",
+    "@rndrntwrk/plugin-555stream": "0.1.1",
     "tsx": "4.21.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "@miladyai/app-core": "workspace:*",
     "@noble/curves": "^2.0.1",
     "@opinion-labs/opinion-clob-sdk": "0.5.2",
+    "@rndrntwrk/plugin-555stream": "0.1.1",
     "@pixiv/three-vrm": "^3.5.1",
     "@stwd/eliza-plugin": "0.2.0",
     "@stwd/sdk": "^0.3.0",

--- a/scripts/cloud-agent-shared.test.ts
+++ b/scripts/cloud-agent-shared.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  loadCloudAgentPlugins,
+  shouldEnableStream555Plugin,
+} from "../deploy/cloud-agent-shared.ts";
+
+describe("cloud agent plugin loading", () => {
+  it("loads the 555stream plugin when the control-plane env is present", async () => {
+    const cloudPlugin = { name: "cloud" };
+    const sqlPlugin = { name: "sql" };
+    const streamPlugin = { name: "555stream" };
+    const loadPlugin = vi.fn(
+      async (specifier: string): Promise<Record<string, unknown>> => {
+        switch (specifier) {
+          case "@elizaos/plugin-elizacloud":
+            return { default: cloudPlugin };
+          case "@elizaos/plugin-sql":
+            return { sqlPlugin };
+          case "@rndrntwrk/plugin-555stream":
+            return { stream555Plugin: streamPlugin };
+          default:
+            throw new Error(`Unexpected plugin request: ${specifier}`);
+        }
+      },
+    );
+
+    const plugins = await loadCloudAgentPlugins(
+      { STREAM555_BASE_URL: "https://control.example.test" },
+      loadPlugin,
+    );
+
+    expect(plugins).toEqual([cloudPlugin, sqlPlugin, streamPlugin]);
+    expect(loadPlugin).toHaveBeenCalledWith("@rndrntwrk/plugin-555stream");
+  });
+
+  it("skips the 555stream plugin when the control-plane env is absent", async () => {
+    const loadPlugin = vi.fn(
+      async (specifier: string): Promise<Record<string, unknown>> => {
+        switch (specifier) {
+          case "@elizaos/plugin-elizacloud":
+            return { elizaOSCloudPlugin: { name: "cloud" } };
+          case "@elizaos/plugin-sql":
+            return { default: { name: "sql" } };
+          case "@rndrntwrk/plugin-555stream":
+            return { stream555Plugin: { name: "555stream" } };
+          default:
+            throw new Error(`Unexpected plugin request: ${specifier}`);
+        }
+      },
+    );
+
+    const plugins = await loadCloudAgentPlugins({}, loadPlugin);
+
+    expect(plugins).toEqual([{ name: "cloud" }, { name: "sql" }]);
+    expect(loadPlugin).not.toHaveBeenCalledWith("@rndrntwrk/plugin-555stream");
+  });
+
+  it("treats blank control-plane values as disabled", () => {
+    expect(shouldEnableStream555Plugin({ STREAM555_BASE_URL: "   " })).toBe(
+      false,
+    );
+    expect(
+      shouldEnableStream555Plugin({
+        STREAM555_BASE_URL: "https://control.example.test",
+      }),
+    ).toBe(true);
+  });
+});

--- a/scripts/release-check.test.ts
+++ b/scripts/release-check.test.ts
@@ -114,13 +114,20 @@ describe("release-check package guards", () => {
             "@elizaos/core": "alpha",
             "@elizaos/plugin-elizacloud": "2.0.0-alpha.7",
             "@elizaos/plugin-sql": "^2.0.0-alpha.17",
+            "@rndrntwrk/plugin-555stream": "^0.1.1",
           },
         },
-        ["@elizaos/core", "@elizaos/plugin-elizacloud", "@elizaos/plugin-sql"],
+        [
+          "@elizaos/core",
+          "@elizaos/plugin-elizacloud",
+          "@elizaos/plugin-sql",
+          "@rndrntwrk/plugin-555stream",
+        ],
       ),
     ).toEqual([
       { name: "@elizaos/core", specifier: "alpha" },
       { name: "@elizaos/plugin-sql", specifier: "^2.0.0-alpha.17" },
+      { name: "@rndrntwrk/plugin-555stream", specifier: "^0.1.1" },
     ]);
   });
 

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -230,6 +230,7 @@ const cloudAgentTemplateReleaseDependencies = [
   "@elizaos/core",
   "@elizaos/plugin-elizacloud",
   "@elizaos/plugin-sql",
+  "@rndrntwrk/plugin-555stream",
 ] as const;
 
 /**

--- a/scripts/release-support-workflows-drift.test.ts
+++ b/scripts/release-support-workflows-drift.test.ts
@@ -94,8 +94,11 @@ describe("release support workflow drift", () => {
   it("keeps the subordinate cloud agent runtime on the dedicated child-image Dockerfile", () => {
     const dockerfile = fs.readFileSync(CLOUD_AGENT_DOCKERFILE, "utf8");
 
+    expect(dockerfile).toContain("deploy/cloud-agent-template/package.json");
     expect(dockerfile).toContain("deploy/cloud-agent-entrypoint.ts");
-    expect(dockerfile).toContain('CMD ["tsx", "entrypoint.ts"]');
+    expect(dockerfile).toContain(
+      'CMD ["./node_modules/.bin/tsx", "cloud-agent-entrypoint.ts"]',
+    );
   });
 
   it("uses the canonical image runtime selector for both agent and cloud launches", () => {


### PR DESCRIPTION
## Summary
- conditionally load `@rndrntwrk/plugin-555stream` into the child cloud-agent runtime when `STREAM555_BASE_URL` is present
- pin the published package into the cloud-agent template and the repo root so `deploy/cloud-agent-shared.ts` resolves it in-repo and in child-agent builds
- fix `deploy/Dockerfile.cloud-agent` so the subordinate runtime installs its own deps and honors the verified v2 compat result
- lock the new contract into release-check and drift tests

## Notes
- This PR targets `rndrntwrk/milaidy` only.
- The ticket packet says `develop`, but this fork does not expose `origin/develop`; `integrate/alice-on-develop` is the develop-aligned base on the fork and keeps the diff to the intended CLOUD-03 work.
- `CLOUD-01` already proved the published package runs against elizaOS v2, so the child-agent Dockerfile now installs with `--legacy-peer-deps` until the package peer metadata is updated upstream.

## Validation
- `bunx vitest run scripts/cloud-agent-shared.test.ts scripts/release-check.test.ts scripts/release-support-workflows-drift.test.ts`
- `bun -e "const { loadCloudAgentPlugins } = await import('./deploy/cloud-agent-shared.ts'); const withStream = await loadCloudAgentPlugins({ STREAM555_BASE_URL: "https://control.example.test" }); const withoutStream = await loadCloudAgentPlugins({}); console.log(JSON.stringify({ withStream: withStream.map((plugin) => plugin && typeof plugin === "object" ? plugin.name ?? "(unnamed)" : String(plugin)), withoutStream: withoutStream.map((plugin) => plugin && typeof plugin === "object" ? plugin.name ?? "(unnamed)" : String(plugin)) }));"`
- `docker build -f deploy/Dockerfile.cloud-agent -t milady-cloud-test .`

## Runtime result
- with `STREAM555_BASE_URL`: `elizaOSCloud`, `@elizaos/plugin-sql`, `555stream`
- without `STREAM555_BASE_URL`: `elizaOSCloud`, `@elizaos/plugin-sql`

## Issue
- References #38