### PR TITLE
fix(agent-server): wire handleAliceOperatorRoutes into HTTP dispatcher

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -143,6 +143,7 @@ import { handleAgentLifecycleRoutes } from "./agent-lifecycle-routes.js";
 import { detectRuntimeModel, resolveProviderFromModel } from "./agent-model.js";
 import { handleAgentStatusRoutes } from "./agent-status-routes.js";
 import { handleAgentTransferRoutes } from "./agent-transfer-routes.js";
+import { handleAliceOperatorRoutes } from "./alice-operator-routes.js";
 import { handleAppPackageRoutes } from "./app-package-routes.js";
 import { handleAppsRoutes } from "./apps-routes.js";
 import { handleAuthRoutes } from "./auth-routes.js";
@@ -5924,6 +5925,26 @@ async function handleRequest(
       pathname,
       json,
       error,
+    })
+  ) {
+    return;
+  }
+
+  // ── Alice operator routes (extracted to alice-operator-routes.ts) ───
+  // Drives POST /api/alice/operator/execute — the action bridge used by
+  // CompanionGoLiveModal and useCompanionStageOperator.executePlan to
+  // dispatch STREAM555_GO_LIVE and related operator actions through the
+  // agent runtime. Without this wiring the client 404s on go-live.
+  if (
+    await handleAliceOperatorRoutes({
+      req,
+      res,
+      method,
+      pathname,
+      json,
+      error,
+      readJsonBody,
+      runtime: state.runtime,
     })
   ) {
     return;


### PR DESCRIPTION
## Summary

The alice operator routes handler at `packages/agent/src/api/alice-operator-routes.ts` is fully defined and unit-tested but **never imported or invoked** from `packages/agent/src/api/server.ts`. The agent runtime's HTTP server therefore 404s on `POST /api/alice/operator/execute`.

This PR adds the one-line import and ~20-line dispatcher call, mirroring the pattern used by `handleAvatarRoutes` and the other extracted route handlers.

## Why this is a blocker for Go Live

`/api/alice/operator/execute` is the endpoint that `CompanionGoLiveModal` and `useCompanionStageOperator.executePlan` hit to dispatch `STREAM555_GO_LIVE` and related operator actions through the plugin action path — the path that runs `applyConfiguredDestinations` (legacyCompat.ts:725) before `POST /stream/start`.

Without this wiring:
- Clicking Go Live in the UI returns a 404 from alice-bot
- Any API-level smoke that drives the real plugin action path 404s
- Alice can still go live via direct `POST /api/agent/v1/sessions/:id/stream/start` on the CP, but that **bypasses the plugin's destination sync entirely** — CP starts with 0 enabled platforms → 400 `No platforms enabled` unless platforms are PUT manually

## Verification (pre-fix)
From inside alice-bot pod `alice-bot-86bc9497dc-qtdpm`:
```
curl -s -o /dev/null -w "%{http_code}" -X POST \
  -H "Content-Type: application/json" \
  -H "x-eliza-token: \$ELIZA_SERVER_AUTH_TOKEN" \
  -d '{"steps":[]}' \
  http://127.0.0.1:3000/api/alice/operator/execute
# → 404
```

## Fix

Two surgical edits to `packages/agent/src/api/server.ts`:

1. **Import** (alphabetical position near other route handler imports):
   ```ts
   import { handleAliceOperatorRoutes } from "./alice-operator-routes.js";
   ```

2. **Dispatcher call** (right after `handleAvatarRoutes`, before the config routes block):
   ```ts
   if (
     await handleAliceOperatorRoutes({
       req, res, method, pathname, json, error, readJsonBody,
       runtime: state.runtime,
     })
   ) {
     return;
   }
   ```

After this change, `handleAliceOperatorRoutes` validates the request is POST on the exact pathname, parses the JSON body (`steps`, `stopOnFailure`), filters each action against `ALICE_OPERATOR_ALLOWED_ACTIONS` (21 allow-listed operator actions including `STREAM555_GO_LIVE`), and invokes each through the agent runtime action-execute path with a synthetic room. Results come back as a normalized array.

## Post-merge verification plan

After the webhook deployer rolls alice-bot:
```
curl -sfS -X POST -H "Content-Type: application/json" \
  -H "x-eliza-token: \$ELIZA_SERVER_AUTH_TOKEN" \
  -d '{"steps":[{"id":"test","action":"STREAM555_GO_LIVE","params":{"inputType":"avatar","avatarIdentity":"alice","layoutMode":"camera-full","destinationPlatforms":"twitch,kick","applyDestinations":true}}]}' \
  http://127.0.0.1:3000/api/alice/operator/execute
```
Expect 200 with a result array containing `{success: true}` for the `STREAM555_GO_LIVE` step, followed by observable live streams on Twitch and Kick.

## Background
This is the final wiring the operator bridge was missing. It should have landed alongside `alice-operator-routes.ts` in the original operator bridge commit but was overlooked. Discovered during the alice × 555stream E2E soak (plan at `/Users/mac/.claude/plans/jazzy-snacking-church.md`).