### PR TITLE
docs(alice): publish operator proof and fix setup validation

### DIFF
--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -58,7 +58,7 @@ curl http://localhost:2138/api/character \
 curl -X POST http://localhost:2138/api/chat \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"message": "Hello, what can you do?"}'
+  -d '{"text": "Hello, what can you do?"}'
 ```
 
 ### Stream a chat response
@@ -67,7 +67,7 @@ curl -X POST http://localhost:2138/api/chat \
 curl -N -X POST http://localhost:2138/api/chat/stream \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"message": "Tell me about yourself"}'
+  -d '{"text": "Tell me about yourself"}'
 ```
 
 The response is a Server-Sent Events stream. Each event contains a `data` field with a JSON payload.

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -1,81 +1,105 @@
 ---
 title: "milady doctor"
 sidebarTitle: "doctor"
-description: "Run diagnostics to verify your Milady installation (planned)."
+description: "Run diagnostics to verify your Milady installation."
 ---
 
-<Warning>
-The `doctor` command is **not yet implemented**. This page describes the planned behavior for an upcoming release. Running `milady doctor` will currently produce an "unknown command" error.
-</Warning>
+`milady doctor` runs a real health check over the current Milady environment. It inspects runtime prerequisites, config resolution, model-provider setup, storage paths, and optional port availability, then prints either a human-readable report or JSON for CI.
 
-The `doctor` command will run a suite of diagnostic checks to verify that your Milady installation is healthy and properly configured. It will inspect the runtime environment, configuration, API key availability, plugin state, and network connectivity, then print a structured report with pass/fail indicators and suggested fixes.
-
-## Planned Usage
+## Usage
 
 ```bash
 milady doctor
 ```
 
-## Planned Diagnostic Checks
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--no-ports` | Skip the port availability checks |
+| `--fix` | Auto-run any safe Milady sub-command fixes |
+| `--json` | Emit machine-readable JSON instead of terminal output |
+
+## Checks
 
 ### Runtime
 
 | Check | Pass Condition |
 |-------|---------------|
-| Node.js / Bun version | Runtime meets minimum version requirement |
-| CLI version | Installed version matches the latest on the active channel |
-| Config file readable | `~/.milady/milady.json` exists and is valid JSON |
-| State directory writable | `~/.milady/` can be written to |
+| Runtime | Bun or Node meets the minimum runtime requirement |
+| `node_modules` | Dependencies are installed in the current project root |
+| Build artifacts | `dist/entry.js` exists, or a source-run warning is emitted |
 
 ### Configuration
 
 | Check | Pass Condition |
 |-------|---------------|
-| Config file valid | File parses without errors and matches the expected schema |
-| Workspace directory | Workspace directory exists and contains bootstrap files |
-| Config path resolution | `MILADY_STATE_DIR` and `MILADY_CONFIG_PATH` resolve to accessible paths |
+| Config file | Resolved config file exists and parses successfully |
+| Model API key | At least one supported provider variable is configured |
+| Host binding | Bind/token configuration is safe for the current host exposure |
 
-### API Keys
+### Storage
 
 | Check | Pass Condition |
 |-------|---------------|
-| At least one model provider configured | One or more model provider environment variables is set |
-| Anthropic API key | `ANTHROPIC_API_KEY` is set (checked if present) |
-| OpenAI API key | `OPENAI_API_KEY` is set (checked if present) |
-| Other provider keys | Any other provider keys detected |
+| State directory | Resolved state directory exists or is safely creatable |
+| Database | Database path exists, or a warning explains that it will be created on first start |
+| Disk space | The state volume has enough free space |
 
 ### Connectivity
 
 | Check | Pass Condition |
 |-------|---------------|
-| API server reachable | Port `2138` (or `MILADY_PORT`) responds to a TCP probe |
-| npm registry reachable | The plugin registry endpoint is accessible |
+| Port `31337` | The runtime port is available, or doctor warns who is using it |
+| Port `2138` | The Control UI/API port is available, or doctor warns who is using it |
 
-### Plugins
-
-| Check | Pass Condition |
-|-------|---------------|
-| Custom plugins valid | All plugins in `~/.milady/plugins/custom/` pass the plugin validation test |
-| Plugin registry cache | Registry cache file is present and not stale |
-| Installed plugins | All registry-installed plugins are present on disk |
-
-## Workarounds Until `doctor` Exists
-
-You can manually verify your installation using existing commands:
+## Example
 
 ```bash
