### PR TITLE
feat(config): add alice config and env matrix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Milady runtime environment example
 # Copy values into .env or ~/.milady/.env as needed.
+# This file covers routine local runtime secrets only. For deploy-only and
+# founder-only controls, use docs/operators/alice-config-and-env-matrix.md.
 
 # ----------------------------------------------------------------------------
 # Core coding-agent credentials (used by swarm/solo coding runs)

--- a/docs/cli/environment.md
+++ b/docs/cli/environment.md
@@ -6,6 +6,19 @@ description: "Complete reference for all Milady environment variables."
 
 Milady reads environment variables at startup to configure paths, ports, API access, feature flags, and runtime behavior. Variables take precedence over config file values for path and server settings. This page documents every recognized environment variable.
 
+If you are deciding **where** a value should live, start with the
+[Alice Config and Env Matrix](/operators/alice-config-and-env-matrix). This
+page is exhaustive by variable name; the matrix is the operational source of
+truth for separating local runtime secrets, deploy secrets, and founder-only
+controls.
+
+## Use the matrix first
+
+- `milady.json` is for structure and repeatable defaults.
+- `~/.milady/.env` is for routine local runtime secrets.
+- process env or a deploy secret store is for exposed-backend and deployment tokens.
+- founder-only controls stay outside routine operator-managed config.
+
 ## Path and State
 
 These variables control where Milady stores its state, config, and credentials.

--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -6,6 +6,12 @@ description: "Initialize the Milady config file and agent workspace."
 
 Initialize the Milady configuration file (`~/.milady/milady.json`) and bootstrap the agent workspace directory with required scaffold files. Run this command once before starting the agent for the first time, or to repair a missing or incomplete workspace.
 
+Before you run setup, decide which values belong in config, local `.env`,
+deploy secrets, or founder-only controls by using the
+[Alice Config and Env Matrix](/operators/alice-config-and-env-matrix). `setup`
+creates repeatable structure; it does not replace deploy-only secret
+provisioning.
+
 ## Usage
 
 ```bash
@@ -141,6 +147,7 @@ In a fresh workspace, Milady bootstraps these operator-facing files:
 
 - `milady setup` prepares config and workspace state, but it does **not** set the agent name by itself. If `agents.list[].name` is missing, the first `milady start` still opens onboarding.
 - `MILADY_STATE_DIR` changes where `milady.json` lives, but the workspace path still follows the normal resolution order. In isolated environments, pass `--workspace` explicitly or set `agents.defaults.workspace` in config so setup, start, and doctor all point at the same directory.
+- Provider keys for local runtime can live in `~/.milady/.env`, but exposed-backend tokens such as `MILADY_API_TOKEN` should stay in process env or your deploy secret store. The matrix page above is the authoritative split.
 - For source-checkout verification before the CLI is installed globally, use the repo runner:
 
 ```bash

--- a/docs/deployment.mdx
+++ b/docs/deployment.mdx
@@ -6,6 +6,11 @@ description: Deploy Milady using Docker, Docker Compose, or cloud containers. Co
 
 Milady supports multiple deployment strategies: standalone Docker containers, Docker Compose orchestration, and cloud-managed containers for Eliza Cloud (AWS ECS).
 
+Before you set deployment variables, use the
+[Alice Config and Env Matrix](/operators/alice-config-and-env-matrix). The
+matrix is the canonical boundary between local runtime secrets, deploy secrets,
+and founder-only controls.
+
 ## Quick Start with Docker Compose
 
 The fastest way to deploy Milady is using the included setup script, which builds the image, generates authentication tokens, runs interactive onboarding, and starts the gateway.
