### PR TITLE
fix(broadcast-shell): satisfy 555stream capture-service handshake

### DIFF
--- a/packages/app-core/src/components/shell/BroadcastShell.tsx
+++ b/packages/app-core/src/components/shell/BroadcastShell.tsx
@@ -20,13 +20,74 @@
  *   capture pipeline can't accidentally trigger UI affordances by hovering
  *   the cursor over the scene.
  *
+ * Capture-service handshake:
+ * The 555stream capture-service worker (worker.js:2161) waits for
+ * `window.__agentShowControl` to be defined as the "React mounted"
+ * signal — that contract was originally defined for the legacy
+ * services/agent-show standalone page bundled inside control-plane.
+ * BroadcastShell sets a stub global on mount to satisfy that detector,
+ * then waits for `useCompanionSceneStatus().avatarReady` to flip true
+ * before adding the `.avatar-ready` class on `document.documentElement`,
+ * which is the second signal the worker waits for (worker.js:2174)
+ * before considering the capture ready and starting the FFmpeg push.
+ *
+ * Without this handshake the capture worker times out at 20s and falls
+ * back to its own DOM-injected agent-show standalone page (the bundled
+ * blonde Alice fallback), regardless of whether VrmEngine successfully
+ * booted in headless Chromium.
+ *
  * The companion tab on the regular shell still uses the normal
  * `<CompanionShell />` and is unchanged by this component.
  */
 
 import { useRenderGuard } from "@miladyai/app-core/hooks";
-import { memo } from "react";
+import { memo, useEffect } from "react";
 import { CompanionSceneHost } from "../companion/CompanionSceneHost";