-# Check model providers
-milady models
+milady doctor --no-ports
+```
 
-# Validate custom plugins
-milady plugins test
+```text
+Milady Health Check
 
-# Inspect config file location and values
-milady config path
-milady config show
+  System
+  ✓ Runtime              Bun 1.3.1
+  ✓ node_modules         /path/to/repo/node_modules
+  ✓ Build artifacts      /path/to/repo/dist
 
-# Verify workspace setup
-milady setup
+  Configuration
+  ✓ Config file          /tmp/mld008-state-proof/milady.json
+  ✓ Model API key        OLLAMA_BASE_URL set (Ollama (local))
+  ✓ Host binding         Loopback only (default)
+
+  Storage
+  ✓ State directory      /tmp/mld008-state-proof
+  ✓ Database             /tmp/mld008-state-proof/workspace/.eliza/.elizadb
+  ✓ Disk space           15.5 GB free
+
+  Everything looks good. Ready to run milady start.
+```
+
+## JSON Mode
+
+Use JSON mode for automation or acceptance evidence:
+
+```bash
+milady doctor --json --no-ports
+```
+
+Doctor exits non-zero when any check returns `fail`.
+
+## Auto-fix
+
+`--fix` only runs safe Milady subcommands such as `milady setup`. It does not shell out to arbitrary remediation strings.
+
+## Source Checkout Validation
+
+If you are validating from a source checkout instead of an installed CLI, use the repo runner:
+
+```bash
+bun scripts/run-node.mjs doctor --no-ports
 ```
 
 ## Related

--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -17,6 +17,10 @@ milady setup [options]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--workspace <dir>` | string | (from config or `~/.milady/workspace/`) | Custom agent workspace directory to create or verify |
+| `--provider <name>` | string | (interactive wizard) | Set a model provider non-interactively |
+| `--key <value>` | string | (none) | Provider API key or URL passed on argv. Prefer `--key-stdin` for secrets |
+| `--key-stdin` | boolean | false | Read the provider API key or URL from stdin |
+| `--no-wizard` | boolean | false | Skip the interactive provider wizard entirely |
 
 Global flags:
 
@@ -44,6 +48,19 @@ milady --profile staging setup
 
 # Setup with an absolute path
 milady setup --workspace /srv/milady/workspace
+
+# Non-interactive Ollama setup for an isolated operator profile
+milady --profile alice setup \
+  --workspace ~/.milady-alice/workspace \
+  --provider ollama \
+  --key http://localhost:11434 \
+  --no-wizard
+
+# Read a provider key from stdin instead of argv
+printf '%s\n' "$ANTHROPIC_API_KEY" | milady setup \
+  --provider anthropic \
+  --key-stdin \
+  --no-wizard
 ```
 
 ## Behavior
@@ -59,13 +76,25 @@ milady setup --workspace /srv/milady/workspace
 
 3. **Ensure the workspace** -- creates the workspace directory if it does not exist and writes all required bootstrap files (character definition, default settings, etc.). This step is idempotent -- running setup on an existing workspace is safe.
 
-4. **Report success** -- prints the resolved workspace path and a "Setup complete." message.
+4. **Optionally persist provider config** -- if `--provider` and `--key` / `--key-stdin` are supplied, setup writes the resolved provider value into the config `env` section before continuing.
+
+5. **Report success** -- prints the resolved workspace path and a "Setup complete." message.
 
 ## Output
 
 ```
 → No config found, using defaults
 ✓ Agent workspace ready: /Users/you/.milady/workspace
+Setup complete.
+```
+
+When a provider is set non-interactively, setup prints an extra confirmation first:
+
+```
+✓ Saved OLLAMA_BASE_URL
+✓ Config loaded
+✓ Agent workspace ready: /Users/you/.milady/workspace
+
 Setup complete.
 ```
 
@@ -98,6 +127,25 @@ The agent workspace is the directory where Milady stores:
 - Plugin data
 
 Bootstrap files are only written on first setup or if they are missing. Existing files are not overwritten.
+
+In a fresh workspace, Milady bootstraps these operator-facing files:
+
+- `AGENTS.md`
+- `BOOTSTRAP.md`
+- `HEARTBEAT.md`
+- `IDENTITY.md`
+- `TOOLS.md`
+- `USER.md`
+
+## Important Notes
+
+- `milady setup` prepares config and workspace state, but it does **not** set the agent name by itself. If `agents.list[].name` is missing, the first `milady start` still opens onboarding.
+- `MILADY_STATE_DIR` changes where `milady.json` lives, but the workspace path still follows the normal resolution order. In isolated environments, pass `--workspace` explicitly or set `agents.defaults.workspace` in config so setup, start, and doctor all point at the same directory.
+- For source-checkout verification before the CLI is installed globally, use the repo runner:
+
+```bash
+bun scripts/run-node.mjs setup --no-wizard
+```
 
 ## Related
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -156,6 +156,7 @@
             "group": "Operators",
             "pages": [
               "operators/alice-operator-bootstrap",
+              "operators/alice-operator-proof-2026-04-01",
               "operators/alice-system-boundary",
               "operators/stack-lifecycle-glossary",
               "agents/runtime-and-lifecycle",

--- a/docs/es/api-reference.mdx
+++ b/docs/es/api-reference.mdx
@@ -68,7 +68,7 @@ curl http://localhost:2138/api/character \
 curl -X POST http://localhost:2138/api/chat \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"message": "Hello, what can you do?"}'
+  -d '{"text": "Hello, what can you do?"}'
 ```
 
 <div id="stream-a-chat-response">
