### PR TITLE
fix(deps): bump three to ^0.183.2 to fix headless Chromium GPUShaderStage crash

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -45,10 +45,10 @@
     "@miladyai/capacitor-talkmode": "workspace:*",
     "@miladyai/capacitor-websiteblocker": "workspace:*",
     "@miladyai/ui": "workspace:*",
-    "@pixiv/three-vrm": "^3.4.5",
+    "@pixiv/three-vrm": "^3.5.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "three": "^0.182.0",
+    "three": "^0.183.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -57,7 +57,7 @@
     "@tailwindcss/vite": "^4.1.18",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@types/three": "^0.182.0",
+    "@types/three": "^0.183.1",
     "@vitejs/plugin-react-swc": "^4.2.1",
     "jsdom": "^28.1.0",
     "react-test-renderer": "^19.2.4",

--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,7 @@
         "@noble/curves": "^2.0.1",
         "@opinion-labs/opinion-clob-sdk": "0.5.2",
         "@pixiv/three-vrm": "^3.5.1",
+        "@rndrntwrk/plugin-555stream": "workspace:*",
         "@stwd/eliza-plugin": "0.2.0",
         "@stwd/sdk": "^0.3.0",
         "@whiskeysockets/baileys": "7.0.0-rc.9",
@@ -132,10 +133,10 @@
         "@miladyai/capacitor-websiteblocker": "workspace:*",
         "@miladyai/shared": "workspace:*",
         "@miladyai/ui": "workspace:*",
-        "@pixiv/three-vrm": "^3.4.5",
+        "@pixiv/three-vrm": "^3.5.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "three": "^0.182.0",
+        "three": "^0.183.2",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -144,7 +145,7 @@
         "@tailwindcss/vite": "^4.1.18",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "@types/three": "^0.182.0",
+        "@types/three": "^0.183.1",
         "@vitejs/plugin-react-swc": "^4.2.1",
         "jsdom": "^28.1.0",
         "react-test-renderer": "^19.2.4",