@@ -199,6 +204,12 @@ When extra mounts or a home volume are specified, the setup script generates a `
 | 18790 | Bridge (inter-service communication) | Host-mapped | `MILADY_BRIDGE_PORT` |
 
 ## Environment Variables
+
+Deployment rule of thumb:
+
+- compose wiring such as paths, ports, and image tags can live in `deploy/.env`
+- public-backend auth tokens, wallet/export controls, and database URLs belong in process env or your secret manager
+- routine local operator keys do not need to be copied into every hosted deployment unless that deployment will actually use them
 
 ### Required
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -156,6 +156,7 @@
             "group": "Operators",
             "pages": [
               "operators/alice-operator-bootstrap",
+              "operators/alice-config-and-env-matrix",
               "operators/alice-high-risk-action-register",
               "operators/alice-operator-proof-2026-04-01",
               "operators/alice-system-boundary",

--- a/docs/operators/alice-config-and-env-matrix.md
+++ b/docs/operators/alice-config-and-env-matrix.md
@@ -1,0 +1,155 @@
+---
+title: "Alice Config and Env Matrix"
+sidebarTitle: "config/env matrix"
+description: "Single source of truth for where Alice configuration lives: milady.json, local .env, deploy secrets, and founder-only controls."
+---
+
+# Alice Config and Env Matrix
+
+Use this page before editing `~/.milady/milady.json`, `~/.milady/.env`, or any
+deploy secret store. The goal is simple:
+
+- `milady.json` stores structure and repeatable defaults
+- `~/.milady/.env` stores routine local runtime secrets
+- deploy secret stores or process env carry exposed-backend and deployment
+  secrets
+- founder-only controls stay out of operator-managed config surfaces
+
+The typed source of truth lives in `src/config/alice-config-matrix.ts`.
+
+## Storage rules
+
+| Surface | Use for | Do not use for |
+| --- | --- | --- |
+| `~/.milady/milady.json` | workspace paths, agent defaults, model selection, connectors, cloud mode, gateway/database structure | high-blast-radius secrets that startup blocks from config-to-env sync |
+| `~/.milady/.env` | local operator runtime secrets such as provider API keys | deploy-only tokens for exposed services |
+| deploy secret manager / process env | public-backend auth tokens, database URLs, wallet keys, export tokens, hosted cloud secrets | checked-in examples or copied local config defaults |
+| founder-only secret store | repo tokens, wallet keys, export tokens, marketplace or infra authority | day-to-day operator setup |
+
+## Product matrix
+
+### 1. Alice local operator runtime
+
+Use this surface for local `setup`, `doctor`, and `start`.
+
+| Field | Value |
+| --- | --- |
+| Set in | `milady.json`, `~/.milady/.env` |
+| Config keys | `env.shellEnv`, `models.small`, `models.large`, `agents.defaults.workspace`, `agents.list[]`, `tools`, `connectors` |
+| Required env | one of `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `AI_GATEWAY_API_KEY`, `OLLAMA_BASE_URL`, `ELIZAOS_CLOUD_API_KEY` |
+| Optional env | `MILADY_PROFILE`, `MILADY_STATE_DIR`, `MILADY_CONFIG_PATH`, `MILADY_WORKSPACE_ROOT`, `MILADY_PORT`, `LOG_LEVEL`, `MILADY_TUI_SHOW_THINKING` |
+| Repeatable path | `milady setup` -> `milady doctor --no-ports` -> `milady start` |
+
+Notes:
+- Keep local structure in config and provider secrets in `~/.milady/.env`.
+- `doctor` expects a valid config file plus at least one provider or Ollama endpoint.
+
+### 2. Alice exposed or self-hosted backend
+
+Use this surface when the backend is reachable remotely and the API is not
+loopback-only.
+
+| Field | Value |
+| --- | --- |
+| Set in | `milady.json`, process env, deploy secret manager |
+| Config keys | `agents.defaults.workspace`, `gateway`, `database`, `connectors` |
+| Required env | `MILADY_API_BIND`, `MILADY_API_TOKEN`, `MILADY_ALLOWED_ORIGINS`, plus one provider key or `OLLAMA_BASE_URL` |
+| Optional env | `POSTGRES_URL`, `PGLITE_DATA_DIR`, `MILADY_PAIRING_DISABLED`, `MILADY_ALLOW_WS_QUERY_TOKEN` |
+| Founder-only control on this surface | `MILADY_WALLET_EXPORT_TOKEN` |
+| Repeatable path | `milady setup --no-wizard` -> `milady doctor --no-ports` -> `milady start` |
+
+Notes:
+- `MILADY_API_TOKEN` is a deploy secret, not a config-file secret.
+- If the backend is exposed beyond loopback, pair token, bind, and CORS settings together. Do not configure them independently.
+
+### 3. Alice Docker and Compose deployment
+
+Use this surface for the repository deployment flow under `deploy/`.
+
+| Field | Value |
+| --- | --- |
+| Set in | `deploy/.env`, deploy secret manager, process env |
+| Config keys | `cloud.container`, `database`, `gateway` |
+| Required env | `MILADY_GATEWAY_TOKEN`, `MILADY_CONFIG_DIR`, `MILADY_WORKSPACE_DIR` |
+| Optional env | `MILADY_IMAGE`, `MILADY_GATEWAY_PORT`, `MILADY_BRIDGE_PORT`, `MILADY_API_BIND`, `MILADY_API_TOKEN`, `MILADY_ALLOWED_ORIGINS`, `MILADY_DOCKER_APT_PACKAGES`, `MILADY_EXTRA_MOUNTS`, `MILADY_HOME_VOLUME`, `POSTGRES_URL`, provider keys, `ELIZAOS_CLOUD_API_KEY` |
+| Founder-only control on this surface | `MILADY_WALLET_EXPORT_TOKEN` |
+| Repeatable path | `cd deploy && ./docker-setup.sh` -> `docker compose up -d` -> `docker compose logs -f milady-gateway` |
+
+Notes:
+- Compose wiring belongs in `deploy/.env`.
+- Exposed-service tokens and database URLs still belong in the deploy secret path, not in checked-in examples.
+
+### 4. Alice managed cloud and Eliza Cloud integration
+
+Use this surface when Alice should use Eliza Cloud inference or attach to a
+managed cloud agent.
+
+| Field | Value |
+| --- | --- |
+| Set in | `milady.json`, `~/.milady/.env`, deploy secret manager |
+| Config keys | `cloud.enabled`, `cloud.provider`, `cloud.baseUrl`, `cloud.inferenceMode`, `cloud.runtime`, `cloud.services` |
+| Required env | `ELIZAOS_CLOUD_API_KEY` |
+| Optional env | `ELIZAOS_CLOUD_ENABLED`, `ELIZAOS_CLOUD_BASE_URL`, `ELIZAOS_CLOUD_SMALL_MODEL`, `ELIZAOS_CLOUD_LARGE_MODEL` |
+| Repeatable path | `milady setup --no-wizard` -> `milady doctor --no-ports` -> `milady start` |
+
+Notes:
+- Local onboarding may cache cloud settings in config, but hosted deployments should still provision the API key as a secret.
+- Pick one inference mode deliberately. Do not mix local and cloud credentials without an explicit `cloud.inferenceMode` decision.
+
+### 5. Founder-only and high-blast-radius controls
+
+These controls should not be treated as normal operator configuration.
+
+| Control class | Keys |
+| --- | --- |
+| Repo / issue authority | `GITHUB_TOKEN` |
+| Wallet / value movement | `EVM_PRIVATE_KEY`, `SOLANA_PRIVATE_KEY` |
+| Export or API authority | `MILADY_WALLET_EXPORT_TOKEN` |
+| Database authority | `POSTGRES_URL`, `DATABASE_URL` |
+| Marketplace / infra authority | `SKILLSMP_API_KEY` |
+
+Notes:
+- Most of these keys are blocked from config-to-env sync by startup policy in `packages/autonomous/src/config/env-vars.ts`.
+- Treat them as secret-manager values, not as routine `milady.json` or local `.env` content.
+
+## Minimum repeatable paths
+
+### Local operator path
+
+```bash
+milady setup
+milady doctor --no-ports
+milady start
+```
+
+The only secret requirement is one valid provider key or local model endpoint.
+
+### Exposed backend path
+
+```bash
+export MILADY_API_BIND=0.0.0.0
+export MILADY_API_TOKEN="$(openssl rand -hex 32)"
+export MILADY_ALLOWED_ORIGINS="https://app.milady.ai"
+milady doctor --no-ports
+milady start
+```
+
+Add `POSTGRES_URL` only if the runtime should use Postgres instead of PGLite.
+
+### Docker deploy path
+
+```bash
+cd deploy
+./docker-setup.sh
+docker compose up -d
+```
+
+Populate `deploy/.env` for compose wiring, and keep deploy-only tokens in the
+runtime environment or secret manager used to launch Compose.
+
+## Related docs
+
+- `cli/setup`
+- `cli/environment`
+- `deployment`
+- `operators/alice-high-risk-action-register`

