### PR TITLE
fix(alice-operator): pass action params in both flat and nested shapes

### DIFF
--- a/packages/agent/src/api/alice-operator-routes.ts
+++ b/packages/agent/src/api/alice-operator-routes.ts
@@ -209,13 +209,23 @@ async function executeOperatorStep(
     };
   }
 
+  // Pass options in BOTH shapes so action handlers that read flat
+  // `options[key]` (e.g., plugin-555stream/legacyCompat.ts:713 reading
+  // `options.inputType` directly) AND handlers that read
+  // `options.parameters[key]` (e.g., bsc-trade.ts reading
+  // `options.parameters?.toAddress`) both resolve correctly. Without
+  // this dual shape, STREAM555_GO_LIVE sees `options.inputType ===
+  // undefined` and falls back to 'screen', which skips the capture job
+  // submission path in control-plane (screen is not in the
+  // avatar/capture/composition list).
+  const paramsRecord = step.params ?? {};
   let callbackPayload: Content | Record<string, unknown> | undefined;
   const rawResult = await Promise.resolve(
     action.handler(
       runtime,
       message,
       state,
-      { parameters: step.params ?? {} },
+      { ...paramsRecord, parameters: paramsRecord },
       async (content: unknown) => {
         if (content && typeof content === "object") {
           callbackPayload = content as Content;


### PR DESCRIPTION
## Summary
Fixes the final missing wire for go-live: the alice operator bridge was passing action params in `{parameters: ...}` shape, which works for some actions (e.g., bsc-trade reads `options.parameters?.toAddress`) but breaks actions that read flat `options[key]` — notably the entire `plugin-555stream/legacyCompat.ts` surface including `STREAM555_GO_LIVE`.

**Symptom**: Phase D smoke test via `POST /api/alice/operator/execute` with `STREAM555_GO_LIVE` and params including `inputType: "avatar"` was executing the action, successfully syncing destinations, creating the Cloudflare Live Input, and provisioning simulcast outputs for Twitch + Kick — but then timing out after 45s with `stream start did not reach Cloudflare connected state`.

**Root cause**: inside the plugin handler, `optionString(options, 'inputType')` returned `undefined` because the real value lived at `options.parameters.inputType`, not `options.inputType`. That fell back to the default `'screen'` (`legacyCompat.ts:713`). `screen` is a valid input type at CP validation time but is NOT in the capture-job submission list at `stream.js:1088`:

```js
if (['capture', 'website', 'composition', 'lofi', 'radio', 'rtmp', 'file', 'avatar'].includes(input.type)) {
  // submit capture job
}
```

So no capture job was submitted, no Puppeteer worker rendered the VRM scene, no FFmpeg pushed to the CF Live Input, and the session stalled at `publisher: none` until the 45s timeout.

## Fix
Pass options as `{...params, parameters: params}` so both conventions work simultaneously:
- Actions reading flat `options[key]` (plugin-555stream, most legacy actions) resolve correctly
- Actions reading `options.parameters[key]` (bsc-trade and other newer actions) continue to resolve correctly

One-file, ~11 line addition with a comment explaining the rationale so future contributors don't revert it.

## Verified end-to-end state (pre-fix)
From the Phase D smoke test response:
- `destinationSync.attempted: 7, applied: 5, failed: 0`
  - Twitch: `enabled: true, configured: true`
  - Kick: `enabled: true, configured: true`
  - X/YouTube/PumpFun: `enabled: false, configured: true` (provisioned but disabled for initial soak)
- `cfSessionId: "6b73bbb0cc04be9561c53c09cbf59e7d"` ← CF Live Input created
- Simulcast outputs provisioned: `twitch.cfOutputId: c22d8c8c…`, `kick.cfOutputId: 3c817740…`
- `phase: "starting"`, `publisher: "none"` ← stalled waiting for capture worker
- `statusReason: "publisher did not attach"` ← no capture job was submitted

After this fix lands and the operator bridge passes `inputType: "avatar"` through, the CP will enter the avatar capture path, `submitJob` will queue a capture-service worker, the worker will load `http://control-plane:3000/agent-show/?sessionId=…&headless=true`, render Alice's VRM on `pro-streamer-stage.glb`, and FFmpeg the output to the Cloudflare Live Input → Twitch + Kick via simulcast.

## Follow-up
After this PR merges, one last thing to verify: that the plugin's `STREAM555_GO_LIVE` handler successfully completes the `waitForStreamReadiness` gate (polls until `cloudflare.isConnected: true`) before timing out. If the capture worker takes > 45s to connect (the current `DEFAULT_CF_CONNECT_TIMEOUT_MS`), the smoke would still fail — but with a different message (would show `publisher: capture` or similar instead of `publisher: none`). That would be a separate, easier-to-diagnose fix.