+import { useCompanionSceneStatus } from "../companion/companion-scene-status-context";
+
+declare global {
+  interface Window {
+    /**
+     * Stub object the 555stream capture-service worker waits for to
+     * confirm the React app has mounted. The original
+     * services/agent-show standalone page exposes a richer control
+     * surface here; in broadcast mode we only need the property to
+     * exist so the worker stops timing out.
+     */
+    __agentShowControl?: Record<string, unknown>;
+  }
+}
+
+function CaptureHandshake() {
+  const { avatarReady } = useCompanionSceneStatus();
+
+  // Signal "React mounted" as soon as BroadcastShell mounts. The capture
+  // worker uses the existence of this global as the primary readiness
+  // gate; the value contents are not currently inspected.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!window.__agentShowControl) {
+      window.__agentShowControl = { source: "broadcast-shell" };
+    }
+    return () => {
+      // Intentionally NOT clearing __agentShowControl on unmount — once
+      // the capture worker has read it the contract is fulfilled and a
+      // late teardown shouldn't retract it.
+    };
+  }, []);
+
+  // Signal "avatar ready" via the documentElement class the capture
+  // worker waitForSelector's on (worker.js:2174). We only flip it once
+  // CompanionSceneHost reports the teleport-in animation has finished,
+  // so the first FFmpeg frames don't catch the avatar mid-load.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    if (!avatarReady) return;
+    document.documentElement.classList.add("avatar-ready");
+  }, [avatarReady]);
+
+  return null;
+}
 
 export const BroadcastShell = memo(function BroadcastShell() {
   useRenderGuard("BroadcastShell");
@@ -35,7 +96,9 @@ export const BroadcastShell = memo(function BroadcastShell() {
       data-broadcast-shell
       className="fixed inset-0 h-screen w-screen overflow-hidden bg-black"
     >
-      <CompanionSceneHost active interactive={false} />
+      <CompanionSceneHost active interactive={false}>
+        <CaptureHandshake />
+      </CompanionSceneHost>
     </div>
   );
 });


### PR DESCRIPTION
## Summary

PR #68 added \`BroadcastShell\` so the 555stream capture-service can grab the live \`CompanionSceneHost\` instead of falling back to the legacy \`agent-show\` standalone. PR #69 bumped \`three\` to \`^0.183.2\` to fix the \`GPUShaderStage\` undefined crash that was blocking \`VrmEngine\` from booting in headless Chromium.

After both, the capture worker successfully navigates to \`http://alice-bot:3000/?broadcast=1\`, the React app boots, \`VrmEngine\` initializes (\`[VrmEngine] Using WebGLRenderer\`), and Three.js loads cleanly. **But the capture worker still falls back to its DOM-injected blonde-Alice page.** The reason is a missing handshake.

## Root cause

The 555stream capture-service worker waits for two specific signals on the page it navigates to before considering the avatar capture ready and starting the FFmpeg push (\`services/capture-service/src/worker.js:2161\` and \`:2174\`):

1. \`window.__agentShowControl\` defined (\"React app mounted — __agentShowControl available\")
2. \`.avatar-ready\` class on \`document.documentElement\` (\"Avatar ready CSS class detected\")

If either is missing after 20 seconds, the worker prints \`React app did not mount after 20s — will render fallback UI\` and DOM-injects a hardcoded blonde-Alice fallback page directly into the document body, then captures *that* instead of the live render.

These signals were originally defined for the **legacy \`services/agent-show\` standalone page bundled inside control-plane**. PR #68's \`BroadcastShell\` mounts the live milaidy \`CompanionSceneHost\` + \`VrmEngine\` but never sets either marker, so the capture worker correctly notices the milaidy React app booted but the fallback fires anyway.

## What changes

\`packages/app-core/src/components/shell/BroadcastShell.tsx\` — adds a tiny \`CaptureHandshake\` child component that mounts inside \`CompanionSceneHost\` so it can read the scene-status context. The component renders nothing.

- **\`window.__agentShowControl\`** is set to \`{ source: \"broadcast-shell\" }\` as soon as the shell mounts. The capture worker only checks for existence, not contents, so a stub is sufficient. A TS module augmentation declares the global on \`Window\` for type safety.
- **The \`.avatar-ready\` class on \`document.documentElement\`** is added only after \`useCompanionSceneStatus().avatarReady\` flips \`true\`, which is when \`CompanionSceneHost\` reports the teleport-in animation has finished. Setting it earlier would let FFmpeg catch the first frames mid-load.

## What this enables

After this lands the capture worker should log:

\`\`\`
[CaptureWorker] React app mounted — __agentShowControl available
[CaptureWorker] Avatar ready CSS class detected
\`\`\`

instead of the current:

\`\`\`
[CaptureWorker] React app did not mount after 20s — will render fallback UI
[CaptureWorker] Rendering fallback avatar UI via DOM injection
\`\`\`

…and the FFmpeg encode will be a clean grab of the live milaidy companion view rendered by the alice-bot pod, instead of the DOM-injected hardcoded blonde-Alice fallback.

## Test plan

- [x] Local TypeScript typecheck on \`packages/app-core\`: zero new errors in \`BroadcastShell\` or \`CaptureHandshake\`.
- [ ] After merge: webhook deploy fires → fresh alice-bot image → re-enable 555stream plugin on the new pod → run \`STREAM555_GO_LIVE\` smoke with \`params.url=http://alice-bot:3000/?broadcast=1\`.
- [ ] capture-service-gpu logs show \`[CaptureWorker] React app mounted — __agentShowControl available\` and \`[CaptureWorker] Avatar ready CSS class detected\` (instead of the fallback).
- [ ] Visual confirmation on Twitch + Kick that the live milaidy companion view is on stream — current loaded character is \`Chen\` from \`apps/app/characters/vrm/Chen.vrm\`, NOT the bundled blonde Alice in the golden circuit tunnel.

## Risk / blast radius

One file touched (\`BroadcastShell.tsx\`), 65 lines added. \`CaptureHandshake\` only mounts inside \`BroadcastShell\` so the regular companion shell is unaffected. Reversible by reverting the merge commit.

## Pairs with

- #68 — BroadcastShell architecture (the broadcast view itself)
- #69 — three.js r182→r183 bump (the upstream WebGL crash fix)

This is the third and final piece needed for the broadcast view to actually ship live frames to Twitch/Kick.

## Out of scope follow-ups (deliberately deferred)

- **Plugin auto-default \`STREAM555_BROADCAST_URL\`** — small plugin-555stream patch so callers don't need \`params.url\`.
- **Vite chunk hygiene** — \`apps/app/vite.config.ts:239\` \`/@pixiv/three-vrm/\` matcher doesn't catch \`@pixiv/three-vrm-materials-mtoon\` etc.
- **CompanionViewOverlay bubble extraction** — pull just the chat/action bubble layer out of \`CompanionViewOverlay\` so \`BroadcastShell\` can mount it without dragging Header/hub/chat dock along.