### PR TITLE
feat(knowledge): add alice source registry

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -157,6 +157,7 @@
             "pages": [
               "operators/alice-operator-bootstrap",
               "operators/alice-config-and-env-matrix",
+              "operators/alice-knowledge-source-register",
               "operators/alice-high-risk-action-register",
               "operators/alice-operator-proof-2026-04-01",
               "operators/alice-system-boundary",

--- a/docs/guides/knowledge.md
+++ b/docs/guides/knowledge.md
@@ -6,6 +6,25 @@ description: Upload documents, URLs, and YouTube transcripts to build a searchab
 
 The knowledge system provides Retrieval Augmented Generation (RAG) for the Milady agent. You can upload documents, URLs, and YouTube videos to build a searchable knowledge base. When the agent responds to questions, it retrieves relevant fragments from this knowledge base to ground its answers in your specific content.
 
+For Alice-specific system grounding, the canonical governance layer is the
+[Alice Knowledge Source Register](/operators/alice-knowledge-source-register).
+That register defines which repo docs, action references, runbooks, and
+founder-note surfaces are eligible for ingestion, how they are versioned, and
+how often they must refresh.
+
+## Alice grounding rule
+
+Alice should answer system questions from registered current sources, not from
+stale memory:
+
+- system and API questions should prefer current repo docs and action references
+- operator and recovery questions should prefer runbooks
+- founder notes require corroboration before they are treated as shipped truth
+
+The register also assigns a `sourceVersion` and refresh rule to each source set
+so the agent can tell whether a knowledge answer is grounded in current docs or
+older planning material.
+
 ## Architecture Overview
 
 The knowledge system is built on three layers:

--- a/docs/operators/alice-knowledge-source-register.md
+++ b/docs/operators/alice-knowledge-source-register.md
@@ -1,0 +1,145 @@
+---
+title: "Alice Knowledge Source Register"
+sidebarTitle: "knowledge register"
+description: "Versioned source registry for Alice knowledge ingestion, with refresh rules and provenance requirements."
+---
+
+# Alice Knowledge Source Register
+
+Use this register to decide which repository content Alice may ingest for system
+questions, operator guidance, and founder-only context. The goal is to keep
+Alice grounded in current source-aware docs instead of stale memory.
+
+The typed source of truth lives in `src/runtime/alice-knowledge-source-register.ts`.
+
+## Core rule
+
+Alice should answer system questions from **current registered sources** with
+explicit provenance:
+
+- `source_id`
+- `source_path`
+- `source_version`
+- `refresh_rule`
+
+Founder notes can inform internal strategy, but they must not be treated as
+shipped product truth without corroboration from current repo docs or runbooks.
+
+## Source sets
+
+### 1. Alice system docs
+
+| Field | Value |
+| --- | --- |
+| Source type | repo docs |
+| Grounding policy | ground system answers |
+| Anchors | `docs/cli`, `docs/runtime`, `docs/configuration.mdx`, `docs/config-schema.mdx`, `docs/deployment.mdx`, `docs/guides/knowledge.md` |
+| Refresh trigger | on merge to `main` |
+| Refresh window | 1 day |
+| Owner | Docs + runtime owner |
+
+Use this set for:
+- setup and configuration questions
+- runtime and deployment questions
+- questions about the current documented Milady behavior
+
+Stale risk:
+- Alice can repeat outdated setup or deployment guidance after docs/runtime changes.
+
+### 2. Alice action and API references
+
+| Field | Value |
+| --- | --- |
+| Source type | action reference |
+| Grounding policy | ground system answers |
+| Anchors | `docs/rest`, `docs/plugin-registry`, `docs/plugins`, `docs/guides/custom-actions.mdx`, `docs/guides/hooks.mdx` |
+| Refresh trigger | on merge to `main` |
+| Refresh window | 1 day |
+| Owner | API + plugin surface owner |
+
+Use this set for:
+- endpoint and route behavior
+- plugin or action-reference questions
+- knowledge/API workflow questions
+
+Stale risk:
+- Alice can cite old endpoint or plugin behavior if reference docs lag behind runtime changes.
+
+### 3. Alice operator runbooks
+
+| Field | Value |
+| --- | --- |
+| Source type | runbook |
+| Grounding policy | ground operator recovery |
+| Anchors | `docs/operators`, `docs/stability`, `docs/solo-vs-swarm-replay-benchmark-runbook.md` |
+| Refresh trigger | before operator proof |
+| Refresh window | 7 days |
+| Owner | Operator docs owner |
+
+Use this set for:
+- recovery paths
+- proof and validation paths
+- operator-only questions about what to do next
+
+Stale risk:
+- operators can follow stale proof or recovery guidance even while the general docs look current.
+
+### 4. Alice founder notes and planning surfaces
+
+| Field | Value |
+| --- | --- |
+| Source type | founder note |
+| Grounding policy | founder corroboration required |
+| Anchors | `AGENTS.md`, `docs/plans`, `docs/superpowers/plans`, `docs/superpowers/specs`, `docs/fast-mode-implementation-dossier`, `docs/autonomous-loop-implementation`, `docs/triggers-system-implementation`, `docs/KNOWLEDGE_TAB_IMPLEMENTATION_PLAN.md` |
+| Refresh trigger | manual founder approval |
+| Refresh window | 30 days |
+| Owner | Founder / product lead |
+
+Use this set for:
+- product-direction context
+- implementation intent
+- planning dossiers and future-shape reasoning
+
+Stale risk:
+- planning assumptions can be mistaken for shipped behavior if they are ingested without corroboration.
+
+## Versioning model
+
+Every source set is versioned from the actual files under its anchors:
+
+- only text knowledge files are included
+- each snapshot records `fileCount`
+- each snapshot records `lastModifiedAt`
+- each snapshot derives a deterministic `sourceVersion` from file path, mtime, and size
+
+That means Alice can distinguish:
+
+- same source id, new version
+- same question scope, different freshness state
+- founder-note context versus shipped-doc context
+
+## Refresh policy by source type
+
+| Source type | When to refresh | Why |
+| --- | --- | --- |
+| Repo docs | every merge to `main` | prevents setup/runtime drift |
+| Action references | every merge to `main` | keeps endpoint and action behavior current |
+| Runbooks | before proof, recovery drill, or operator handoff | keeps operational guidance tied to current practice |
+| Founder notes | only with explicit founder review | avoids turning planning notes into accidental product truth |
+
+## Grounding policy
+
+When Alice answers:
+
+- product/system questions should prefer system docs and action references
+- operator recovery questions should prefer operator runbooks
+- founder notes should only supplement an answer after corroboration from current docs or runbooks
+
+If a source set is beyond its refresh window, it should be treated as stale and
+revalidated before it is trusted for grounding.
+
+## Related docs
+
+- `guides/knowledge`
+- `operators/alice-config-and-env-matrix`
+- `operators/alice-high-risk-action-register`

--- a/src/runtime/alice-knowledge-source-register.test.ts
+++ b/src/runtime/alice-knowledge-source-register.test.ts
@@ -1,0 +1,26 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  ALICE_KNOWLEDGE_SOURCE_REGISTER,
+  buildAliceKnowledgeSourceSnapshot,
+  validateAliceKnowledgeSourceRegister,
+} from "./alice-knowledge-source-register";
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(currentDir, "..", "..");
+
+describe("Alice knowledge source register", () => {
+  it("validates current anchors and refresh rules", () => {
+    expect(() => validateAliceKnowledgeSourceRegister(repoRoot)).not.toThrow();
+  });
+
+  it("builds versioned snapshots for each source set", () => {
+    for (const entry of ALICE_KNOWLEDGE_SOURCE_REGISTER) {
+      const snapshot = buildAliceKnowledgeSourceSnapshot(repoRoot, entry);
+      expect(snapshot.fileCount).toBeGreaterThan(0);
+      expect(snapshot.sourceVersion.startsWith(`${entry.id}:`)).toBe(true);
+      expect(snapshot.lastModifiedAt).not.toBeNull();
+    }
+  });
+});

