### PR TITLE
feat(safety): add alice high-risk action register

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -156,6 +156,7 @@
             "group": "Operators",
             "pages": [
               "operators/alice-operator-bootstrap",
+              "operators/alice-high-risk-action-register",
               "operators/alice-operator-proof-2026-04-01",
               "operators/alice-system-boundary",
               "operators/stack-lifecycle-glossary",

--- a/docs/operators/alice-high-risk-action-register.md
+++ b/docs/operators/alice-high-risk-action-register.md
@@ -1,0 +1,156 @@
+# Alice High-Risk Action Register
+
+## Purpose
+
+Inventory the privileged actions Alice can take or mutate, name the owner for
+each path, and make the guardrail path explicit so operator mode never depends
+on a silent high-risk capability.
+
+## Safety rule
+
+No entry in this register is allowed to be `silent` in operator mode. Every
+high-risk path must be one of:
+
+- an explicit API request
+- an explicit named action the operator enabled
+- a human approval step
+
+The typed source of truth lives in `src/security/high-risk-action-register.ts`.
+
+## Register
+
+### 1. Server-side shell execution
+
+- Owner: Milady API server + operator runtime owner
+- Privileged surface: `POST /api/terminal/run`
+- Operator visibility: explicit API request
+- Guardrails:
+  - `src/api/permissions-routes.ts`
+  - `src/security/terminal-run-limits.ts`
+  - `src/services/sandbox-manager.ts`
+  - `packages/autonomous/src/api/server.ts`
+- Security anchors:
+  - `src/security/terminal-run-limits.ts`
+  - `src/security/audit-log.ts`
+- Why it is high risk:
+  - host command execution can mutate state, leak data, or bypass operator intent
+
+### 2. Custom action definition changes
+
+- Owner: Custom action API owner
+- Privileged surface:
+  - `POST /api/custom-actions`
+  - `PUT /api/custom-actions/:id`
+  - `POST /api/custom-actions/:id/test`
+  - `DELETE /api/custom-actions/:id`
+- Operator visibility: explicit API request
+- Guardrails:
+  - `packages/autonomous/src/api/server.ts`
+  - `packages/autonomous/src/runtime/custom-actions.ts`
+  - `src/security/terminal-run-limits.ts`
+  - `src/security/network-policy.ts`
+- Security anchors:
+  - `src/security/terminal-run-limits.ts`
+  - `src/security/network-policy.ts`
+  - `src/security/audit-log.ts`
+- Why it is high risk:
+  - custom actions persist in config and can create privileged shell/code/http execution paths
+
+### 3. HTTP custom action execution
+
+- Owner: Custom action runtime owner
+- Privileged surface: named runtime HTTP action
+- Operator visibility: explicit named action
+- Guardrails:
+  - `packages/autonomous/src/runtime/custom-actions.ts`
+  - `src/security/network-policy.ts`
+- Security anchors:
+  - `src/security/network-policy.ts`
+  - `src/security/audit-log.ts`
+- Why it is high risk:
+  - external requests can become SSRF or metadata access if DNS pinning and private-IP blocks fail
+
+### 4. Code custom action execution
+
+- Owner: Custom action runtime owner
+- Privileged surface: named runtime code action
+- Operator visibility: explicit named action
+- Guardrails:
+  - `packages/autonomous/src/runtime/custom-actions.ts`
+  - `packages/autonomous/src/api/server.ts`
+  - `src/security/network-policy.ts`
+  - `src/security/terminal-run-limits.ts`
+- Security anchors:
+  - `src/security/network-policy.ts`
+  - `src/security/terminal-run-limits.ts`
+  - `src/security/audit-log.ts`
+- Why it is high risk:
+  - code handlers can trigger network side effects and persist as privileged automation
+
+### 5. Plugin install and uninstall
+
+- Owner: Plugin manager + operator UI owner
+- Privileged surface:
+  - `POST /api/plugins/install`
+  - `POST /api/plugins/uninstall`
+  - plugin eject flow
+- Operator visibility: explicit API request
+- Guardrails:
+  - `packages/autonomous/src/api/server.ts`
+  - `src/services/plugin-installer.ts`
+  - `src/security/audit-log.ts`
+- Security anchors:
+  - `src/security/audit-log.ts`
+  - `src/security/high-risk-action-register.ts`
+- Why it is high risk:
+  - plugin lifecycle changes persist across restarts and widen the loaded runtime surface
+
+### 6. Skill marketplace install and uninstall
+
+- Owner: Skill marketplace owner
+- Privileged surface:
+  - `POST /api/skills/marketplace/install`
+  - `POST /api/skills/marketplace/uninstall`
+- Operator visibility: explicit API request
+- Guardrails:
+  - `packages/autonomous/src/api/server.ts`
+  - `packages/autonomous/src/services/skill-marketplace.ts`
+  - `src/security/audit-log.ts`
+- Security anchors:
+  - `src/security/audit-log.ts`
+  - `src/security/high-risk-action-register.ts`
+- Why it is high risk:
+  - marketplace skill ingestion changes workspace behavior and can introduce new executable guidance/artifacts
+
+### 7. Wallet signing and transaction approval
+
+- Owner: Remote signing service owner
+- Privileged surface:
+  - signing request submission
+  - `POST /api/sandbox/sign/approve`
+- Operator visibility: human approval required
+- Guardrails:
+  - `packages/autonomous/src/services/signing-policy.ts`
+  - `packages/autonomous/src/services/remote-signing-service.ts`
+  - `packages/autonomous/src/api/sandbox-routes.ts`
+  - `src/security/audit-log.ts`
+- Security anchors:
+  - `src/security/audit-log.ts`
+  - `src/security/high-risk-action-register.ts`
+- Why it is high risk:
+  - signing turns Alice from an advisor into a value-moving actor
+
+## Audit requirements
+
+Every register entry names audit requirements even when the current runtime path
+still needs fuller coverage. The minimum bar is:
+
+- accepted privileged capability invocations are visible to operators
+- denied policy decisions are visible to operators
+- value-moving requests record submission, approval/rejection, and expiry
+
+## Related docs
+
+- `operators/alice-system-boundary`
+- `operators/alice-operator-bootstrap`
+- `stability/alice-evaluation-set`

--- a/docs/operators/alice-operator-bootstrap.md
+++ b/docs/operators/alice-operator-bootstrap.md
@@ -47,6 +47,7 @@ Use this document when:
    - What is Milady responsible for?
    - What is Alice responsible for?
    - What is `555-bot` responsible for?
+   - What high-risk actions are allowed, gated, or denied in operator mode?
 7. Run the first-use validation:
    - run `milady setup` or `bun scripts/run-node.mjs setup` for a source checkout
    - run `milady doctor --no-ports` or `bun scripts/run-node.mjs doctor --no-ports`
@@ -92,5 +93,6 @@ Use this document when:
 - `deployment`
 - `agents/runtime-and-lifecycle`
 - `guides/knowledge`
+- `operators/alice-high-risk-action-register`
 - `operators/alice-operator-proof-2026-04-01`
 - `Render-Network-OS/555-bot: docs/ALICE_DEPLOYMENT_DOCS_INDEX.md`

--- a/src/security/__tests__/high-risk-action-register.test.ts
+++ b/src/security/__tests__/high-risk-action-register.test.ts
@@ -1,0 +1,28 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  ALICE_HIGH_RISK_ACTION_REGISTER,
+  validateAliceHighRiskActionRegister,
+} from "../high-risk-action-register";
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(currentDir, "..", "..", "..");
+
+describe("Alice high-risk action register", () => {
+  it("has owners, explicit operator visibility, and audit requirements", () => {
+    expect(() => validateAliceHighRiskActionRegister()).not.toThrow();
+  });
+
+  it("references real files for guardrails and security anchors", () => {
+    for (const entry of ALICE_HIGH_RISK_ACTION_REGISTER) {
+      for (const file of [...entry.guardrailPaths, ...entry.securityAnchors]) {
+        expect(
+          existsSync(path.join(repoRoot, file)),
+          `${entry.id} references missing file: ${file}`,
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/src/security/high-risk-action-register.ts
+++ b/src/security/high-risk-action-register.ts
@@ -1,0 +1,258 @@
+export type AliceHighRiskActionId =
+  | "terminal-run"
+  | "custom-action-definition"
+  | "custom-action-http"
+  | "custom-action-code"
+  | "plugin-install-uninstall"
+  | "skill-marketplace-install-uninstall"
+  | "wallet-signing";
+
+export type OperatorVisibility =
+  | "explicit_api_request"
+  | "explicit_named_action"
+  | "human_approval_required";
+
+export interface AliceHighRiskActionEntry {
+  id: AliceHighRiskActionId;
+  action: string;
+  owner: string;
+  risk: string;
+  operatorVisibility: OperatorVisibility;
+  currentGuardrails: string[];
+  guardrailPaths: string[];
+  securityAnchors: string[];
+  auditRequirements: string[];
+}
+
+export const ALICE_HIGH_RISK_ACTION_REGISTER: AliceHighRiskActionEntry[] = [
+  {
+    id: "terminal-run",
+    action: "Server-side shell execution through /api/terminal/run",
+    owner: "Milady API server + operator runtime owner",
+    risk:
+      "Arbitrary host command execution can mutate state, leak data, or bypass operator intent.",
+    operatorVisibility: "explicit_api_request",
+    currentGuardrails: [
+      "Shell access can be disabled through the permissions route before terminal execution is attempted.",
+      "Terminal execution can require an explicit terminal token and a client id before the server accepts a run.",
+      "Commands are capped to a single line and 4096 characters, with concurrent and duration limits enforced.",
+      "Sandbox mode remains the isolation owner when shell execution is routed into a sandboxed runtime path.",
+    ],
+    guardrailPaths: [
+      "packages/autonomous/src/api/server.ts",
+      "src/api/permissions-routes.ts",
+      "src/services/sandbox-manager.ts",
+      "src/security/terminal-run-limits.ts",
+    ],
+    securityAnchors: [
+      "src/security/terminal-run-limits.ts",
+      "src/security/audit-log.ts",
+    ],
+    auditRequirements: [
+      "Record privileged capability invocation for each accepted terminal run.",
+      "Record deny decisions for disabled shell, invalid token, or terminal rate-limit rejection.",
+    ],
+  },
+  {
+    id: "custom-action-definition",
+    action: "Create, update, test, or delete custom shell/code/http actions",
+    owner: "Custom action API owner",
+    risk:
+      "Persistent custom actions can survive restarts and create privileged execution paths if they are not explicitly gated.",
+    operatorVisibility: "explicit_api_request",
+    currentGuardrails: [
+      "Only http, shell, and code handlers are accepted by the API.",
+      "Creating or updating shell/code handlers requires the same terminal authorization gate used for direct terminal runs.",
+      "Testing shell/code handlers is also gated by terminal authorization rather than a silent background path.",
+    ],
+    guardrailPaths: [
+      "packages/autonomous/src/api/server.ts",
+      "packages/autonomous/src/runtime/custom-actions.ts",
+      "src/security/terminal-run-limits.ts",
+      "src/security/network-policy.ts",
+    ],
+    securityAnchors: [
+      "src/security/terminal-run-limits.ts",
+      "src/security/network-policy.ts",
+      "src/security/audit-log.ts",
+    ],
+    auditRequirements: [
+      "Record privileged capability invocation for custom-action create, update, test, and delete operations.",
+      "Record policy decisions when terminal authorization blocks shell/code action changes.",
+    ],
+  },
+  {
+    id: "custom-action-http",
+    action: "HTTP custom action execution against external services",
+    owner: "Custom action runtime owner",
+    risk:
+      "Unpinned or internal-network requests can turn a user prompt into SSRF or metadata service access.",
+    operatorVisibility: "explicit_named_action",
+    currentGuardrails: [
+      "HTTP action targets are resolved through DNS pinning and blocked if they resolve to private, loopback, link-local, or metadata addresses.",
+      "Redirects are denied to avoid bouncing from an external hostname into an internal target.",
+      "Response bodies are truncated before being surfaced back into the runtime.",
+    ],
+    guardrailPaths: [
+      "packages/autonomous/src/runtime/custom-actions.ts",
+      "src/security/network-policy.ts",
+    ],
+    securityAnchors: [
+      "src/security/network-policy.ts",
+      "src/security/audit-log.ts",
+    ],
+    auditRequirements: [
+      "Record privileged capability invocation when a custom HTTP action reaches an external boundary.",
+      "Record deny decisions when network policy blocks a host or redirect.",
+    ],
+  },
+  {
+    id: "custom-action-code",
+    action: "Code custom action execution inside the runtime VM",
+    owner: "Custom action runtime owner",
+    risk:
+      "Code handlers can issue network requests and transform operator input into privileged automation with fewer visual cues than a direct shell run.",
+    operatorVisibility: "explicit_named_action",
+    currentGuardrails: [
+      "Code handlers run inside a constrained VM with a 30 second timeout instead of direct unrestricted module access.",
+      "The exposed fetch surface is wrapped by the same network safety checks used for HTTP custom actions.",
+      "Shell or code custom actions cannot be created or updated without terminal authorization.",
+    ],
+    guardrailPaths: [
+      "packages/autonomous/src/runtime/custom-actions.ts",
+      "packages/autonomous/src/api/server.ts",
+      "src/security/network-policy.ts",
+      "src/security/terminal-run-limits.ts",
+    ],
+    securityAnchors: [
+      "src/security/network-policy.ts",
+      "src/security/terminal-run-limits.ts",
+      "src/security/audit-log.ts",
+    ],
+    auditRequirements: [
+      "Record privileged capability invocation for code action execution.",
+      "Record deny decisions when code-action creation or testing is blocked by terminal authorization.",
+    ],
+  },
+  {
+    id: "plugin-install-uninstall",
+    action: "Install or uninstall runtime plugins",
+    owner: "Plugin manager + operator UI owner",
+    risk:
+      "Plugin lifecycle changes modify the loaded runtime surface, persist across restarts, and can introduce new code paths.",
+    operatorVisibility: "explicit_api_request",
+    currentGuardrails: [
+      "Install requests require an explicit package name and reject invalid npm package identifiers.",
+      "Plugin installs are serialized and constrained to the Milady-installed plugins directory.",
+      "Runtime restart is explicit and tied to the install or uninstall result rather than hidden background mutation.",
+    ],
+    guardrailPaths: [
+      "packages/autonomous/src/api/server.ts",
+      "src/services/plugin-installer.ts",
+      "src/security/audit-log.ts",
+    ],
+    securityAnchors: [
+      "src/security/audit-log.ts",
+      "src/security/high-risk-action-register.ts",
+    ],
+    auditRequirements: [
+      "Record privileged capability invocation for plugin install, uninstall, and eject.",
+      "Record failures that change runtime shape but do not complete successfully.",
+    ],
+  },
+  {
+    id: "skill-marketplace-install-uninstall",
+    action: "Install or uninstall marketplace skills",
+    owner: "Skill marketplace owner",
+    risk:
+      "Marketplace skill ingestion adds executable guidance/artifacts into the operator workspace and can widen the action surface.",
+    operatorVisibility: "explicit_api_request",
+    currentGuardrails: [
+      "Skill ids are validated before install or uninstall is allowed.",
+      "Skills with warning or critical scan findings cannot be enabled until the findings are explicitly acknowledged.",
+      "Marketplace actions refresh discovered skills after mutation so the visible state matches the workspace state.",
+    ],
+    guardrailPaths: [
+      "packages/autonomous/src/api/server.ts",
+      "packages/autonomous/src/services/skill-marketplace.ts",
+      "src/security/audit-log.ts",
+    ],
+    securityAnchors: [
+      "src/security/audit-log.ts",
+      "src/security/high-risk-action-register.ts",
+    ],
+    auditRequirements: [
+      "Record privileged capability invocation for skill install and uninstall.",
+      "Record marketplace policy decisions when a scan acknowledgment is required before enablement.",
+    ],
+  },
+  {
+    id: "wallet-signing",
+    action: "Remote wallet signing and transaction approval",
+    owner: "Remote signing service owner",
+    risk:
+      "Signing turns Alice from an advisor into a value-moving actor, so replay, rate, contract, and value controls must be explicit.",
+    operatorVisibility: "human_approval_required",
+    currentGuardrails: [
+      "Signing requests run through chain, contract, method, value, replay, and rate-limit policy evaluation.",
+      "Policy can require human confirmation globally or above a configured value threshold before signing proceeds.",
+      "Submitted, rejected, approved, and expired signing paths are tracked through the audit log.",
+    ],
+    guardrailPaths: [
+      "packages/autonomous/src/services/signing-policy.ts",
+      "packages/autonomous/src/services/remote-signing-service.ts",
+      "packages/autonomous/src/api/sandbox-routes.ts",
+      "src/security/audit-log.ts",
+    ],
+    securityAnchors: [
+      "src/security/audit-log.ts",
+      "src/security/high-risk-action-register.ts",
+    ],
+    auditRequirements: [
+      "Record signing submission, rejection, approval, and expiration events.",
+      "Record policy updates that change signing behavior.",
+    ],
+  },
+] as const;
+
+export function validateAliceHighRiskActionRegister(): void {
+  const ids = new Set<string>();
+
+  for (const entry of ALICE_HIGH_RISK_ACTION_REGISTER) {
+    if (ids.has(entry.id)) {
+      throw new Error(`Duplicate high-risk action id: ${entry.id}`);
+    }
+    ids.add(entry.id);
+
+    if (!entry.owner.trim()) {
+      throw new Error(`Missing owner for high-risk action: ${entry.id}`);
+    }
+    if (!entry.action.trim()) {
+      throw new Error(`Missing action description for high-risk action: ${entry.id}`);
+    }
+    if (!entry.risk.trim()) {
+      throw new Error(`Missing risk summary for high-risk action: ${entry.id}`);
+    }
+    if (entry.currentGuardrails.length === 0) {
+      throw new Error(`Missing guardrails for high-risk action: ${entry.id}`);
+    }
+    if (entry.guardrailPaths.length === 0) {
+      throw new Error(`Missing guardrail paths for high-risk action: ${entry.id}`);
+    }
+    if (entry.securityAnchors.length === 0) {
+      throw new Error(`Missing security anchors for high-risk action: ${entry.id}`);
+    }
+    if (
+      !entry.securityAnchors.some((anchor) =>
+        anchor.startsWith("src/security/"),
+      )
+    ) {
+      throw new Error(
+        `High-risk action ${entry.id} must reference at least one src/security anchor`,
+      );
+    }
+    if (entry.auditRequirements.length === 0) {
+      throw new Error(`Missing audit requirements for high-risk action: ${entry.id}`);
+    }
+  }
+}

--- a/src/security/terminal-run-limits.ts
+++ b/src/security/terminal-run-limits.ts
@@ -1,0 +1,1 @@
+export * from "@miladyai/autonomous/api/terminal-run-limits";


### PR DESCRIPTION
## Summary
- add a typed Alice high-risk action register under `src/security`
- validate that every privileged path has an owner, explicit operator visibility, and real guardrail/security anchors
- publish the operator-facing safety register and wire it into the docs nav

## Validation
- `bun --bun -e "import { ALICE_HIGH_RISK_ACTION_REGISTER, validateAliceHighRiskActionRegister } from ./src/security/high-risk-action-register.ts; import { existsSync } from node:fs; import { resolve } from node:path; validateAliceHighRiskActionRegister(); const missing = []; for (const entry of ALICE_HIGH_RISK_ACTION_REGISTER) { for (const rel of [...entry.guardrailPaths, ...entry.securityAnchors]) { const path = resolve(rel); if (!existsSync(path)) missing.push(path); } } if (missing.length) { console.error(JSON.stringify(missing, null, 2)); process.exit(1); } console.log(JSON.stringify({ entries: ALICE_HIGH_RISK_ACTION_REGISTER.length }, null, 2));"`
- `node -e "JSON.parse(require(\"node:fs\").readFileSync(\"docs/docs.json\",\"utf8\")); console.log(\"docs.json ok\")"`

## Ticket
- Closes #15