@@ -79,7 +79,7 @@ curl -X POST http://localhost:2138/api/chat \
 curl -N -X POST http://localhost:2138/api/chat/stream \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"message": "Tell me about yourself"}'
+  -d '{"text": "Tell me about yourself"}'
 ```
 
 La respuesta es un flujo de Server-Sent Events. Cada evento contiene un campo `data` con un payload JSON.

--- a/docs/fr/api-reference.mdx
+++ b/docs/fr/api-reference.mdx
@@ -68,7 +68,7 @@ curl http://localhost:2138/api/character \
 curl -X POST http://localhost:2138/api/chat \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"message": "Hello, what can you do?"}'
+  -d '{"text": "Hello, what can you do?"}'
 ```
 
 <div id="stream-a-chat-response">
@@ -79,7 +79,7 @@ curl -X POST http://localhost:2138/api/chat \
 curl -N -X POST http://localhost:2138/api/chat/stream \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"message": "Tell me about yourself"}'
+  -d '{"text": "Tell me about yourself"}'
 ```
 
 La réponse est un flux Server-Sent Events. Chaque événement contient un champ `data` avec un payload JSON.

--- a/docs/operators/alice-operator-bootstrap.md
+++ b/docs/operators/alice-operator-bootstrap.md
@@ -19,6 +19,7 @@ Use this document when:
 - access to `555-bot` if you intend to use the production deploy path
 - model/provider credentials
 - required plugin credentials for the surfaces you will enable
+- if you are validating in an isolated profile or temp state dir, an explicit workspace path
 
 ## Steps
 
@@ -31,6 +32,8 @@ Use this document when:
    - `installation`
    - `quickstart`
    - `configuration`
+   - `cli/setup`
+   - `cli/doctor`
 3. Confirm runtime and lifecycle expectations:
    - `agents/runtime-and-lifecycle`
    - `architecture`
@@ -45,9 +48,11 @@ Use this document when:
    - What is Alice responsible for?
    - What is `555-bot` responsible for?
 7. Run the first-use validation:
-   - fresh install to first useful response
-   - boundary answer check
-   - provider/config sanity check
+   - run `milady setup` or `bun scripts/run-node.mjs setup` for a source checkout
+   - run `milady doctor --no-ports` or `bun scripts/run-node.mjs doctor --no-ports`
+   - run `milady models`
+   - start the runtime and confirm `GET /api/status` returns `state=running`
+   - send one legacy `POST /api/chat` request with a `text` field to verify the chat surface and the current troubleshooting boundary
 
 ## Decision points
 
@@ -55,24 +60,31 @@ Use this document when:
   stop after Milady runtime validation.
 - Alice production usage:
   continue into `555-bot` deploy and validation docs.
+- Source-checkout validation:
+  prefer `bun scripts/run-node.mjs <command>` over calling `node milady.mjs <command>` directly.
 
 ## Failure modes
 
 - runtime starts but cannot answer boundary questions
+- first `start` re-enters onboarding because `agents.list[].name` is still unset
 - provider configuration is incomplete
+- local Ollama is configured but unreachable on `127.0.0.1:11434`
 - corpus exists but production corpus is stale
 - deploy docs reference an older path than the live system
 
 ## Recovery
 
 - use `doctor` and configuration docs for provider/runtime failures
+- if `MILADY_STATE_DIR` is isolated, pass `--workspace` during setup and mirror that path into `agents.defaults.workspace`
+- if `POST /api/chat` returns a graceful fallback response, verify the configured provider is actually reachable before treating the runtime as inference-ready
 - resync corpus ownership using `guides/knowledge`
 - defer to `555-bot` deployment canon when deploy documents conflict
 
 ## Evidence
 
 - install/start output
-- first successful boundary-response transcript
+- `doctor`, `models`, and `/api/status` proof
+- first chat-response or graceful fallback transcript
 - links to the exact docs used for setup
 
 ## Related tickets/docs
@@ -80,4 +92,5 @@ Use this document when:
 - `deployment`
 - `agents/runtime-and-lifecycle`
 - `guides/knowledge`
+- `operators/alice-operator-proof-2026-04-01`
 - `Render-Network-OS/555-bot: docs/ALICE_DEPLOYMENT_DOCS_INDEX.md`

--- a/docs/operators/alice-operator-proof-2026-04-01.md
+++ b/docs/operators/alice-operator-proof-2026-04-01.md
@@ -1,0 +1,110 @@
+---
+title: "Alice Operator Proof 2026-04-01"
+sidebarTitle: "Alice Proof 2026-04-01"
+description: "Dry-run evidence for the Alice operator bootstrap path on the rndrntwrk/milaidy fork."
+---
+
+# Alice Operator Proof: 2026-04-01
+
+This proof run validates the current Alice operator path on the `rndrntwrk/milaidy` fork from a clean source checkout. The goal was to verify the install, configure, health-check, startup, and troubleshooting path end to end without relying on undocumented steps.
+
+## Scope
+
+- repo: `rndrntwrk/milaidy`
+- verification date: `2026-04-01`
+- verification mode: isolated state dir + explicit workspace
+- runtime path exercised: source checkout via `bun scripts/run-node.mjs`
+
+## Docs Exercised
+
+- `/installation`
+- `/quickstart`
+- `/configuration`
+- `/cli/setup`
+- `/cli/doctor`
+- `/cli/models`
+- `/operators/alice-operator-bootstrap`
+- `/guides/knowledge`
+
+## Environment
+
+The proof used an isolated profile rooted at `/tmp/mld008-state-proof` with workspace `/tmp/mld008-state-proof/workspace`. The config was seeded with:
+
+- `agents.list[0].name = "Alice"`
+- `agents.defaults.workspace = "/tmp/mld008-state-proof/workspace"`
+- `env.OLLAMA_BASE_URL = "http://localhost:11434"`
+
+The explicit workspace path matters here: `MILADY_STATE_DIR` changes the config location, but `setup` still resolves workspace independently unless you pass `--workspace` or preconfigure `agents.defaults.workspace`.
+
+## Commands Run
+
+```bash
+export MILADY_STATE_DIR=/tmp/mld008-state-proof
+export MILADY_CONFIG_PATH=/tmp/mld008-state-proof/milady.json
+export MILADY_PROJECT_ROOT=/path/to/milaidy
+
+bun scripts/run-node.mjs setup \
+  --provider ollama \
+  --key http://localhost:11434 \
+  --no-wizard \
+  --workspace /tmp/mld008-state-proof/workspace
+
+bun scripts/run-node.mjs doctor --no-ports
+bun scripts/run-node.mjs models
+bun scripts/run-node.mjs start
+curl http://127.0.0.1:2138/api/status
+curl -X POST http://127.0.0.1:2138/api/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"Hello, what can you do?"}'
+```
+
+## Outcome
+
+| Step | Result | Notes |
+|------|--------|-------|
+| Setup | Pass | Config and workspace bootstrapped successfully |
+| Doctor | Pass | Runtime, config, storage, and database checks passed |
+| Models | Pass | `Ollama (local)` registered as configured |
+| Start | Pass | API/UI bound to `http://127.0.0.1:2138` |
+| Status probe | Pass | `/api/status` returned `state: "running"` |
+| Chat request | Pass with graceful fallback | Request completed cleanly; inference degraded because local Ollama was unreachable |
+
+## Evidence
+
+### Setup
+
+![Setup proof](./evidence/mld-008-setup.svg)
+
+### Doctor
+
+![Doctor proof](./evidence/mld-008-doctor.svg)
+
+### API Status
+
+![Status proof](./evidence/mld-008-status.svg)
+
+### Chat Fallback / Troubleshooting Boundary
+
+![Chat fallback proof](./evidence/mld-008-chat-troubleshoot.svg)
+
+## Key Findings
+
+1. `milady doctor` is implemented and usable now. The old “planned / unknown command” documentation was stale.
+2. `POST /api/chat` expects a `text` field, not `message`. The public API examples using `message` were stale and produced a `{"error":"text is required"}` response until corrected.
+3. `setup` alone does not establish the agent identity. If `agents.list[].name` is absent, the first `start` re-enters onboarding.
+4. In isolated environments, pass `--workspace` explicitly and keep `agents.defaults.workspace` aligned with it so setup, doctor, and runtime state agree.
+5. The current degraded path is safe: when Ollama is configured but unreachable, the runtime remains up and `/api/chat` returns a fallback message instead of crashing.
+
+## What This Proof Does Not Claim
+
+- It does not claim successful real-model inference from Ollama on this machine. No local Ollama instance was reachable at `127.0.0.1:11434`.
+- It does not validate production Alice deployment. That remains owned by `555-bot`.
+
+## Close Condition Mapping
+
+This proof satisfies the remaining documentation acceptance for:
+
+- screenshot-backed walkthrough evidence
+- dry-run verification of the install/configure/start/troubleshoot path
+
+The remaining operator responsibility after this point is provider-specific: point Milady at a reachable model backend before expecting a real first-response from the chat surface.

