### PR TITLE
fix(broadcast): bypass onboarding coordinator for capture headless Chromium

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -588,6 +588,40 @@ async function runMain(): Promise<void> {
         window as unknown as { __agentShowControl?: Record<string, unknown> }
       ).__agentShowControl = { source: "broadcast-boot" };
     }
+
+    // Teach the startup coordinator that onboarding is already complete.
+    //
+    // milaidy's StartupCoordinator seeds its `onboardingComplete` flag
+    // from `localStorage["eliza:onboarding-complete"]` (see
+    // packages/app-core/src/state/persistence.ts:417 +
+    // useLifecycleState.ts:48). A fresh headless Chromium has empty
+    // localStorage, so the coordinator transitions to
+    // `onboarding-required` and App.tsx renders StartupShell →
+    // OnboardingWizard — the character-select screen with the EN
+    // language chip that was appearing on stream instead of the
+    // companion view.
+    //
+    // For alice-bot specifically this is an architectural mismatch:
+    // milaidy's SPA treats each browser as a personal install to
+    // onboard, but alice-bot is a server-side, always-on, single-
+    // tenant agent whose state lives in /home/node/.milaidy/milaidy.json
+    // on the PVC. Every browser that connects should behave like an
+    // already-onboarded viewer.
+    //
+    // For broadcast captures specifically we force the marker so the
+    // coordinator skips onboarding and goes straight through
+    // `starting-runtime` → `hydrating` → `ready`, at which point
+    // BroadcastShell mounts CompanionSceneHost with whatever character
+    // AppContext resolves. The proper long-term fix is to have the
+    // coordinator consult a server-side `/api/agent/v1/onboarding-state`
+    // endpoint before falling back to localStorage — tracked as a
+    // follow-up.
+    try {
+      localStorage.setItem("eliza:onboarding-complete", "1");
+    } catch {
+      /* storage unavailable — the coordinator's own try/catch handles this */
+    }
+
     injectPopoutApiBase();
     mountReactApp();
     return;