--- a/src/runtime/alice-knowledge-source-register.ts
+++ b/src/runtime/alice-knowledge-source-register.ts
@@ -1,0 +1,308 @@
+import { createHash } from "node:crypto";
+import { readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+export type AliceKnowledgeSourceId =
+  | "alice-system-docs"
+  | "alice-action-references"
+  | "alice-operator-runbooks"
+  | "alice-founder-notes";
+
+export type AliceKnowledgeSourceType =
+  | "repo-docs"
+  | "action-reference"
+  | "runbook"
+  | "founder-note";
+
+export type AliceKnowledgeGroundingPolicy =
+  | "ground-system-answers"
+  | "ground-operator-recovery"
+  | "founder-corroboration-required";
+
+export type AliceKnowledgeRefreshTrigger =
+  | "on-merge-to-main"
+  | "before-release-or-demo"
+  | "before-operator-proof"
+  | "manual-founder-approval";
+
+export interface AliceKnowledgeRefreshRule {
+  trigger: AliceKnowledgeRefreshTrigger;
+  maxAgeDays: number;
+  owner: string;
+  staleRisk: string;
+}
+
+export interface AliceKnowledgeSourceEntry {
+  id: AliceKnowledgeSourceId;
+  label: string;
+  sourceType: AliceKnowledgeSourceType;
+  description: string;
+  groundingPolicy: AliceKnowledgeGroundingPolicy;
+  anchors: string[];
+  refreshRule: AliceKnowledgeRefreshRule;
+  intendedQuestions: string[];
+  provenanceFields: string[];
+}
+
+export interface AliceKnowledgeSourceSnapshot {
+  id: AliceKnowledgeSourceId;
+  fileCount: number;
+  sourceVersion: string;
+  lastModifiedAt: string | null;
+  files: string[];
+}
+
+const TEXT_KNOWLEDGE_EXTENSIONS = new Set([
+  ".md",
+  ".mdx",
+  ".txt",
+  ".json",
+  ".json5",
+  ".yaml",
+  ".yml",
+]);
+
+export const ALICE_KNOWLEDGE_SOURCE_REGISTER: AliceKnowledgeSourceEntry[] = [
+  {
+    id: "alice-system-docs",
+    label: "Alice system docs",
+    sourceType: "repo-docs",
+    description:
+      "Canonical system, configuration, runtime, deployment, and core guide docs that should answer product and system-behavior questions.",
+    groundingPolicy: "ground-system-answers",
+    anchors: [
+      "docs/cli",
+      "docs/runtime",
+      "docs/configuration.mdx",
+      "docs/config-schema.mdx",
+      "docs/deployment.mdx",
+      "docs/guides/knowledge.md",
+    ],
+    refreshRule: {
+      trigger: "on-merge-to-main",
+      maxAgeDays: 1,
+      owner: "Docs + runtime owner",
+      staleRisk:
+        "Alice can answer from old setup or deployment assumptions after a docs/runtime change.",
+    },
+    intendedQuestions: [
+      "How do I set up Alice?",
+      "How does runtime configuration work?",
+      "Which deployment path is current?",
+    ],
+    provenanceFields: ["source_id", "source_path", "source_version", "refresh_rule"],
+  },
+  {
+    id: "alice-action-references",
+    label: "Alice action and API references",
+    sourceType: "action-reference",
+    description:
+      "REST, API, plugin-registry, and action-reference docs used when Alice answers how an endpoint, tool, or action surface behaves.",
+    groundingPolicy: "ground-system-answers",
+    anchors: [
+      "docs/rest",
+      "docs/plugin-registry",
+      "docs/plugins",
+      "docs/guides/custom-actions.md",
+      "docs/guides/hooks.md",
+    ],
+    refreshRule: {
+      trigger: "on-merge-to-main",
+      maxAgeDays: 1,
+      owner: "API + plugin surface owner",
+      staleRisk:
+        "Alice can cite stale endpoint or action behavior if these references drift behind runtime changes.",
+    },
+    intendedQuestions: [
+      "What does this endpoint do?",
+      "How does the knowledge API behave?",
+      "Which plugin/action surface is canonical?",
+    ],
+    provenanceFields: ["source_id", "source_path", "source_version", "refresh_rule"],
+  },
+  {
+    id: "alice-operator-runbooks",
+    label: "Alice operator runbooks",
+    sourceType: "runbook",
+    description:
+      "Operator guidance, proof artifacts, and repeatable runbooks for setup, safety, evaluation, and recovery.",
+    groundingPolicy: "ground-operator-recovery",
+    anchors: [
+      "docs/operators",
+      "docs/stability",
+      "docs/solo-vs-swarm-replay-benchmark-runbook.md",
+    ],
+    refreshRule: {
+      trigger: "before-operator-proof",
+      maxAgeDays: 7,
+      owner: "Operator docs owner",
+      staleRisk:
+        "Operators can follow stale recovery or proof guidance even when product docs look current.",
+    },
+    intendedQuestions: [
+      "How should an operator validate Alice right now?",
+      "Which runbook is current for proof or recovery?",
+      "What evidence pack backs the current behavior?",
+    ],
+    provenanceFields: ["source_id", "source_path", "source_version", "refresh_rule"],
+  },
+  {
+    id: "alice-founder-notes",
+    label: "Alice founder notes and planning surfaces",
+    sourceType: "founder-note",
+    description:
+      "High-context planning, implementation dossiers, and founder-level notes that can inform strategy but should not become user-facing facts without corroboration.",
+    groundingPolicy: "founder-corroboration-required",
+    anchors: [
+      "AGENTS.md",
+      "docs/plans",
+      "docs/superpowers/plans",
+      "docs/superpowers/specs",
+      "docs/fast-mode-implementation-dossier",
+      "docs/autonomous-loop-implementation",
+      "docs/triggers-system-implementation",
+      "docs/KNOWLEDGE_TAB_IMPLEMENTATION_PLAN.md",
+    ],
+    refreshRule: {
+      trigger: "manual-founder-approval",
+      maxAgeDays: 30,
+      owner: "Founder / product lead",
+      staleRisk:
+        "Planning assumptions can be mistaken for shipped behavior if they are ingested without corroboration.",
+    },
+    intendedQuestions: [
+      "What is the intended direction for Alice?",
+      "Which planning dossier explains this subsystem?",
+      "What founder context should be corroborated before answering publicly?",
+    ],
+    provenanceFields: ["source_id", "source_path", "source_version", "refresh_rule"],
+  },
+] as const;
+
+function isTextKnowledgeFile(filePath: string): boolean {
+  return TEXT_KNOWLEDGE_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+function collectKnowledgeFilesFromAnchor(rootDir: string, anchor: string): string[] {
+  const resolved = path.resolve(rootDir, anchor);
+  const stats = statSync(resolved);
+
+  if (stats.isFile()) {
+    return isTextKnowledgeFile(resolved) ? [anchor] : [];
+  }
+
+  const files: string[] = [];
+  const entries = readdirSync(resolved, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.name.startsWith(".")) {
+      continue;
+    }
+
+    const nextRelative = path.posix.join(anchor.replaceAll(path.sep, "/"), entry.name);
+    const nextResolved = path.resolve(rootDir, nextRelative);
+
+    if (entry.isDirectory()) {
+      files.push(...collectKnowledgeFilesFromAnchor(rootDir, nextRelative));
+      continue;
+    }
+
+    if (entry.isFile() && isTextKnowledgeFile(nextResolved)) {
+      files.push(nextRelative);
+    }
+  }
+
+  return files;
+}
+
+export function listAliceKnowledgeSourceFiles(
+  rootDir: string,
+  entry: AliceKnowledgeSourceEntry,
+): string[] {
+  const files = new Set<string>();
+
+  for (const anchor of entry.anchors) {
+    for (const file of collectKnowledgeFilesFromAnchor(rootDir, anchor)) {
+      files.add(file);
+    }
+  }
+
+  return Array.from(files).sort();
+}
+
+export function buildAliceKnowledgeSourceSnapshot(
+  rootDir: string,
+  entry: AliceKnowledgeSourceEntry,
+): AliceKnowledgeSourceSnapshot {
+  const files = listAliceKnowledgeSourceFiles(rootDir, entry);
+  const hash = createHash("sha1");
+  let latestMtimeMs = 0;
+
+  for (const relativeFile of files) {
+    const resolved = path.resolve(rootDir, relativeFile);
+    const stats = statSync(resolved);
+    const normalized = relativeFile.replaceAll(path.sep, "/");
+    hash.update(`${normalized}:${Math.trunc(stats.mtimeMs)}:${stats.size}\n`);
+    if (stats.mtimeMs > latestMtimeMs) {
+      latestMtimeMs = stats.mtimeMs;
+    }
+  }
+
+  return {
+    id: entry.id,
+    fileCount: files.length,
+    sourceVersion: files.length
+      ? `${entry.id}:${hash.digest("hex").slice(0, 12)}`
+      : `${entry.id}:empty`,
+    lastModifiedAt: latestMtimeMs ? new Date(latestMtimeMs).toISOString() : null,
+    files,
+  };
+}
+
+export function validateAliceKnowledgeSourceRegister(rootDir: string): void {
+  const ids = new Set<string>();
+
+  for (const entry of ALICE_KNOWLEDGE_SOURCE_REGISTER) {
+    if (ids.has(entry.id)) {
+      throw new Error(`Duplicate Alice knowledge source id: ${entry.id}`);
+    }
+    ids.add(entry.id);
+
+    if (!entry.label.trim()) {
+      throw new Error(`Missing label for knowledge source: ${entry.id}`);
+    }
+    if (!entry.description.trim()) {
+      throw new Error(`Missing description for knowledge source: ${entry.id}`);
+    }
+    if (entry.anchors.length === 0) {
+      throw new Error(`Missing anchors for knowledge source: ${entry.id}`);
+    }
+    if (entry.intendedQuestions.length === 0) {
+      throw new Error(`Missing intended questions for knowledge source: ${entry.id}`);
+    }
+    if (entry.provenanceFields.length === 0) {
+      throw new Error(`Missing provenance fields for knowledge source: ${entry.id}`);
+    }
+    if (entry.refreshRule.maxAgeDays <= 0) {
+      throw new Error(`Invalid refresh window for knowledge source: ${entry.id}`);
+    }
+
+    for (const anchor of entry.anchors) {
+      const resolved = path.resolve(rootDir, anchor);
+      try {
+        statSync(resolved);
+      } catch {
+        throw new Error(
+          `Knowledge source ${entry.id} references missing anchor: ${anchor}`,
+        );
+      }
+    }
+
+    const snapshot = buildAliceKnowledgeSourceSnapshot(rootDir, entry);
+    if (snapshot.fileCount === 0) {
+      throw new Error(
+        `Knowledge source ${entry.id} does not currently resolve any text sources`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a typed Alice knowledge source register under `src/runtime`
- version each knowledge source set from real repo files with explicit provenance and refresh rules
- publish the operator-facing register and wire the knowledge guide back to the new grounding policy

## Validation
- `git diff --check`
- `bun --bun` register validation and snapshot generation
- `node` parse check for `docs/docs.json`

## Ticket
- Closes #17