### PR TITLE
fix(broadcast): set capture handshake marker synchronously in boot path

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -562,6 +562,32 @@ async function runMain(): Promise<void> {
     // shell only needs the React app, AppContext, and CompanionSceneHost
     // to come up. App.tsx's `useIsBroadcast()` gate routes the render to
     // BroadcastShell once the startup coordinator reaches "ready".
+    //
+    // Set the 555stream capture-service "React mounted" handshake marker
+    // SYNCHRONOUSLY here, before the React app even mounts. The capture
+    // worker uses
+    //   page.waitForFunction(
+    //     () => typeof window.__agentShowControl !== 'undefined',
+    //     { timeout: 20000 }
+    //   )
+    // as its primary "is the page ready" gate (see
+    // services/capture-service/src/worker.js:2161). Setting the global at
+    // the boot path means the worker's first poll catches it within
+    // ~100ms of the page loading — eliminating any race window between
+    // the React commit phase and the worker's 20s timeout, which is the
+    // failure mode that was making the worker fall back to its legacy
+    // DOM-injected agent-show standalone page.
+    //
+    // BroadcastShell's <CaptureHandshake/> child still runs the same
+    // assignment from a useEffect for the in-React lifecycle (and adds
+    // the .avatar-ready class once useCompanionSceneStatus().avatarReady
+    // flips true), but the boot-path assignment is the primary path
+    // because it can't race with React commit timing.
+    if (typeof window !== "undefined") {
+      (
+        window as unknown as { __agentShowControl?: Record<string, unknown> }
+      ).__agentShowControl = { source: "broadcast-boot" };
+    }
     injectPopoutApiBase();
     mountReactApp();
     return;


### PR DESCRIPTION
## Summary

PR #70 added the React-lifecycle handshake (\`CaptureHandshake\` child of \`BroadcastShell\`, sets \`window.__agentShowControl\` from a \`useEffect\`). Verified post-deploy:

- Bundle contains \`__agentShowControl = { source: \"broadcast-shell\" }\` ✓
- BroadcastShell wires \`CaptureHandshake\` as child of \`CompanionSceneHost\` ✓
- React app boots in headless Chromium (\`React DevTools\` console message fires) ✓
- VrmEngine initializes (\`[VrmEngine] Using WebGLRenderer\` logs twice, once per character) ✓
- Three.js loads cleanly (only deprecation warnings) ✓
- **No more** \`Cannot read properties of undefined (reading 'VERTEX')\` ✓
- **No more** SwiftShader deprecation warning ✓

But the capture worker **still** times out after 20 seconds and falls back to its legacy DOM-injected blonde-Alice page:

\`\`\`
[CaptureWorker] React app did not mount after 20s — will render fallback UI
[CaptureWorker] Rendering fallback avatar UI via DOM injection
\`\`\`

## Hypothesis

The React \`useEffect\` commit phase is racing with the capture worker's \`page.waitForFunction\` polling. Possible causes:

- The \`useEffect\` fires after the worker's 20-second deadline (unlikely but possible if bundle parse + initial render is slow inside headless SwiftShader on the alice-bot image build).
- React 18 strict-mode mount-unmount-mount semantics cause the effect cleanup to fire before the worker's poll catches the global.
- The worker's poll function executes in a different JS context than the React effect.

Rather than continue diagnosing race conditions, this PR sets the marker **synchronously in the boot path** of \`apps/app/src/main.tsx\` BEFORE \`mountReactApp()\` is even called. The capture worker's first poll then catches it within ~100 ms with no chance of any race window.

## What changes

\`apps/app/src/main.tsx\` — inside the existing \`if (isBroadcastWindow())\` boot branch, add a synchronous assignment:

\`\`\`ts
if (typeof window !== \"undefined\") {
  (window as unknown as { __agentShowControl?: Record<string, unknown> })
    .__agentShowControl = { source: \"broadcast-boot\" };
}
injectPopoutApiBase();
mountReactApp();
\`\`\`

That's the entire change. 26 lines added (most of them comment block explaining the racy behavior + cross-references to capture-service worker.js).

## Why this doesn't replace PR #70

The \`.avatar-ready\` class still has to be added at the right time — only after the avatar's teleport-in animation finishes, so FFmpeg doesn't catch the first frames mid-load. PR #70's \`CaptureHandshake\` remains the right place for that — it has \`useCompanionSceneStatus().avatarReady\` in scope. This commit just adds a redundant pre-React assignment for \`__agentShowControl\`, not a replacement.

## Test plan

- [ ] After merge: webhook deploy → fresh alice-bot pod → re-enable plugin → run \`STREAM555_GO_LIVE\` smoke with \`params.url=http://alice-bot:3000/?broadcast=1\`.
- [ ] capture-service-gpu logs show \`[CaptureWorker] React app mounted — __agentShowControl available\` within ~100 ms of \`Navigated to avatar renderer\` (instead of timing out at 20s).
- [ ] Then \`[CaptureWorker] Avatar ready CSS class detected\` (or the force-add fallback after 20s, which is still a clean capture).
- [ ] **NO** \`React app did not mount after 20s — will render fallback UI\`.
- [ ] **NO** \`Rendering fallback avatar UI via DOM injection\`.
- [ ] Visual confirmation on Twitch + Kick: live milaidy companion view (Chen character from \`apps/app/characters/vrm/Chen.vrm\`), NOT the bundled blonde Alice in the golden circuit tunnel.

## Risk / blast radius

One file touched, 26 lines added, all inside the existing \`if (isBroadcastWindow())\` branch which only fires when \`?broadcast\` is on the URL. Zero impact on popout, normal app shell, or detached window paths. Reversible by reverting the merge commit.

## Pairs with

- #68 — BroadcastShell architecture (the broadcast view itself)
- #69 — three.js r182→r183 bump (the upstream WebGL crash fix)
- #70 — in-React handshake (\`CaptureHandshake\` for \`.avatar-ready\` class + redundant React-lifecycle marker)

This is the fourth and (hopefully final) piece needed for the broadcast view to actually ship live frames to Twitch/Kick.