--- a/src/config/__tests__/alice-config-matrix.test.ts
+++ b/src/config/__tests__/alice-config-matrix.test.ts
@@ -1,0 +1,28 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  ALICE_CONFIG_MATRIX,
+  validateAliceConfigMatrix,
+} from "../alice-config-matrix";
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(currentDir, "..", "..", "..");
+
+describe("Alice config matrix", () => {
+  it("has unique entries with repeatable commands and environment scope", () => {
+    expect(() => validateAliceConfigMatrix()).not.toThrow();
+  });
+
+  it("anchors every matrix entry to real repo files", () => {
+    for (const entry of ALICE_CONFIG_MATRIX) {
+      for (const file of entry.sourceAnchors) {
+        expect(
+          existsSync(path.join(repoRoot, file)),
+          `${entry.id} references missing file: ${file}`,
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/src/config/alice-config-matrix.ts
+++ b/src/config/alice-config-matrix.ts
@@ -1,0 +1,284 @@
+export type AliceConfigMatrixId =
+  | "alice-local-runtime"
+  | "alice-remote-runtime"
+  | "alice-container-deploy"
+  | "alice-managed-cloud"
+  | "alice-founder-controls";
+
+export type AliceConfigScope =
+  | "local-runtime"
+  | "remote-runtime"
+  | "container-deploy"
+  | "managed-cloud"
+  | "founder-only-control";
+
+export type AliceConfigStorageSurface =
+  | "milady.json"
+  | "~/.milady/.env"
+  | "process-env"
+  | "deploy-secret-manager"
+  | "deploy/.env";
+
+export interface AliceConfigMatrixEntry {
+  id: AliceConfigMatrixId;
+  scope: AliceConfigScope;
+  surface: string;
+  summary: string;
+  setIn: AliceConfigStorageSurface[];
+  configKeys: string[];
+  requiredEnv: string[];
+  optionalEnv: string[];
+  founderOnlyControls: string[];
+  repeatableCommands: string[];
+  sourceAnchors: string[];
+  notes: string[];
+}
+
+export const ALICE_CONFIG_MATRIX: AliceConfigMatrixEntry[] = [
+  {
+    id: "alice-local-runtime",
+    scope: "local-runtime",
+    surface: "Alice local operator runtime",
+    summary:
+      "Single-user local setup for `milady setup`, `milady doctor`, and `milady start` on the operator machine.",
+    setIn: ["milady.json", "~/.milady/.env"],
+    configKeys: [
+      "env.shellEnv",
+      "models.small",
+      "models.large",
+      "agents.defaults.workspace",
+      "agents.list[]",
+      "tools",
+      "connectors",
+    ],
+    requiredEnv: [
+      "ANTHROPIC_API_KEY | OPENAI_API_KEY | GOOGLE_GENERATIVE_AI_API_KEY | AI_GATEWAY_API_KEY | OLLAMA_BASE_URL | ELIZAOS_CLOUD_API_KEY",
+    ],
+    optionalEnv: [
+      "MILADY_PROFILE",
+      "MILADY_STATE_DIR",
+      "MILADY_CONFIG_PATH",
+      "MILADY_WORKSPACE_ROOT",
+      "MILADY_PORT",
+      "LOG_LEVEL",
+      "MILADY_TUI_SHOW_THINKING",
+    ],
+    founderOnlyControls: [],
+    repeatableCommands: [
+      "milady setup",
+      "milady doctor --no-ports",
+      "milady start",
+    ],
+    sourceAnchors: [
+      "src/config/zod-schema.ts",
+      "src/config/types.milady.ts",
+      "src/config/types.agents.ts",
+      "docs/cli/setup.md",
+      "docs/cli/environment.md",
+    ],
+    notes: [
+      "Keep structure in `milady.json` and routine local secrets in `~/.milady/.env`.",
+      "At least one model provider or Ollama endpoint must exist before `milady doctor` passes the model-key check.",
+    ],
+  },
+  {
+    id: "alice-remote-runtime",
+    scope: "remote-runtime",
+    surface: "Alice exposed or self-hosted backend",
+    summary:
+      "Remote backend reachable over HTTPS or Tailscale, with an authenticated API and repeatable state paths.",
+    setIn: ["milady.json", "process-env", "deploy-secret-manager"],
+    configKeys: [
+      "agents.defaults.workspace",
+      "gateway",
+      "database",
+      "connectors",
+    ],
+    requiredEnv: [
+      "MILADY_API_BIND",
+      "MILADY_API_TOKEN",
+      "MILADY_ALLOWED_ORIGINS",
+      "ANTHROPIC_API_KEY | OPENAI_API_KEY | GOOGLE_GENERATIVE_AI_API_KEY | AI_GATEWAY_API_KEY | OLLAMA_BASE_URL | ELIZAOS_CLOUD_API_KEY",
+    ],
+    optionalEnv: [
+      "POSTGRES_URL",
+      "PGLITE_DATA_DIR",
+      "MILADY_PAIRING_DISABLED",
+      "MILADY_ALLOW_WS_QUERY_TOKEN",
+    ],
+    founderOnlyControls: ["MILADY_WALLET_EXPORT_TOKEN"],
+    repeatableCommands: [
+      "milady setup --no-wizard",
+      "milady doctor --no-ports",
+      "milady start",
+    ],
+    sourceAnchors: [
+      "packages/autonomous/src/config/env-vars.ts",
+      "docs/eliza-cloud-deployment.md",
+      "docs/cli/doctor.md",
+      "docs/cli/environment.md",
+    ],
+    notes: [
+      "`MILADY_API_TOKEN` is a deploy secret, not a config-file secret. It is blocked from config-to-env sync on startup.",
+      "If the backend is exposed beyond loopback, pairing and CORS rules must be intentional before operators connect.",
+    ],
+  },
+  {
+    id: "alice-container-deploy",
+    scope: "container-deploy",
+    surface: "Alice Docker and Compose deployment",
+    summary:
+      "Containerized gateway or API deployment with host volume mounts and explicit runtime/deploy secret boundaries.",
+    setIn: ["deploy/.env", "deploy-secret-manager", "process-env"],
+    configKeys: ["cloud.container", "database", "gateway"],
+    requiredEnv: [
+      "MILADY_GATEWAY_TOKEN",
+      "MILADY_CONFIG_DIR",
+      "MILADY_WORKSPACE_DIR",
+    ],
+    optionalEnv: [
+      "MILADY_IMAGE",
+      "MILADY_GATEWAY_PORT",
+      "MILADY_BRIDGE_PORT",
+      "MILADY_API_BIND",
+      "MILADY_API_TOKEN",
+      "MILADY_ALLOWED_ORIGINS",
+      "MILADY_DOCKER_APT_PACKAGES",
+      "MILADY_EXTRA_MOUNTS",
+      "MILADY_HOME_VOLUME",
+      "POSTGRES_URL",
+      "ANTHROPIC_API_KEY",
+      "OPENAI_API_KEY",
+      "GOOGLE_GENERATIVE_AI_API_KEY",
+      "AI_GATEWAY_API_KEY",
+      "ELIZAOS_CLOUD_API_KEY",
+    ],
+    founderOnlyControls: ["MILADY_WALLET_EXPORT_TOKEN"],
+    repeatableCommands: [
+      "cd deploy && ./docker-setup.sh",
+      "docker compose up -d",
+      "docker compose logs -f milady-gateway",
+    ],
+    sourceAnchors: [
+      "docs/deployment.mdx",
+      "deploy/docker-setup.sh",
+      "deploy/docker-compose.yml",
+      "deploy/Dockerfile",
+    ],
+    notes: [
+      "Use `deploy/.env` for compose wiring and secret-manager or process env for tokens that should not persist in repository-local files.",
+      "Provider keys are runtime secrets; gateway and export tokens are deploy-only secrets for the exposed service boundary.",
+    ],
+  },
+  {
+    id: "alice-managed-cloud",
+    scope: "managed-cloud",
+    surface: "Alice managed cloud and Eliza Cloud integration",
+    summary:
+      "Cloud-backed inference or managed-agent attachment where Milady delegates part of runtime behavior to Eliza Cloud.",
+    setIn: ["milady.json", "~/.milady/.env", "deploy-secret-manager"],
+    configKeys: [
+      "cloud.enabled",
+      "cloud.provider",
+      "cloud.baseUrl",
+      "cloud.inferenceMode",
+      "cloud.runtime",
+      "cloud.services",
+    ],
+    requiredEnv: ["ELIZAOS_CLOUD_API_KEY"],
+    optionalEnv: [
+      "ELIZAOS_CLOUD_ENABLED",
+      "ELIZAOS_CLOUD_BASE_URL",
+      "ELIZAOS_CLOUD_SMALL_MODEL",
+      "ELIZAOS_CLOUD_LARGE_MODEL",
+    ],
+    founderOnlyControls: [],
+    repeatableCommands: [
+      "milady setup --no-wizard",
+      "milady doctor --no-ports",
+      "milady start",
+    ],
+    sourceAnchors: [
+      "packages/autonomous/src/config/types.milady.ts",
+      "docs/eliza-cloud-deployment.md",
+      "docs/cli/environment.md",
+      "docs/deployment.mdx",
+    ],
+    notes: [
+      "Local onboarding may cache cloud settings in config, but hosted environments should still provision cloud API keys through a deploy secret manager.",
+      "Cloud runtime and local runtime should not mix conflicting provider secrets without a deliberate `cloud.inferenceMode` choice.",
+    ],
+  },
+  {
+    id: "alice-founder-controls",
+    scope: "founder-only-control",
+    surface: "Founder-only and high-blast-radius controls",
+    summary:
+      "Secrets and controls that should be restricted to founders or infra owners because they grant repo, wallet, export, or database authority.",
+    setIn: ["process-env", "deploy-secret-manager"],
+    configKeys: ["registry", "x402"],
+    requiredEnv: [],
+    optionalEnv: [],
+    founderOnlyControls: [
+      "GITHUB_TOKEN",
+      "MILADY_WALLET_EXPORT_TOKEN",
+      "EVM_PRIVATE_KEY",
+      "SOLANA_PRIVATE_KEY",
+      "POSTGRES_URL",
+      "DATABASE_URL",
+      "SKILLSMP_API_KEY",
+    ],
+    repeatableCommands: [
+      "milady doctor --no-ports",
+      "milady start",
+    ],
+    sourceAnchors: [
+      "packages/autonomous/src/config/env-vars.ts",
+      "docs/SECURITY.md",
+      "docs/cli/environment.md",
+      "docs/deployment.mdx",
+    ],
+    notes: [
+      "Most of these keys are blocked from config-to-env sync by startup policy and must never be relied on through `milady.json`.",
+      "Treat `SKILLSMP_API_KEY` as founder-only on shared or hosted environments even though it is not in the startup blocklist.",
+    ],
+  },
+] as const;
+
+export function validateAliceConfigMatrix(): void {
+  const ids = new Set<string>();
+
+  for (const entry of ALICE_CONFIG_MATRIX) {
+    if (ids.has(entry.id)) {
+      throw new Error(`Duplicate Alice config matrix id: ${entry.id}`);
+    }
+    ids.add(entry.id);
+
+    if (!entry.surface.trim()) {
+      throw new Error(`Missing surface label for config matrix entry: ${entry.id}`);
+    }
+    if (!entry.summary.trim()) {
+      throw new Error(`Missing summary for config matrix entry: ${entry.id}`);
+    }
+    if (entry.setIn.length === 0) {
+      throw new Error(`Missing storage surfaces for config matrix entry: ${entry.id}`);
+    }
+    if (entry.sourceAnchors.length === 0) {
+      throw new Error(`Missing source anchors for config matrix entry: ${entry.id}`);
+    }
+    if (entry.repeatableCommands.length === 0) {
+      throw new Error(
+        `Missing repeatable commands for config matrix entry: ${entry.id}`,
+      );
+    }
+    if (
+      entry.requiredEnv.length === 0 &&
+      entry.optionalEnv.length === 0 &&
+      entry.founderOnlyControls.length === 0
+    ) {
+      throw new Error(
+        `Config matrix entry ${entry.id} must describe at least one environment surface`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a typed Alice configuration and environment matrix under `src/config`
- publish a single operator-facing matrix that separates local runtime secrets, deploy secrets, and founder-only controls
- wire setup, environment, deployment, and the local env example back to the matrix so setup and deploy stay repeatable

## Validation
- `git diff --check`
- `bun --bun` matrix validation for unique entries and real source anchors
- `node` parse check for `docs/docs.json`

## Ticket
- Closes #16