--- a/docs/operators/evidence/mld-008-chat-troubleshoot.svg
+++ b/docs/operators/evidence/mld-008-chat-troubleshoot.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1045" height="258" viewBox="0 0 1045 258">
+<rect width="100%" height="100%" fill="#0b1020" rx="18"/>
+<text x="28" y="32" fill="#7dd3fc" font-family="Menlo, Monaco, monospace" font-size="20" font-weight="600">MLD-008 Proof: graceful chat fallback</text>
+<text x="28" y="86" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">POST /api/chat response:</text>
+<text x="28" y="114" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">{"text":"Sorry, I couldn't generate a response right now. Please try again.","agentName":"Alice"}</text>
+<text x="28" y="142" fill="#9fb0c3" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve"> </text>
+<text x="28" y="170" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">Local Ollama probe:</text>
+<text x="28" y="198" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">curl: (7) Failed to connect to 127.0.0.1 port 11434 after 0 ms: Couldn't connect to server</text>
+</svg>

--- a/docs/operators/evidence/mld-008-doctor.svg
+++ b/docs/operators/evidence/mld-008-doctor.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1178" height="678" viewBox="0 0 1178 678">
+<rect width="100%" height="100%" fill="#0b1020" rx="18"/>
+<text x="28" y="32" fill="#7dd3fc" font-family="Menlo, Monaco, monospace" font-size="20" font-weight="600">MLD-008 Proof: doctor</text>
+<text x="28" y="86" fill="#9fb0c3" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve"> </text>
+<text x="28" y="114" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">Milady Health Check</text>
+<text x="28" y="142" fill="#9fb0c3" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve"> </text>
+<text x="28" y="170" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  System</text>
+<text x="28" y="198" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  ✓ Runtime              Bun 1.3.1</text>
+<text x="28" y="226" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  ✓ node_modules         /Volumes/OWC Envoy Pro FX/desktop_dump/new/Work/555/milaidy-mld008-proof/node_modules</text>
+<text x="28" y="254" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  ✓ Build artifacts      /Volumes/OWC Envoy Pro FX/desktop_dump/new/Work/555/milaidy-mld008-proof/dist</text>
+<text x="28" y="282" fill="#9fb0c3" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve"> </text>
+<text x="28" y="310" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  Configuration</text>
+<text x="28" y="338" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  ✓ Config file          /tmp/mld008-state-proof/milady.json</text>
+<text x="28" y="366" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  ✓ Model API key        OLLAMA_BASE_URL set (Ollama (local))</text>
+<text x="28" y="394" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  ✓ Host binding         Loopback only (default)</text>
+<text x="28" y="422" fill="#9fb0c3" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve"> </text>
+<text x="28" y="450" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  Storage</text>
+<text x="28" y="478" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  ✓ State directory      /tmp/mld008-state-proof</text>
+<text x="28" y="506" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  ✓ Database             /tmp/mld008-state-proof/workspace/.eliza/.elizadb</text>
+<text x="28" y="534" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  ✓ Disk space           15.5 GB free</text>
+<text x="28" y="562" fill="#9fb0c3" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve"> </text>
+<text x="28" y="590" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  Everything looks good. Ready to run milady start.</text>
+<text x="28" y="618" fill="#9fb0c3" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve"> </text>
+</svg>