@@ -413,7 +414,7 @@
     },
     "eliza/packages/daemon": {
       "name": "@elizaos/daemon",
-      "version": "2.0.0-alpha.124",
+      "version": "2.0.0-alpha.127",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@types/node": "^22.10.2",
@@ -427,7 +428,7 @@
     },
     "eliza/packages/elizaos": {
       "name": "elizaos",
-      "version": "2.0.0-alpha.124",
+      "version": "2.0.0-alpha.127",
       "bin": {
         "elizaos": "./dist/cli.js",
       },
@@ -444,7 +445,7 @@
     },
     "eliza/packages/interop": {
       "name": "@elizaos/interop",
-      "version": "2.0.0-alpha.124",
+      "version": "2.0.0-alpha.127",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -459,18 +460,18 @@
     },
     "eliza/packages/rust": {
       "name": "@elizaos/rust",
-      "version": "2.0.0-alpha.124",
+      "version": "2.0.0-alpha.127",
     },
     "eliza/packages/schemas": {
       "name": "@elizaos/schemas",
-      "version": "2.0.0-alpha.124",
+      "version": "2.0.0-alpha.127",
       "devDependencies": {
         "@bufbuild/buf": "^1.47.2",
       },
     },
     "eliza/packages/typescript": {
       "name": "@elizaos/core",
-      "version": "2.0.0-alpha.124",
+      "version": "2.0.0-alpha.127",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.13",
         "@ai-sdk/google": "^3.0.8",
@@ -535,6 +536,7 @@
         "@elizaos/plugin-elizacloud": "workspace:*",
         "@elizaos/plugin-experience": "workspace:*",
         "@elizaos/plugin-form": "workspace:*",
+        "@elizaos/plugin-knowledge": "workspace:*",
         "@elizaos/plugin-local-embedding": "workspace:*",
         "@elizaos/plugin-ollama": "workspace:*",
         "@elizaos/plugin-openai": "workspace:*",
@@ -542,11 +544,14 @@
         "@elizaos/plugin-personality": "workspace:*",
         "@elizaos/plugin-pi-ai": "workspace:*",
         "@elizaos/plugin-plugin-manager": "workspace:*",
+        "@elizaos/plugin-rolodex": "workspace:*",
         "@elizaos/plugin-scratchpad": "workspace:*",
         "@elizaos/plugin-secrets-manager": "workspace:*",
         "@elizaos/plugin-shell": "workspace:*",
         "@elizaos/plugin-solana": "1.2.6",
         "@elizaos/plugin-sql": "workspace:*",
+        "@elizaos/plugin-todo": "workspace:*",
+        "@elizaos/plugin-trajectory-logger": "workspace:*",
         "@elizaos/plugin-trust": "workspace:*",
         "@hapi/boom": "^10.0.1",
         "@mariozechner/pi-ai": "0.52.12",
@@ -555,6 +560,7 @@
         "@miladyai/plugin-wechat": "github:milady-ai/plugin-wechat",
         "@miladyai/shared": "workspace:*",
         "@noble/curves": "^2.0.1",
+        "@rndrntwrk/plugin-555stream": "workspace:*",
         "@whiskeysockets/baileys": "7.0.0-rc.9",
         "coding-agent-adapters": "0.16.3",
         "dotenv": "^17.2.3",
@@ -610,7 +616,7 @@
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
         "lucide-react": "^0.575.0",
-        "three": "^0.182.0",
+        "three": "^0.183.2",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -620,17 +626,34 @@
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "@types/three": "^0.182.0",
+        "@types/three": "^0.183.1",
         "react-test-renderer": "^19.2.4",
         "tailwindcss": "^4.1.18",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18",
       },
       "peerDependencies": {
-        "@pixiv/three-vrm": "^3.4.5",
+        "@pixiv/three-vrm": "^3.5.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "three": "^0.182.0",
+        "three": "^0.183.2",
+      },
+    },
+    "packages/plugin-555stream": {
+      "name": "@rndrntwrk/plugin-555stream",
+      "version": "0.1.0-beta.1",
+      "dependencies": {
+        "ethers": "^6.15.0",
+        "ws": "^8.18.0",
+      },
+      "devDependencies": {
+        "@elizaos/core": "^1.7.0",
+        "@types/node": "^20.0.0",
+        "@types/ws": "^8.5.0",
+        "typescript": "^5.0.0",
+      },
+      "peerDependencies": {
+        "@elizaos/core": "^1.7.0",
       },
     },
     "packages/plugin-music-library": {
@@ -1298,6 +1321,10 @@
         "vitest": "^2.0.0",
       },
     },
+    "plugins/plugin-knowledge": {
+      "name": "@elizaos/plugin-knowledge",
+      "version": "0.0.0-stub",
+    },
     "plugins/plugin-lifeops-browser": {
       "name": "@miladyai/plugin-lifeops-browser",
       "version": "0.0.0",
@@ -1464,7 +1491,7 @@
         "typescript": "^5.9.3",
       },
       "peerDependencies": {
-        "@elizaos/core": "2.0.0-alpha.114",
+        "@elizaos/core": "workspace:*",
       },
     },
     "plugins/plugin-pdf/typescript": {
@@ -1549,6 +1576,10 @@
         "typescript": "5.8.2",
         "vitest": "3.1.4",
       },
+    },
+    "plugins/plugin-rolodex": {
+      "name": "@elizaos/plugin-rolodex",
+      "version": "0.0.0-stub",
     },
     "plugins/plugin-scratchpad": {
       "name": "@elizaos/plugin-scratchpad-root",
@@ -1754,6 +1785,14 @@
         "tsup": "8.4.0",
         "vitest": "1.6.1",
       },