--- a/packages/app-core/src/App.tsx
+++ b/packages/app-core/src/App.tsx
@@ -763,24 +763,28 @@ export function App() {
 
   // Broadcast mode — render only the CompanionSceneHost (VRM stage + chat
   // and action overlays) full-screen, with no Header, sidebar, hub nav, or
-  // settings chrome. Wait for the startup coordinator to reach "ready"
-  // first so the avatar stack has access to the resolved character
-  // catalog and AppContext state before VrmEngine boots; the loader is
-  // rendered behind the same StartupShell as the rest of the app.
+  // settings chrome.
   //
   // This is the URL the capture-service's headless Chromium navigates to
   // when STREAM555_GO_LIVE is invoked with `inputType: avatar` —
   // replacing the legacy parallel agent-show static page so the broadcast
   // frame is byte-for-byte the live companion view.
+  //
+  // IMPORTANT: unlike the regular app shell we do NOT gate on
+  // `startupCoordinator.phase === "ready"` here. alice-bot is a
+  // single-tenant, server-side, always-on agent whose state lives in
+  // /home/node/.milaidy/milaidy.json on the PVC — the broadcast view
+  // should behave like an already-onboarded viewer and render
+  // CompanionSceneHost immediately. Popout mode above does the same
+  // for StreamView. main.tsx's broadcast boot path seeds
+  // localStorage["eliza:onboarding-complete"] = "1" before React mounts
+  // so the coordinator never flips to `onboarding-required`; this is
+  // defense-in-depth for the case where the coordinator is still in an
+  // earlier phase (splash/restoring-session/polling-backend) when the
+  // capture worker's first frame grab fires — the VRM scene still
+  // renders via AppContext defaults, which AppProvider hydrates
+  // independently of the coordinator state machine.
   if (isBroadcast) {
-    if (startupCoordinator.phase !== "ready") {
-      return (
-        <BugReportProvider value={bugReport}>
-          <StartupShell />
-          <BugReportModal />
-        </BugReportProvider>
-      );
-    }
     return <BroadcastShell />;
   }
 


### PR DESCRIPTION
## Summary

The broadcast capture pipeline (PR #68 \`BroadcastShell\` + PR #69 \`three@^0.183.2\` + PR #70 \`CaptureHandshake\` + PR #71 boot-path \`__agentShowControl\`) now actually mounts the milaidy React app in the 555stream capture-service's headless Chromium and VrmEngine boots cleanly. But the frame that ends up on Twitch/Kick is the **OnboardingWizard character-select screen** — Chen/Jin/Kei/Momo/Rin/Ryu/Satoshi/Yuki/Alice chip row, CONTINUE button, EN language switcher, Go Live header — not the live \`CompanionSceneHost\` view.

This PR fixes that.

## Root cause

milaidy's StartupCoordinator seeds its \`onboardingComplete\` flag from **localStorage**, not from the server:

- \`packages/app-core/src/state/persistence.ts:417\`
  \`\`\`ts
  const ONBOARDING_COMPLETE_STORAGE_KEY = \"eliza:onboarding-complete\";
  export function loadPersistedOnboardingComplete(): boolean {
    try {
      return localStorage.getItem(ONBOARDING_COMPLETE_STORAGE_KEY) === \"1\";
    } catch { return false; }
  }
  \`\`\`
- \`packages/app-core/src/state/useLifecycleState.ts:48\`
  \`\`\`ts
  onboardingComplete: loadPersistedOnboardingComplete(),
  \`\`\`
- \`:407\`
  \`\`\`ts
  if (!state.onboardingComplete) return \"onboarding\";
  \`\`\`

A fresh headless Chromium has empty localStorage → coordinator transitions to \`onboarding-required\` → App.tsx's broadcast branch sees \`phase !== \"ready\"\` and returns \`<StartupShell />\` → StartupShell renders OnboardingWizard → that's what's on stream.

**For alice-bot specifically this is an architectural mismatch.** milaidy's SPA treats each browser as a personal install that needs to go through onboarding on its own device. alice-bot is the *opposite* — it's a server-side, always-on, single-tenant agent whose state lives in \`/home/node/.milaidy/milaidy.json\` on the \`alice-milaidy-state\` PVC. I verified this directly:

\`\`\`json
\"agents\": {
  \"list\": [{
    \"id\": \"main\",
    \"default\": true,
    \"name\": \"alice\",
    \"bio\": [...],
    \"system\": \"You are alice, the CEO of 555, powered by milaidy...\"
  }]
}
\`\`\`

Every browser that connects — including a capture worker's headless Chromium — should behave like an **already-onboarded viewer** of that server-side truth, not like a fresh device that needs to pick a character.

## What changes

Two files, 50 insertions.

### 1. \`apps/app/src/main.tsx\` — seed localStorage before React mounts

Inside the existing \`if (isBroadcastWindow())\` boot branch, force the onboarding-complete flag into localStorage synchronously before \`mountReactApp()\`:

\`\`\`ts
try {
  localStorage.setItem(\"eliza:onboarding-complete\", \"1\");
} catch {
  /* storage unavailable — the coordinator's own try/catch handles this */
}
\`\`\`

The coordinator now seeds its state to \`onboardingComplete: true\` on first render and transitions straight through \`splash → restoring-session → polling-backend → starting-runtime → hydrating → ready\`, skipping \`onboarding-required\` entirely.

### 2. \`packages/app-core/src/App.tsx\` — drop the phase gate from the broadcast branch

Before:

\`\`\`tsx
if (isBroadcast) {
  if (startupCoordinator.phase !== \"ready\") {
    return <StartupShell />;  // ← the bug
  }
  return <BroadcastShell />;
}
\`\`\`

After:

\`\`\`tsx
if (isBroadcast) {
  return <BroadcastShell />;  // ← unconditional
}
\`\`\`

Even with the localStorage seed in place, there are transient early phases (\`splash\`, \`restoring-session\`, \`polling-backend\`) where the coordinator is briefly not-ready. The capture worker's 20-second frame-ready deadline can fire during that window. Popout mode already renders \`<StreamView />\` unconditionally for the same reason. \`BroadcastShell\` now does too — AppContext hydrates independently of the coordinator's state machine, and \`CompanionSceneHost\`'s scene config / VRM catalog come from AppContext + default fallbacks, not from the coordinator.

## Net effect

- Capture-service navigates to \`http://alice-bot:3000/?broadcast=1\`
- Boot path seeds \`window.__agentShowControl\` (from PR #71) AND \`localStorage[\"eliza:onboarding-complete\"] = \"1\"\` (new)
- React mounts, App.tsx sees \`isBroadcast\`, returns \`<BroadcastShell />\` immediately
- \`CompanionSceneHost\` mounts, \`VrmEngine\` boots, \`CaptureHandshake\` adds \`.avatar-ready\` after teleport-in
- Capture worker sees both markers, FFmpeg grabs the live companion view and pushes to Cloudflare
- **No OnboardingWizard. No EN chip. No Go Live header button. No character-select row.** Just the VRM scene, full-bleed 1920x1080.

## Test plan

- [x] Local TypeScript typecheck on \`packages/app-core\`: zero new errors on \`App.tsx\` or \`main.tsx\`.
- [ ] After merge: webhook deploy → fresh alice-bot pod → re-enable 555stream plugin on the new pod → run broadcast smoke with \`params.url=http://alice-bot:3000/?broadcast=1\`.
- [ ] capture-gpu logs show \`React app mounted — __agentShowControl available\` within ~50ms and \`Avatar ready CSS class detected\` within a few seconds (after VRM teleport-in).
- [ ] **NO** \`onboarding-required\` phase logged anywhere.
- [ ] **NO** OnboardingWizard character-select row visible on Twitch + Kick.
- [ ] Visual confirmation on Twitch + Kick: live \`CompanionSceneHost\` render with whatever character AppContext's default resolves to (likely whichever index the catalog defaults to).

## Risk / blast radius

Two files, 50 lines added/changed, all inside the broadcast-specific branches (\`isBroadcastWindow()\` in main.tsx, \`if (isBroadcast)\` in App.tsx). Zero impact on popout, regular app shell, detached window, or any other startup path. The localStorage seed only fires when \`?broadcast\` is on the URL.

## Follow-up (NOT in this PR, deliberately deferred)

**Server-aware onboarding coordinator.** Teach the StartupCoordinator to consult a server-side \`/api/agent/v1/onboarding-state\` endpoint (or similar) during the \`polling-backend\` phase and use its \`onboardingComplete\` response as the primary truth, falling back to localStorage only if the backend doesn't know. That fixes the root architectural mismatch (client-side-only onboarding state) for **every** fresh browser that ever opens alice.rndrntwrk.com, not just the broadcast one. It's a 3-file PR touching the coordinator state machine (\`startup-coordinator.ts\` + \`useLifecycleState.ts\`), a data loader (\`useDataLoaders.ts\`), and a new agent route on the backend (\`packages/agent/src/api/\`). Too large to rush through under broadcast-pipeline time pressure — scheduled for regular milaidy work queue.

## Pairs with

- #68 — \`BroadcastShell\` architecture
- #69 — three.js r183 WebGL fix
- #70 — \`CaptureHandshake\` React-lifecycle markers
- #71 — boot-path \`__agentShowControl\` handshake

This is the fifth and final piece needed for the broadcast pipeline to ship the live companion view to Twitch and Kick.