### PR TITLE
fix(companion): mount SceneOverlayDataBridge so chat panel renders data

### DIFF
--- a/packages/app-core/src/App.tsx
+++ b/packages/app-core/src/App.tsx
@@ -65,6 +65,7 @@ import { TasksEventsPanel } from "./components/chat/TasksEventsPanel";
 import { DeferredSetupChecklist } from "./components/cloud/FlaminaGuide";
 
 import { MusicPlayerGlobal } from "./components/music/MusicPlayerGlobal";
+import { SceneOverlayDataBridge } from "./components/companion/scene-overlay-bridge";
 import {
   BugReportProvider,
   useBugReportState,
@@ -822,6 +823,20 @@ export function App() {
         />
       )}
       <MusicPlayerGlobal />
+
+      {/*
+        SceneOverlayDataBridge — leaf that subscribes to app state
+        (conversationMessages, agentStatus, triggers) and pushes it into
+        the VrmEngine's SceneOverlayManager so the in-scene chat / status
+        / heartbeat billboards get data. Mounted at the App level so it
+        doesn't re-render CompanionSceneHost on every chat update, and
+        so the companion view shows the same bubbles regardless of which
+        tab the user is looking at. This is also the fix for the
+        "action bubbles regressed" report — operator actions are inline
+        ConversationMessages, so they appear in the chat panel once the
+        bridge is mounted.
+      */}
+      <SceneOverlayDataBridge />
 
       {/* Persistent game overlay — stays visible across all tabs */}
       {activeGameViewerUrl && gameOverlayEnabled && tab !== "apps" && (

--- a/packages/app-core/src/components/shell/BroadcastShell.tsx
+++ b/packages/app-core/src/components/shell/BroadcastShell.tsx
@@ -44,6 +44,7 @@ import { useRenderGuard } from "@miladyai/app-core/hooks";
 import { memo, useEffect } from "react";
 import { CompanionSceneHost } from "../companion/CompanionSceneHost";
 import { useCompanionSceneStatus } from "../companion/companion-scene-status-context";
+import { SceneOverlayDataBridge } from "../companion/scene-overlay-bridge";
 
 declare global {
   interface Window {
@@ -99,6 +100,17 @@ export const BroadcastShell = memo(function BroadcastShell() {
       <CompanionSceneHost active interactive={false}>
         <CaptureHandshake />
       </CompanionSceneHost>
+      {/*
+        SceneOverlayDataBridge is a leaf that subscribes to React state
+        (conversationMessages, agentStatus, triggers) and pushes it into
+        the SceneOverlayManager via the VrmEngine debug registry. It must
+        be mounted OUTSIDE CompanionSceneHost so it doesn't trigger
+        re-renders of the 3D host on every chat / status / trigger update.
+        Without this, the chat / status / heartbeat billboards inside the
+        scene render but never receive any data, which is why the live
+        capture had no chat bubbles after PR #68.
+      */}
+      <SceneOverlayDataBridge />
     </div>
   );
 });


### PR DESCRIPTION
## Summary

PR #68 shipped `BroadcastShell` + `CompanionSceneHost` with the `SceneOverlayManager` billboards (chat / status / heartbeats) already rendering inside the VRM scene, but the `SceneOverlayDataBridge` that feeds React state into that manager was defined in `packages/app-core/src/components/companion/scene-overlay-bridge.ts` and **never imported or mounted anywhere in the codebase**. Result: the 3D chat panel rendered as an empty billboard both on stream and in the user's own browser.

This also explains the "action bubbles regressed" report — operator actions are stored as inline `ConversationMessage` entries (no `kind` field, no separate panel type), so they flow through the same `setChatMessages` code path that was never being called. Once the bridge is mounted, operator-triggered actions show up alongside chat messages like they used to.

## Changes

Mount `<SceneOverlayDataBridge />` in two places:

1. **Inside `BroadcastShell`** (`packages/app-core/src/components/shell/BroadcastShell.tsx`), as a sibling of `CompanionSceneHost`. Must be OUTSIDE the scene host so chat / status / trigger updates don't cascade a re-render of the 3D scene.

2. **In `App.tsx`** at the app level, near `MusicPlayerGlobal`. This restores the chat and operator-action bubbles in the regular companion view (the user's own browser), which is where the regression was originally reported.

## Scope

This is the smallest possible fix. `SceneOverlayManager` already has all the billboard rendering, layout, animation, and public `setChatMessages` / `setAgentStatus` / `setHeartbeats` methods wired up. All we're doing is mounting the leaf component that calls those methods.

Zero changes to `VrmEngine`, `SceneOverlayManager`, `scene-overlay-renderer`, or `CompanionSceneHost`.

## Test plan

- [x] Package typecheck (`bun run tsc --noEmit -p tsconfig.json` in `packages/app-core`): zero new errors in `App.tsx`, `BroadcastShell.tsx`, or `scene-overlay-bridge.ts`. Pre-existing baseline errors in `../agent/` and unrelated `src/` files are untouched.
- [ ] Webhook deploy builds alice-bot image + rolls deployment (~15-20 min)
- [ ] Run `STREAM555_GO_LIVE` smoke against `http://alice-bot:3000/?broadcast=1`
- [ ] Verify on Twitch + Kick: companion scene renders + chat panel billboard shows the latest messages
- [ ] Verify in the user's own browser on `https://alice.rndrntwrk.com`: chat panel inside the scene now shows messages, operator-activated actions appear as chat bubbles

## Related

Builds on top of:
- #68 — initial `?broadcast` mode
- #69 — three.js r183 bump (headless `GPUShaderStage` crash)
- #70 — capture handshake markers
- #71 — synchronous boot-path handshake
- #72 — onboarding coordinator bypass for headless