--- a/docs/operators/evidence/mld-008-setup.svg
+++ b/docs/operators/evidence/mld-008-setup.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1035" height="286" viewBox="0 0 1035 286">
+<rect width="100%" height="100%" fill="#0b1020" rx="18"/>
+<text x="28" y="32" fill="#7dd3fc" font-family="Menlo, Monaco, monospace" font-size="20" font-weight="600">MLD-008 Proof: setup</text>
+<text x="28" y="86" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">✓ Saved OLLAMA_BASE_URL</text>
+<text x="28" y="114" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">⚠ Passing secrets via --key exposes them in shell history and process lists. Prefer --key-stdin.</text>
+<text x="28" y="142" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">✓ Config loaded</text>
+<text x="28" y="170" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">✓ Agent workspace ready: /tmp/mld008-state-proof/workspace</text>
+<text x="28" y="198" fill="#9fb0c3" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve"> </text>
+<text x="28" y="226" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">Setup complete.</text>
+</svg>

--- a/docs/operators/evidence/mld-008-status.svg
+++ b/docs/operators/evidence/mld-008-status.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="594" viewBox="0 0 900 594">
+<rect width="100%" height="100%" fill="#0b1020" rx="18"/>
+<text x="28" y="32" fill="#7dd3fc" font-family="Menlo, Monaco, monospace" font-size="20" font-weight="600">MLD-008 Proof: /api/status</text>
+<text x="28" y="86" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">{</text>
+<text x="28" y="114" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  "state": "running",</text>
+<text x="28" y="142" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  "agentName": "Alice",</text>
+<text x="28" y="170" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  "model": "ollama",</text>
+<text x="28" y="198" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  "startedAt": 1775076383112,</text>
+<text x="28" y="226" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  "uptime": 17693,</text>
+<text x="28" y="254" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  "startup": {</text>
+<text x="28" y="282" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">    "phase": "running",</text>
+<text x="28" y="310" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">    "attempt": 0</text>
+<text x="28" y="338" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  },</text>
+<text x="28" y="366" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  "cloud": {</text>
+<text x="28" y="394" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">    "connectionStatus": "disconnected",</text>
+<text x="28" y="422" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">    "activeAgentId": null</text>
+<text x="28" y="450" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  },</text>
+<text x="28" y="478" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  "pendingRestart": false,</text>
+<text x="28" y="506" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">  "pendingRestartReasons": []</text>
+<text x="28" y="534" fill="#e5edf5" font-family="Menlo, Monaco, monospace" font-size="18" xml:space="preserve">}</text>
+</svg>