+    },
+    "plugins/plugin-todo": {
+      "name": "@elizaos/plugin-todo",
+      "version": "0.0.0-stub",
+    },
+    "plugins/plugin-trajectory-logger": {
+      "name": "@elizaos/plugin-trajectory-logger",
+      "version": "0.0.0-stub",
     },
     "plugins/plugin-trust": {
       "name": "@elizaos/plugin-trust-root",
@@ -2200,6 +2239,8 @@
 
     "@elizaos/plugin-imessage-root": ["@elizaos/plugin-imessage-root@workspace:plugins/plugin-imessage"],
 
+    "@elizaos/plugin-knowledge": ["@elizaos/plugin-knowledge@workspace:plugins/plugin-knowledge"],
+
     "@elizaos/plugin-local-embedding": ["@elizaos/plugin-local-embedding@workspace:plugins/plugin-local-embedding/typescript"],
 
     "@elizaos/plugin-local-embedding-root": ["@elizaos/plugin-local-embedding-root@workspace:plugins/plugin-local-embedding"],
@@ -2234,6 +2275,8 @@
 
     "@elizaos/plugin-plugin-manager-root": ["@elizaos/plugin-plugin-manager-root@workspace:plugins/plugin-plugin-manager"],
 
+    "@elizaos/plugin-rolodex": ["@elizaos/plugin-rolodex@workspace:plugins/plugin-rolodex"],
+
     "@elizaos/plugin-scratchpad": ["@elizaos/plugin-scratchpad@workspace:plugins/plugin-scratchpad/typescript"],
 
     "@elizaos/plugin-scratchpad-root": ["@elizaos/plugin-scratchpad-root@workspace:plugins/plugin-scratchpad"],
@@ -2259,6 +2302,10 @@
     "@elizaos/plugin-sql-root": ["@elizaos/plugin-sql-root@workspace:plugins/plugin-sql"],
 
     "@elizaos/plugin-telegram": ["@elizaos/plugin-telegram@workspace:plugins/plugin-telegram"],
+
+    "@elizaos/plugin-todo": ["@elizaos/plugin-todo@workspace:plugins/plugin-todo"],
+
+    "@elizaos/plugin-trajectory-logger": ["@elizaos/plugin-trajectory-logger@workspace:plugins/plugin-trajectory-logger"],
 
     "@elizaos/plugin-trust": ["@elizaos/plugin-trust@workspace:plugins/plugin-trust/typescript"],
 
@@ -2586,7 +2633,7 @@
 
     "@miladyai/plugin-selfcontrol": ["@miladyai/plugin-selfcontrol@workspace:packages/plugin-selfcontrol"],
 
-    "@miladyai/plugin-wechat": ["@miladyai/plugin-wechat@github:milady-ai/plugin-wechat#d73ade8", { "peerDependencies": { "@elizaos/core": "alpha" } }, "milady-ai-plugin-wechat-d73ade8", "sha512-ibuaYzgoN7H6JxY+B9xXCYY2fGmCOk3vchjtVvcTiXwtbst4c4XlzYxq3dLXqCIUBePbb7xGmwFsaEVVpNc55g=="],
+    "@miladyai/plugin-wechat": ["@elizaos/plugin-wechat@github:milady-ai/plugin-wechat#9633f91", { "peerDependencies": { "@elizaos/core": "workspace:*" } }, "milady-ai-plugin-wechat-9633f91", "sha512-GNtV1sCErgsm6f0K9ITX1WFR+Giq+Qys+cJ2q0vJPDkFn3mibwpC0BJa7GwsFoN7Jsj8xnLN5relyF5fMOdMBg=="],
 
     "@miladyai/shared": ["@miladyai/shared@workspace:packages/shared"],
 
@@ -2879,6 +2926,8 @@
     "@reflink/reflink-win32-arm64-msvc": ["@reflink/reflink-win32-arm64-msvc@0.1.19", "", { "os": "win32", "cpu": "arm64" }, "sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ=="],
 
     "@reflink/reflink-win32-x64-msvc": ["@reflink/reflink-win32-x64-msvc@0.1.19", "", { "os": "win32", "cpu": "x64" }, "sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w=="],
+
+    "@rndrntwrk/plugin-555stream": ["@rndrntwrk/plugin-555stream@workspace:packages/plugin-555stream"],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.3", "", { "os": "android", "cpu": "arm64" }, "sha512-0T1k9FinuBZ/t7rZ8jN6OpUKPnUjNdYHoj/cESWrQ3ZraAJ4OMm6z7QjSfCxqj8mOp9kTKc1zHK3kGz5vMu+nQ=="],
 
@@ -3434,7 +3483,7 @@
 
     "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
 
-    "@types/three": ["@types/three@0.182.0", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~0.22.0" } }, "sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q=="],
+    "@types/three": ["@types/three@0.183.1", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~1.0.1" } }, "sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
@@ -4784,7 +4833,7 @@
 
     "mermaid": ["mermaid@11.14.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.1.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.1", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.19", "dompurify": "^3.3.1", "katex": "^0.16.25", "khroma": "^2.1.0", "lodash-es": "^4.17.23", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0" } }, "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g=="],
 
-    "meshoptimizer": ["meshoptimizer@0.22.0", "", {}, "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg=="],
+    "meshoptimizer": ["meshoptimizer@1.0.1", "", {}, "sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
@@ -5546,7 +5595,7 @@
 
     "thread-stream": ["thread-stream@4.0.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA=="],
 
-    "three": ["three@0.182.0", "", {}, "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ=="],
+    "three": ["three@0.183.2", "", {}, "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ=="],
 
     "through2": ["through2@4.0.2", "", { "dependencies": { "readable-stream": "3" } }, "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw=="],
 
@@ -5976,6 +6025,10 @@
 
     "@elizaos-plugins/client-telegram-account/vitest": ["vitest@1.6.1", "", { "dependencies": { "@vitest/expect": "1.6.1", "@vitest/runner": "1.6.1", "@vitest/snapshot": "1.6.1", "@vitest/spy": "1.6.1", "@vitest/utils": "1.6.1", "acorn-walk": "^8.3.2", "chai": "^4.3.10", "debug": "^4.3.4", "execa": "^8.0.1", "local-pkg": "^0.5.0", "magic-string": "^0.30.5", "pathe": "^1.1.1", "picocolors": "^1.0.0", "std-env": "^3.5.0", "strip-literal": "^2.0.0", "tinybench": "^2.5.1", "tinypool": "^0.8.3", "vite": "^5.0.0", "vite-node": "1.6.1", "why-is-node-running": "^2.2.2" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "1.6.1", "@vitest/ui": "1.6.1", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag=="],
 
+    "@elizaos/app-babylon/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
+
+    "@elizaos/app-defense-of-the-agents/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
+
     "@elizaos/app-scape/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
 
     "@elizaos/daemon/@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
@@ -5984,6 +6037,8 @@
 
     "@elizaos/daemon/vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
 
+    "@elizaos/interop/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
+
     "@elizaos/plugin-agent-orchestrator/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
 
     "@elizaos/plugin-agent-skills/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.30.1", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-nuKvp7wOIz6BFei8WrTdhmSsx5mwnArYyJgh4+vYu3V4J0Ltb8Xm3odPm51n1aSI0XxNCrDl7O88cxCtUdAkaw=="],
@@ -5991,6 +6046,8 @@
     "@elizaos/plugin-agent-skills/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
 
     "@elizaos/plugin-agent-skills/vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
+
+    "@elizaos/plugin-agent-skills-root/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
 
     "@elizaos/plugin-anthropic/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
 
@@ -6028,15 +6085,29 @@
 
     "@elizaos/plugin-discord/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
 
+    "@elizaos/plugin-discord-root/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
+
+    "@elizaos/plugin-edge-tts/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
+
     "@elizaos/plugin-edge-tts/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
+    "@elizaos/plugin-edge-tts-root/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
 
     "@elizaos/plugin-elizacloud/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
 
+    "@elizaos/plugin-evm/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
+
+    "@elizaos/plugin-evm-root/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
+
     "@elizaos/plugin-experience/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
+
+    "@elizaos/plugin-experience-root/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
 
     "@elizaos/plugin-form/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "@elizaos/plugin-google-genai/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
+
+    "@elizaos/plugin-groq/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
 
     "@elizaos/plugin-imessage/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
 
@@ -6118,6 +6189,10 @@
 
     "@elizaos/plugin-secrets-manager/vitest": ["vitest@3.1.4", "", { "dependencies": { "@vitest/expect": "3.1.4", "@vitest/mocker": "3.1.4", "@vitest/pretty-format": "^3.1.4", "@vitest/runner": "3.1.4", "@vitest/snapshot": "3.1.4", "@vitest/spy": "3.1.4", "@vitest/utils": "3.1.4", "chai": "^5.2.0", "debug": "^4.4.0", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.13", "tinypool": "^1.0.2", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0", "vite-node": "3.1.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.1.4", "@vitest/ui": "3.1.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ=="],
 
+    "@elizaos/plugin-secrets-manager-root/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
+
+    "@elizaos/plugin-secrets-manager-root/@elizaos/plugin-anthropic": ["@elizaos/plugin-anthropic@2.0.0-alpha.13", "", { "dependencies": { "@ai-sdk/anthropic": "^3.0.9", "ai": "^6.0.23", "jsonrepair": "^3.12.0", "undici": "^7.16.0" }, "peerDependencies": { "@elizaos/core": "2.0.0-alpha.115" } }, "sha512-u8+za9qUizKJ8iysiZ8GDlcxqhOXtWAvtLHOwv4DUoxjVqKNqXRjdAQSkU2ZvLJjCeDhLLdQJf0DbcGaUKiTOw=="],
+
     "@elizaos/plugin-secrets-manager-root/@vitest/coverage-v8": ["@vitest/coverage-v8@3.2.4", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@bcoe/v8-coverage": "^1.0.2", "ast-v8-to-istanbul": "^0.3.3", "debug": "^4.4.1", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-lib-source-maps": "^5.0.6", "istanbul-reports": "^3.1.7", "magic-string": "^0.30.17", "magicast": "^0.3.5", "std-env": "^3.9.0", "test-exclude": "^7.0.1", "tinyrainbow": "^2.0.0" }, "peerDependencies": { "@vitest/browser": "3.2.4", "vitest": "3.2.4" }, "optionalPeers": ["@vitest/browser"] }, "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ=="],
 
     "@elizaos/plugin-secrets-manager-root/dotenv": ["dotenv@16.4.5", "", {}, "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="],
@@ -6137,6 +6212,8 @@
     "@elizaos/plugin-solana/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
 
     "@elizaos/plugin-sql/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
+
+    "@elizaos/plugin-telegram/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
 
     "@elizaos/plugin-telegram/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
@@ -6246,17 +6323,15 @@
 
     "@miladyai/capacitor-gateway/prettier": ["prettier@3.8.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q=="],
 
-    "@miladyai/homepage/@types/three": ["@types/three@0.183.1", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~1.0.1" } }, "sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw=="],
-
     "@miladyai/homepage/jsdom": ["jsdom@29.0.2", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.5", "@asamuzakjp/dom-selector": "^7.0.6", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.1", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.24.5", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w=="],
-
-    "@miladyai/homepage/three": ["three@0.183.2", "", {}, "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ=="],
 
     "@miladyai/homepage/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
     "@miladyai/plugin-2004scape/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
 
     "@miladyai/plugin-lifeops-browser/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
+
+    "@miladyai/plugin-milady-browser/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
 
     "@miladyai/plugin-selfcontrol/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
 
@@ -6295,6 +6370,10 @@
     "@radix-ui/react-separator/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@rndrntwrk/plugin-555stream/@elizaos/core": ["@elizaos/core@2.0.0-alpha.115", "", { "dependencies": { "@anthropic-ai/sdk": "^0.32.1", "@bufbuild/protobuf": "^2.11.0", "@langchain/core": "^1.1.12", "@langchain/textsplitters": "^1.0.1", "@noble/ciphers": "^1.3.0", "@noble/hashes": "^1.8.0", "@toon-format/toon": "^2.1.0", "adze": "^2.2.5", "dedent": "^1.7.1", "dotenv": "^17.2.3", "drizzle-orm": "^0.45.1", "fast-redact": "^3.5.0", "file-type": "^21.3.0", "glob": "^13.0.0", "handlebars": "^4.7.8", "json5": "^2.2.3", "markdown-it": "^14.1.0", "pdfjs-dist": "^5.4.530", "undici": "^7.0.0", "unique-names-generator": "^4.7.1", "uuid": "^13.0.0", "yaml": "^2.7.0", "zod": "^4.3.6" } }, "sha512-NiPnUxH9iN2Uu80LaYozKYNZFYpFoW9DHZ4XCnNuQVjh9I47/aEcTz5fHBJTpr9Qao93g2/TdsEPLYlzGRgIXg=="],
+
+    "@rndrntwrk/plugin-555stream/@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
@@ -7238,6 +7317,8 @@
 
     "@elizaos/plugin-plugin-manager/vitest/vite-node": ["vite-node@3.1.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.0", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA=="],
 
+    "@elizaos/plugin-secrets-manager-root/@elizaos/core/dotenv": ["dotenv@17.4.1", "", {}, "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw=="],
+
     "@elizaos/plugin-secrets-manager-root/@vitest/coverage-v8/ast-v8-to-istanbul": ["ast-v8-to-istanbul@0.3.12", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g=="],
 
     "@elizaos/plugin-secrets-manager-root/@vitest/coverage-v8/istanbul-lib-source-maps": ["istanbul-lib-source-maps@5.0.6", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.23", "debug": "^4.1.1", "istanbul-lib-coverage": "^3.0.0" } }, "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A=="],
@@ -7494,8 +7575,6 @@
 
     "@miladyai/capacitor-gateway/eslint/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "@miladyai/homepage/@types/three/meshoptimizer": ["meshoptimizer@1.0.1", "", {}, "sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g=="],
-
     "@miladyai/homepage/jsdom/@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.0.9", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg=="],
 
     "@miladyai/homepage/jsdom/whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
@@ -7509,6 +7588,8 @@
     "@puppeteer/browsers/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "@puppeteer/browsers/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "@rndrntwrk/plugin-555stream/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@solana/codecs-core/@solana/errors/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -69,10 +69,10 @@
     "./test-support/test-helpers": "./src/test-support/test-helpers.ts"
   },
   "peerDependencies": {
-    "@pixiv/three-vrm": "^3.4.5",
+    "@pixiv/three-vrm": "^3.5.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "three": "^0.182.0"
+    "three": "^0.183.2"
   },
   "dependencies": {
     "@capacitor/core": "8.0.2",
@@ -87,7 +87,7 @@
     "@miladyai/vrm-utils": "workspace:*",
     "@stwd/sdk": "^0.3.0",
     "lucide-react": "^0.575.0",
-    "three": "^0.182.0",
+    "three": "^0.183.2",
     "zod": "^4.3.6",
     "@miladyai/shared": "workspace:*",
     "@xterm/xterm": "^5.5.0",
@@ -104,7 +104,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@types/three": "^0.182.0",
+    "@types/three": "^0.183.1",
     "react-test-renderer": "^19.2.4",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Summary

Bumps \`three\` from \`^0.182.0\` to \`^0.183.2\` in \`apps/app\` and \`packages/app-core\`. Aligns \`@types/three\` to \`^0.183.1\` and \`@pixiv/three-vrm\` to \`^3.5.1\` (matching the workspace root override). \`apps/web\` already pins \`^0.183.2\` — this aligns the rest of the workspace.

This unblocks PR #68 (the \`?broadcast\` view) so the capture-service's headless Chromium can actually boot \`CompanionSceneHost\` instead of falling back to the legacy \`agent-show\` standalone with the bundled blonde Alice VRM.

## Root cause

Three.js r182 ships a top-level module-init line in \`src/renderers/webgpu/utils/WebGPUConstants.js\`:

\`\`\`js
const GPUShaderStage = ( typeof self !== 'undefined' )
  ? self.GPUShaderStage
  : { VERTEX: 1, FRAGMENT: 2, COMPUTE: 4 };
\`\`\`

In any environment where \`self\` exists but WebGPU is not exposed (Bun, headless Chromium, SwiftShader-backed ANGLE, \`--disable-features=WebGPU\`), \`self.GPUShaderStage\` is \`undefined\`, the const becomes \`undefined\`, and the very next module-init statement in \`three.webgpu.js\` — \`const gpuShaderStageLib = { 'vertex': GPUShaderStage.VERTEX, 'fragment': GPUShaderStage.FRAGMENT, 'compute': GPUShaderStage.COMPUTE }\` — throws:

\`\`\`
PAGE ERROR: Cannot read properties of undefined (reading 'VERTEX')
\`\`\`

\`@pixiv/three-vrm-materials-mtoon@3.5\` does \`import * as THREE2 from \"three/webgpu\"\` 7× at file-top in \`lib/nodes/index.module.js\`, so anything that touches the VRM MToon node-material chain pulls \`WebGPURenderer\` init into the bundle eagerly even when we only render via \`WebGLRenderer\` at runtime. The crash fires before React mounts.

## Upstream references

- [mrdoob/three.js#32539](https://github.com/mrdoob/three.js/pull/32539) — \"WebGPURenderer: Prevent undefined GPUShaderStage\". Adds the missing \`&& self.GPUShaderStage\` guard. Shipped in [r183](https://github.com/mrdoob/three.js/releases/tag/r183).
- [mrdoob/three.js#32794](https://github.com/mrdoob/three.js/issues/32794) — exact \"Vite + headless + Cannot read properties of undefined (reading 'VERTEX')\" reproduction, closed as duplicate of [#32529](https://github.com/mrdoob/three.js/issues/32529).

## Why our lockfile didn't auto-pick up the fix

\`three\` is pre-1.0, so \`^0.182.0\` cannot resolve to \`0.183.x\`. The fix has been published to npm as \`0.183.2\` for weeks but our pin blocks it. This PR explicitly bumps the literal pin.

## Why \`agent-show\` (in 555stream repo) works headless but milaidy doesn't

\`services/agent-show/package.json\` pins \`three@^0.180.0\` — pre-bug. Same Chromium, same SwiftShader, same Puppeteer flags — the only delta is the \`three\` version. \`agent-show\` is the fallback that the capture-service falls back to when the broadcast view crashes. **Out of scope for this PR — that fallback works as-is.**

## Test plan

- [x] Local: \`bun install\` regenerates \`bun.lock\` cleanly with \`three@0.183.2\`, \`@types/three@0.183.1\`, \`@pixiv/three-vrm@3.5.1\` resolved at the top level. \`electrobun/three@0.165.0\` correctly stays scoped.
- [x] Local: \`bun run tsc --noEmit -p tsconfig.json\` in \`packages/app-core\` produces zero new TypeScript errors in three / VRM / BroadcastShell / VrmEngine / VrmStage code paths. The 457 errors that do reproduce are all pre-existing baseline noise unrelated to this bump.
- [ ] After merge: webhook deploy lands → fresh \`alice-bot\` image with \`three@0.183.2\` → re-enable 555stream plugin on the new pod → run \`STREAM555_GO_LIVE\` smoke with \`params.url=http://alice-bot:3000/?broadcast=1\`.
- [ ] Capture-service-gpu logs should show \`[VrmStageAvatar] VRM loaded — vrmStageReady=true\` and **NO** \`PAGE ERROR: Cannot read properties of undefined (reading 'VERTEX')\` and **NO** \`React app did not mount after 20s — will render fallback UI\`.
- [ ] Visual confirmation on Twitch + Kick: stream shows the live milaidy companion view (whatever character the runtime currently has loaded — \`Chen\` from \`apps/app/characters/vrm/Chen.vrm\` per the last probe), **NOT** the bundled blonde Alice in the golden circuit tunnel.

## Risk / blast radius

Three lines of JSON across two files plus a regenerated \`bun.lock\`. The change is fully reversible by reverting the merge commit. The character config / runtime / capture-service / control-plane are all unchanged by this PR.

## Out of scope (deferred follow-ups)

1. **Vite chunk hygiene** — \`apps/app/vite.config.ts:239\` matches \`/@pixiv/three-vrm/\` literally, missing all the \`@pixiv/three-vrm-materials-mtoon\`, \`@pixiv/three-vrm-core\`, \`@pixiv/three-vrm-springbone\`, \`@pixiv/three-vrm-node-constraint\` subpackages. They fall through to random auto-split chunks instead of landing in \`vendor-vrm\`. Pure hygiene fix, separate PR.
2. **plugin-555stream \`STREAM555_BROADCAST_URL\` env var auto-default** — so callers don't have to pass \`params.url\` explicitly to \`STREAM555_GO_LIVE\`. Lets the operator bridge / \`useCompanionStageOperator.ts:637\` continue passing \`inputType: \"avatar\"\` without a URL and have the plugin auto-resolve the broadcast URL from an env var. Separate plugin patch.
3. **\`CompanionViewOverlay\` bubble extraction** — pull just the chat and action bubble layer out of \`CompanionViewOverlay\` so \`BroadcastShell\` can mount it without dragging the Header / hub / chat dock along. PR #68 only mounts \`CompanionSceneHost\`. Separate refactor PR.