--- a/docs/rest/conversations.md
+++ b/docs/rest/conversations.md
@@ -119,7 +119,7 @@ Send a message and get the agent's response synchronously (non-streaming).
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `message` | string | Yes | User message text |
+| `text` | string | Yes | User message text |
 | `channelType` | string | No | Channel type override |
 | `images` | array | No | Attached image data |
 
@@ -247,7 +247,7 @@ Send a message and receive a streaming SSE response in the legacy single-room co
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `message` | string | Yes | User message text |
+| `text` | string | Yes | User message text |
 | `channelType` | string | No | Channel type override |
 
 **SSE Events**

--- a/docs/zh/api-reference.mdx
+++ b/docs/zh/api-reference.mdx
@@ -68,7 +68,7 @@ curl http://localhost:2138/api/character \
 curl -X POST http://localhost:2138/api/chat \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"message": "Hello, what can you do?"}'
+  -d '{"text": "Hello, what can you do?"}'
 ```
 
 <div id="stream-a-chat-response">
@@ -79,7 +79,7 @@ curl -X POST http://localhost:2138/api/chat \
 curl -N -X POST http://localhost:2138/api/chat/stream \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"message": "Tell me about yourself"}'
+  -d '{"text": "Tell me about yourself"}'
 ```
 
 响应是一个 Server-Sent Events 流。每个事件包含一个带有 JSON 载荷的 `data` 字段。


### PR DESCRIPTION
## Summary
- Add a dated Alice operator proof page with image-backed evidence for setup, doctor, status, and graceful chat fallback.
- Update the operator bootstrap and CLI setup/doctor docs to match the real source-checkout workflow.
- Fix stale legacy chat examples to use the text request field.

## Validation
- Verified setup, doctor, models, start, api status, and legacy chat on an isolated proof state dir.
- Verified docs/docs.json parses cleanly with jq.
- Mint broken-links could not run in this environment because the mint binary is not installed.

## Scope
- Fork only: rndrntwrk/milaidy -> main.
- Docs-only diff.