### PR TITLE
feat(companion): server-authoritative camera zoom via CompanionStageState

### DIFF
--- a/packages/agent/src/api/misc-routes.ts
+++ b/packages/agent/src/api/misc-routes.ts
@@ -1,5 +1,7 @@
 import crypto from "node:crypto";
+import fs from "node:fs";
 import type http from "node:http";
+import path from "node:path";
 import { logger, ModelType, type AgentRuntime, type UUID } from "@elizaos/core";
 import type { ElizaConfig } from "../config/config.js";
 import { loadElizaConfig, saveElizaConfig } from "../config/config.js";
@@ -15,6 +17,137 @@ import {
   isPrivyWalletProvisioningEnabled,
 } from "../services/privy-wallets.js";
 import type { ReadJsonBodyOptions } from "./http-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Companion stage state — persistent scene state shared between the
+// operator's browser and the 555stream capture-service's headless
+// Chromium so both views render identically.
+//
+// Phase 1 only persists camera framing (zoom / yaw / pitch / pan). The
+// shape must agree with
+// `packages/app-core/src/components/companion/companion-stage-state.ts`
+// on the client — if you change one, update the other. Inlined here
+// (rather than imported) because `packages/agent` doesn't import from
+// `packages/app-core` as a runtime dep.
+// ---------------------------------------------------------------------------
+
+interface CompanionStageCamera {
+  zoom: number;
+  yaw: number;
+  pitch: number;
+  pan: number;
+}
+
+interface CompanionStageState {
+  camera: CompanionStageCamera;
+}
+
+interface PartialCompanionStageState {
+  camera?: Partial<CompanionStageCamera>;
+}
+
+const DEFAULT_COMPANION_STAGE_STATE: CompanionStageState = {
+  camera: {
+    zoom: 0.95,
+    yaw: 0,
+    pitch: 0,
+    pan: 0,
+  },
+};
+
+const COMPANION_STAGE_DIR = path.join(
+  process.env.ELIZA_DATA_DIR || path.join(process.cwd(), "data"),
+  "companion",
+);
+const COMPANION_STAGE_FILE = path.join(COMPANION_STAGE_DIR, "stage.json");
+
+function clamp01(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+function clampFinite(
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+function sanitizeCompanionStageState(
+  raw: unknown,
+): CompanionStageState {
+  const candidate =
+    raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+  const rawCamera =
+    candidate.camera && typeof candidate.camera === "object"
+      ? (candidate.camera as Record<string, unknown>)
+      : {};
+  return {
+    camera: {
+      zoom: clamp01(
+        rawCamera.zoom,
+        DEFAULT_COMPANION_STAGE_STATE.camera.zoom,
+      ),
+      yaw: clampFinite(rawCamera.yaw, 0, -Math.PI, Math.PI),
+      pitch: clampFinite(rawCamera.pitch, 0, -Math.PI / 2, Math.PI / 2),
+      pan: clampFinite(rawCamera.pan, 0, -5, 5),
+    },
+  };
+}
+
+function readCompanionStageState(): CompanionStageState {
+  try {
+    if (fs.existsSync(COMPANION_STAGE_FILE)) {
+      const raw = JSON.parse(
+        fs.readFileSync(COMPANION_STAGE_FILE, "utf-8"),
+      );
+      return sanitizeCompanionStageState(raw);
+    }
+  } catch (err) {
+    logger.warn(
+      `[companion-stage] Failed to read ${COMPANION_STAGE_FILE}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  return { ...DEFAULT_COMPANION_STAGE_STATE };
+}
+
+function writeCompanionStageState(next: CompanionStageState): void {
+  try {
+    fs.mkdirSync(COMPANION_STAGE_DIR, { recursive: true });
+    fs.writeFileSync(
+      COMPANION_STAGE_FILE,
+      JSON.stringify(next, null, 2),
+      "utf-8",
+    );
+  } catch (err) {
+    logger.warn(
+      `[companion-stage] Failed to persist ${COMPANION_STAGE_FILE}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}
+
+function mergeCompanionStagePatch(
+  base: CompanionStageState,
+  patch: PartialCompanionStageState,
+): CompanionStageState {
+  return {
+    camera: {
+      ...base.camera,
+      ...(patch.camera ?? {}),
+    },
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -176,6 +309,58 @@ export async function handleMiscRoutes(
       loop: false,
     });
     json(res, { ok: true });
+    return true;
+  }
+
+  // ── GET /api/companion/stage ─────────────────────────────────────────
+  //
+  // Return the current persistent companion stage state so a newly
+  // connected browser (operator's tab OR the 555stream capture-service
+  // headless Chromium) can hydrate its local camera/orbit refs to
+  // match the authoritative server state before the first WS push
+  // arrives. This avoids the "first frame shows default zoom, second
+  // frame snaps to the operator's zoom" glitch on reconnect.
+  if (method === "GET" && pathname === "/api/companion/stage") {
+    json(res, { ok: true, state: readCompanionStageState() });
+    return true;
+  }
+
+  // ── POST /api/companion/stage ────────────────────────────────────────
+  //
+  // Mutate the persistent companion stage state. Body is a patch of
+  // the form `{ patch: { camera: { zoom?: number, yaw?: ... } } }`.
+  // The route deep-merges the patch into the current state, sanitizes
+  // the result (defensive clamping against NaN/Infinity and
+  // out-of-range values), persists the merged state to
+  // `$ELIZA_DATA_DIR/companion/stage.json`, and broadcasts the new
+  // full state to every connected `/ws` client as a
+  // `"companion-stage-state"` message.
+  //
+  // The operator's own browser receives the echo and it's a no-op
+  // (the local optimistic update already applied the same values).
+  // The capture-service's headless Chromium receives the echo and
+  // applies it to its own VrmEngine, so the stream mirrors the
+  // operator's camera framing within a single WS round-trip.
+  if (method === "POST" && pathname === "/api/companion/stage") {
+    const body = await readJsonBody<{ patch?: PartialCompanionStageState }>(
+      req,
+      res,
+    );
+    if (!body) return true;
+    if (!body.patch || typeof body.patch !== "object") {
+      error(res, "Missing 'patch' field", 400);
+      return true;
+    }
+    const current = readCompanionStageState();
+    const merged = sanitizeCompanionStageState(
+      mergeCompanionStagePatch(current, body.patch),
+    );
+    writeCompanionStageState(merged);
+    state.broadcastWs?.({
+      type: "companion-stage-state",
+      state: merged,
+    });
+    json(res, { ok: true, state: merged });
     return true;
   }
 

--- a/packages/app-core/src/api/client.ts
+++ b/packages/app-core/src/api/client.ts
@@ -97,6 +97,10 @@ import {
   sanitizeForSettingsDebug,
   settingsDebugCloudSummary,
 } from "@miladyai/shared";
+import type {
+  CompanionStageState,
+  PartialCompanionStageState,
+} from "../components/companion/companion-stage-state";
 import type { ConfigUiHint } from "../types";
 import { stripAssistantStageDirections } from "../utils/assistant-text";
 import { getElizaApiBase, getElizaApiToken } from "../utils/eliza-globals";
@@ -2592,6 +2596,39 @@ export class MiladyClient {
 
   async getEmotes(): Promise<{ emotes: EmoteInfo[] }> {
     return this.fetch("/api/emotes");
+  }
+
+  /**
+   * Hydrate the current companion stage state from the alice-bot server.
+   * Called on mount by the operator's browser and the 555stream
+   * capture-service headless Chromium to align their local camera refs
+   * with the persistent server state before the first WS push arrives.
+   */
+  async getCompanionStageState(): Promise<{
+    ok: boolean;
+    state: CompanionStageState;
+  }> {
+    return this.fetch("/api/companion/stage");
+  }
+
+  /**
+   * Request a persistent mutation to the companion stage state. The
+   * server deep-merges the patch, sanitizes, persists to
+   * `$ELIZA_DATA_DIR/companion/stage.json`, and broadcasts the merged
+   * state to every connected `/ws` subscriber as
+   * `"companion-stage-state"`. Both the caller's own browser and the
+   * capture-service's headless Chromium receive the echo and apply it.
+   *
+   * Callers should apply the patch optimistically before awaiting this
+   * promise to keep local input (scroll wheel, drag) latency-free.
+   */
+  async setCompanionStageState(
+    patch: PartialCompanionStageState,
+  ): Promise<{ ok: boolean; state: CompanionStageState }> {
+    return this.fetch("/api/companion/stage", {
+      method: "POST",
+      body: JSON.stringify({ patch }),
+    });
   }
 
   async runTerminalCommand(command: string): Promise<{ ok: boolean }> {

--- a/packages/app-core/src/components/companion/CompanionSceneHost.scroll-guard.test.ts
+++ b/packages/app-core/src/components/companion/CompanionSceneHost.scroll-guard.test.ts
@@ -36,7 +36,26 @@ vi.mock("./VrmStage", () => ({
 
 import { CompanionSceneHost } from "./CompanionSceneHost";
 
-const COMPANION_ZOOM_STORAGE_KEY = "milady.companion.zoom.v1";
+const COMPANION_STAGE_ENDPOINT = "/api/companion/stage";
+
+function stageSetCalls(fetchMock: unknown) {
+  const mock = fetchMock as { mock?: { calls: unknown[][] } };
+  return (
+    mock.mock?.calls.filter((callArgs) => {
+      const url =
+        typeof callArgs[0] === "string"
+          ? callArgs[0]
+          : callArgs[0] instanceof URL
+            ? callArgs[0].toString()
+            : "";
+      const init = callArgs[1] as { method?: string } | undefined;
+      return (
+        url.includes(COMPANION_STAGE_ENDPOINT) &&
+        (init?.method ?? "GET") === "POST"
+      );
+    }) ?? []
+  );
+}
 
 function createContext(overrides: Record<string, unknown> = {}) {
   return {
@@ -168,11 +187,13 @@ describe("CompanionSceneHost scroll guard", () => {
       target: nestedTarget,
     } as WheelEvent);
 
-    expect(globalThis.localStorage.setItem).not.toHaveBeenCalled();
+    // No POST to the companion-stage endpoint — the wheel event was
+    // ignored because it came from inside a `data-no-camera-zoom` region.
+    expect(stageSetCalls(globalThis.fetch)).toHaveLength(0);
     expect(preventDefault).not.toHaveBeenCalled();
   });
 
-  it("persists zoom when wheel input comes from the scene surface", async () => {
+  it("persists zoom through the companion stage endpoint when wheel input comes from the scene surface", async () => {
     const rootMock = createCompanionRootMock();
     await act(async () => {
       renderSceneHost(rootMock);
@@ -189,10 +210,12 @@ describe("CompanionSceneHost scroll guard", () => {
       target: document.createElement("div"),
     } as WheelEvent);
 
-    expect(globalThis.localStorage.setItem).toHaveBeenCalledWith(
-      COMPANION_ZOOM_STORAGE_KEY,
-      expect.any(String),
-    );
+    // The commit goes through `client.setCompanionStageState(...)` which
+    // eventually calls `fetch("/api/companion/stage", { method: "POST", ... })`.
+    // We don't assert the exact zoom value because it depends on the
+    // wheel-to-zoom sensitivity constant — just that a POST fired.
+    const calls = stageSetCalls(globalThis.fetch);
+    expect(calls.length).toBeGreaterThan(0);
     expect(preventDefault).toHaveBeenCalledOnce();
   });
 });

--- a/packages/app-core/src/components/companion/CompanionSceneHost.tsx
+++ b/packages/app-core/src/components/companion/CompanionSceneHost.tsx
@@ -27,9 +27,15 @@ import {
   useRef,
   useState,
 } from "react";
+import { client } from "../../api";
 import type { VrmEngine } from "../avatar/VrmEngine";
 import { prefetchVrmToCache } from "../avatar/VrmEngine";
 import { resolveCharacterGreetingAnimation } from "../character/character-greeting";
+import type {
+  CompanionStageState,
+  PartialCompanionStageState,
+} from "./companion-stage-state";
+import { DEFAULT_COMPANION_STAGE_STATE } from "./companion-stage-state";
 import { CompanionSceneStatusContext } from "./companion-scene-status-context";
 import { SharedCompanionSceneContext } from "./shared-companion-scene-context";
 import { VrmStage } from "./VrmStage";
@@ -38,8 +44,7 @@ export { useSharedCompanionScene } from "./shared-companion-scene-context";
 
 const COMPANION_ZOOM_WHEEL_SENSITIVITY = 1 / 720;
 const COMPANION_ZOOM_PINCH_SENSITIVITY = 2.35;
-const COMPANION_ZOOM_STORAGE_KEY = "milady.companion.zoom.v1";
-const DEFAULT_COMPANION_ZOOM = 0.95;
+const DEFAULT_COMPANION_ZOOM = DEFAULT_COMPANION_STAGE_STATE.camera.zoom;
 const COMPANION_TELEPORT_GREETING_DELAY_MS = 400;
 const CAMERA_DRAG_IGNORE_SELECTOR =
   'button, a, label, input, textarea, select, option, [role="button"], [role="listbox"], [role="tab"], [aria-expanded], [aria-haspopup], [contenteditable="true"], [data-no-camera-drag="true"]';
@@ -124,34 +129,28 @@ function clampCompanionZoom(value: number): number {
   return Math.max(0, Math.min(1, value));
 }
 
-function loadStoredCompanionZoom(): number {
-  if (typeof localStorage === "undefined") return DEFAULT_COMPANION_ZOOM;
-  try {
-    const raw = localStorage.getItem(COMPANION_ZOOM_STORAGE_KEY);
-    if (raw === null) return DEFAULT_COMPANION_ZOOM;
-    const parsed = Number(raw);
-    return Number.isFinite(parsed)
-      ? clampCompanionZoom(parsed)
-      : DEFAULT_COMPANION_ZOOM;
-  } catch (err) {
+/**
+ * Fire-and-forget the companion stage patch to the alice-bot server.
+ * The server deep-merges the patch into `$ELIZA_DATA_DIR/companion/stage.json`
+ * and broadcasts the new full state as a `"companion-stage-state"` WS
+ * event to every connected browser (this operator, any other operator
+ * tabs, and the 555stream capture-service's headless Chromium). On
+ * the caller's own browser the echo is a no-op because the optimistic
+ * local apply at the call site already committed the same values.
+ *
+ * We don't await the promise. Network latency is ~30-80ms on the
+ * same pod; blocking `setCompanionZoom` on that round-trip would make
+ * wheel scrolling feel laggy. Failures are logged as warnings — the
+ * operator's local view is already correct via the optimistic apply,
+ * so a failed commit just means the stream won't mirror it this time.
+ */
+function commitCompanionStagePatch(patch: PartialCompanionStageState): void {
+  void client.setCompanionStageState(patch).catch((err) => {
     console.warn(
-      "[CompanionSceneHost] Failed to load stored companion zoom:",
-      err,
+      "[CompanionSceneHost] Failed to commit stage patch:",
+      err instanceof Error ? err.message : err,
     );
-    return DEFAULT_COMPANION_ZOOM;
-  }
-}
-
-function persistCompanionZoom(value: number): void {
-  if (typeof localStorage === "undefined") return;
-  try {
-    localStorage.setItem(
-      COMPANION_ZOOM_STORAGE_KEY,
-      String(clampCompanionZoom(value)),
-    );
-  } catch (err) {
-    console.warn("[CompanionSceneHost] Failed to persist companion zoom:", err);
-  }
+  });
 }
 
 function CompanionSceneSurface({
@@ -203,11 +202,6 @@ function CompanionSceneSurface({
     startZoom: 0,
   });
 
-  if (!companionZoomHydratedRef.current) {
-    companionZoomRef.current = loadStoredCompanionZoom();
-    companionZoomHydratedRef.current = true;
-  }
-
   // Lazy-mount VrmStage: only initialize the 3D engine once the scene is
   // actually needed (first time active becomes true). This prevents the WebGL
   // context and asset loads from firing in native/chat mode on startup.
@@ -215,13 +209,84 @@ function CompanionSceneSurface({
   if (active) hasEverBeenActiveRef.current = true;
   const shouldMountVrm = hasEverBeenActiveRef.current;
 
+  // Apply a full `CompanionStageState` snapshot to the local refs and
+  // every VrmEngine currently on stage. Used both by the initial REST
+  // hydration and by the `"companion-stage-state"` WS echo handler so
+  // the stream stays in lock-step with whatever authority (operator
+  // action, another operator tab, runtime-triggered mutation) pushed
+  // the update.
+  const applyCompanionStageState = useCallback(
+    (next: CompanionStageState) => {
+      companionZoomRef.current = clampCompanionZoom(next.camera.zoom);
+      for (const engine of stageEnginesRef.current) {
+        engine.setCompanionZoomNormalized(companionZoomRef.current);
+      }
+    },
+    [],
+  );
+  const applyCompanionStageStateRef = useRef(applyCompanionStageState);
+  applyCompanionStageStateRef.current = applyCompanionStageState;
+
+  // Server-authoritative hydration: on first mount, pull the current
+  // persistent stage state from the alice-bot server and subscribe to
+  // WS `"companion-stage-state"` echoes for subsequent mutations.
+  //
+  // This effect runs in BOTH the operator's browser AND the
+  // 555stream capture-service's headless Chromium — both load the
+  // same SPA, both open `/ws`, and both receive every echo. The echo
+  // handler in the operator's own browser is effectively a no-op
+  // because the optimistic apply at the call site already committed
+  // the same values; in the capture-service's Chromium the echo is
+  // the first time those values are seen, and it applies them to its
+  // own VrmEngine so the stream mirrors the operator's camera
+  // framing within a single WS round-trip.
+  useEffect(() => {
+    if (companionZoomHydratedRef.current) return;
+    companionZoomHydratedRef.current = true;
+
+    let cancelled = false;
+    void client
+      .getCompanionStageState()
+      .then((response) => {
+        if (cancelled) return;
+        if (response?.state) {
+          applyCompanionStageStateRef.current(response.state);
+        }
+      })
+      .catch((err) => {
+        console.warn(
+          "[CompanionSceneHost] Failed to hydrate stage state:",
+          err instanceof Error ? err.message : err,
+        );
+      });
+
+    const unsubscribe = client.onWsEvent(
+      "companion-stage-state",
+      (data: Record<string, unknown>) => {
+        const next = data?.state;
+        if (!next || typeof next !== "object") return;
+        applyCompanionStageStateRef.current(next as CompanionStageState);
+      },
+    );
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, []);
+
   const setCompanionZoom = useCallback((value: number) => {
     const nextZoom = clampCompanionZoom(value);
+    // Optimistic local apply — no round-trip latency for the operator.
     companionZoomRef.current = nextZoom;
-    persistCompanionZoom(nextZoom);
     for (const engine of stageEnginesRef.current) {
       engine.setCompanionZoomNormalized(nextZoom);
     }
+    // Fire-and-forget commit — server persists and broadcasts the
+    // new state to every other subscriber (notably the 555stream
+    // capture-service's headless Chromium) via the
+    // `"companion-stage-state"` WS event.
+    commitCompanionStagePatch({ camera: { zoom: nextZoom } });
   }, []);
 
   const handleStageEngineReady = useCallback((engine: VrmEngine) => {

--- a/packages/app-core/src/components/companion/CompanionSceneHost.tsx
+++ b/packages/app-core/src/components/companion/CompanionSceneHost.tsx
@@ -178,7 +178,25 @@ function CompanionSceneSurface({
   const rootRef = useRef<HTMLDivElement | null>(null);
   const stageEnginesRef = useRef(new Set<VrmEngine>());
   const companionZoomRef = useRef(DEFAULT_COMPANION_ZOOM);
-  const companionZoomHydratedRef = useRef(false);
+  /**
+   * Race guard for the hydration / WS reconciliation loop. Flipped to
+   * true by the first authoritative state application (either the GET
+   * hydration response OR an early WS echo). Subsequent GET responses
+   * drop if it's already true — this prevents a slow GET from
+   * overwriting a fresh WS push that raced it. Reset to false when
+   * `ws-reconnected` fires so the reconnect re-hydration is allowed
+   * to apply.
+   */
+  const authoritativeAppliedRef = useRef(false);
+  /**
+   * Trailing-edge debounce state for commits. Scroll wheel and pinch
+   * fire ~60 events/sec and each one carried a standalone POST in the
+   * first cut of this code, which floods the server's fs.writeFileSync
+   * path. We now accumulate the latest patch into `pendingPatchRef`
+   * and only flush after 120ms of quiescence.
+   */
+  const commitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingPatchRef = useRef<PartialCompanionStageState | null>(null);
   const dragOrbitRef = useRef({ yaw: 0, pitch: 0 });
   const dragStateRef = useRef<{
     active: boolean;
@@ -227,6 +245,51 @@ function CompanionSceneSurface({
   const applyCompanionStageStateRef = useRef(applyCompanionStageState);
   applyCompanionStageStateRef.current = applyCompanionStageState;
 
+  /**
+   * Synchronously flush any pending stage patch through the server
+   * commit path, clearing the debounce timer. Called by the timer
+   * callback itself (normal path) and by the unmount cleanup effect
+   * so the final value isn't silently dropped when the operator
+   * navigates away mid-scroll.
+   */
+  const flushPendingCommit = useCallback(() => {
+    if (commitTimerRef.current != null) {
+      clearTimeout(commitTimerRef.current);
+      commitTimerRef.current = null;
+    }
+    const pending = pendingPatchRef.current;
+    pendingPatchRef.current = null;
+    if (pending) {
+      commitCompanionStagePatch(pending);
+    }
+  }, []);
+
+  /**
+   * Schedule a trailing-edge-debounced commit of the given patch.
+   * Multiple calls within the debounce window accumulate into a
+   * single patch (the most recent value for each field wins), so a
+   * sustained scroll produces exactly one POST after the operator
+   * stops moving the wheel. The local VrmEngine is already caught up
+   * via the synchronous apply at the call site — the debounce only
+   * affects how often the stream (and other subscribers) receive
+   * updates, not how responsive the operator's own view feels.
+   */
+  const scheduleCompanionStageCommit = useCallback(
+    (patch: PartialCompanionStageState) => {
+      pendingPatchRef.current = {
+        camera: {
+          ...pendingPatchRef.current?.camera,
+          ...patch.camera,
+        },
+      };
+      if (commitTimerRef.current != null) {
+        clearTimeout(commitTimerRef.current);
+      }
+      commitTimerRef.current = setTimeout(flushPendingCommit, 120);
+    },
+    [flushPendingCommit],
+  );
+
   // Server-authoritative hydration: on first mount, pull the current
   // persistent stage state from the alice-bot server and subscribe to
   // WS `"companion-stage-state"` echoes for subsequent mutations.
@@ -240,54 +303,103 @@ function CompanionSceneSurface({
   // the first time those values are seen, and it applies them to its
   // own VrmEngine so the stream mirrors the operator's camera
   // framing within a single WS round-trip.
+  //
+  // The effect intentionally has no mount-time dedupe. Earlier
+  // revisions of this code used a `companionZoomHydratedRef` to avoid
+  // re-firing the GET in strict-mode's double-invoke, but that breaks
+  // strict mode — on the second mount the ref is still true (refs
+  // persist across strict mode's mount/cleanup/remount) so the early
+  // return fires and the WS handler is never re-registered, leaving
+  // the dev-mode browser without any reconciliation subscription.
+  // Letting the effect run cleanly on every mount is correct: `fetch`
+  // is idempotent, the cleanup properly unsubscribes the previous
+  // handler, and the second mount re-subscribes.
   useEffect(() => {
-    if (companionZoomHydratedRef.current) return;
-    companionZoomHydratedRef.current = true;
-
     let cancelled = false;
-    void client
-      .getCompanionStageState()
-      .then((response) => {
-        if (cancelled) return;
-        if (response?.state) {
-          applyCompanionStageStateRef.current(response.state);
-        }
-      })
-      .catch((err) => {
-        console.warn(
-          "[CompanionSceneHost] Failed to hydrate stage state:",
-          err instanceof Error ? err.message : err,
-        );
-      });
 
-    const unsubscribe = client.onWsEvent(
+    const hydrateFromServer = () => {
+      void client
+        .getCompanionStageState()
+        .then((response) => {
+          if (cancelled || !response?.state) return;
+          // Race guard: if a WS push already applied authoritative
+          // state while this GET was in flight, the GET is stale by
+          // definition. Drop it so we don't overwrite fresher data.
+          if (authoritativeAppliedRef.current) return;
+          authoritativeAppliedRef.current = true;
+          applyCompanionStageStateRef.current(response.state);
+        })
+        .catch((err) => {
+          console.warn(
+            "[CompanionSceneHost] Failed to hydrate stage state:",
+            err instanceof Error ? err.message : err,
+          );
+        });
+    };
+
+    // Initial hydration on mount.
+    hydrateFromServer();
+
+    // Subscribe to persistent state updates. This is the primary way
+    // the broadcast Chromium learns about operator-originated zoom
+    // changes, and the way any operator tab learns about agent- or
+    // other-tab-originated mutations.
+    const unsubscribeState = client.onWsEvent(
       "companion-stage-state",
       (data: Record<string, unknown>) => {
         const next = data?.state;
         if (!next || typeof next !== "object") return;
+        authoritativeAppliedRef.current = true;
         applyCompanionStageStateRef.current(next as CompanionStageState);
       },
     );
 
+    // Subscribe to WS reconnect signal. Messages sent during a
+    // disconnect gap are lost, so we re-fetch the canonical state
+    // from REST to close the gap. Mirrors the pattern
+    // AppContext.tsx:7564 uses for PTY sessions. Reset the race
+    // guard first so the re-hydration GET is allowed to apply.
+    const unsubscribeReconnect = client.onWsEvent("ws-reconnected", () => {
+      authoritativeAppliedRef.current = false;
+      hydrateFromServer();
+    });
+
     return () => {
       cancelled = true;
-      unsubscribe();
+      unsubscribeState();
+      unsubscribeReconnect();
     };
   }, []);
 
-  const setCompanionZoom = useCallback((value: number) => {
-    const nextZoom = clampCompanionZoom(value);
-    // Optimistic local apply — no round-trip latency for the operator.
-    companionZoomRef.current = nextZoom;
-    for (const engine of stageEnginesRef.current) {
-      engine.setCompanionZoomNormalized(nextZoom);
-    }
-    // Fire-and-forget commit — server persists and broadcasts the
-    // new state to every other subscriber (notably the 555stream
-    // capture-service's headless Chromium) via the
-    // `"companion-stage-state"` WS event.
-    commitCompanionStagePatch({ camera: { zoom: nextZoom } });
-  }, []);
+  // Flush any pending debounced commit on unmount so the final zoom
+  // value isn't silently dropped when the operator navigates away
+  // mid-scroll. The POST fires fire-and-forget via the module-level
+  // `client` singleton and doesn't depend on any component state.
+  useEffect(() => {
+    return () => {
+      flushPendingCommit();
+    };
+  }, [flushPendingCommit]);
+
+  const setCompanionZoom = useCallback(
+    (value: number) => {
+      const nextZoom = clampCompanionZoom(value);
+      // Optimistic local apply — no round-trip latency for the operator.
+      companionZoomRef.current = nextZoom;
+      for (const engine of stageEnginesRef.current) {
+        engine.setCompanionZoomNormalized(nextZoom);
+      }
+      // Trailing-edge debounced commit — server persists and
+      // broadcasts the new state to every other subscriber (notably
+      // the 555stream capture-service's headless Chromium) via the
+      // `"companion-stage-state"` WS event. Debouncing collapses a
+      // sustained scroll into a single POST after 120ms of
+      // quiescence, which keeps the stream in sync without flooding
+      // `fs.writeFileSync` on the server.
+      scheduleCompanionStageCommit({ camera: { zoom: nextZoom } });
+    },
+    [scheduleCompanionStageCommit],
+  );
 
   const handleStageEngineReady = useCallback((engine: VrmEngine) => {
     stageEnginesRef.current.add(engine);

--- a/packages/app-core/src/components/companion/companion-stage-state.ts
+++ b/packages/app-core/src/components/companion/companion-stage-state.ts
@@ -1,0 +1,148 @@
+/**
+ * Companion stage state — server-authoritative visual state for the
+ * companion view.
+ *
+ * ## Why this exists
+ *
+ * Before this module, every piece of scene-level visual state in the
+ * companion view lived in per-browser `localStorage` + React refs + the
+ * `VrmEngine` instance. Camera zoom was stored under
+ * `localStorage["milady.companion.zoom.v1"]`, camera rotation was held
+ * in a component-local `dragOrbitRef`, character vrm was synced via a
+ * separate `/api/stream/settings` endpoint, emotes went through yet
+ * another path (`/api/emote` → `broadcastWs` → `"emote"` event).
+ * Nothing unified. Nothing authoritative.
+ *
+ * Once the 555stream capture-service started loading the same milaidy
+ * SPA at `?broadcast=1` inside a headless Chromium to render the Twitch
+ * / Kick "camera frame", the per-browser approach broke in the obvious
+ * way: the operator's own browser and the capture-service's browser
+ * became two independent React processes with two independent
+ * `localStorage` stores, so operator interactions never crossed the
+ * boundary. Zooming the operator's view didn't change the stream.
+ *
+ * The `CompanionStageState` lives on the alice-bot server
+ * (`$ELIZA_DATA_DIR/companion/stage.json` via
+ * `packages/agent/src/api/misc-routes.ts`). Both the operator's browser
+ * and the capture-service's headless Chromium subscribe to it through
+ * the existing `/ws` channel, receive the same state updates, and
+ * render them identically. Operator commands flow as REST mutations
+ * (`POST /api/companion/stage`) and the server echoes the new state
+ * back over WS to all subscribers. This is exactly the same shape as
+ * `conversationMessages`, `agentStatus`, and the existing `"emote"`
+ * event — we're just extending it to cover camera state.
+ *
+ * ## Phase 1 scope
+ *
+ * Phase 1 only covers the `camera` slice: `zoom`, `yaw`, `pitch`,
+ * `pan`. Future phases will add other scene state (character vrmIndex,
+ * scene preset / theme override, expressions, etc.) to the same
+ * service so there's one authority, one channel, one mutation path.
+ * Emotes stay on `/api/emote` for now — that pipe already works
+ * end-to-end through the WS echo pattern and the migration to
+ * `companion-stage-cue` is a Phase 4 cleanup, not a correctness fix.
+ */
+
+/**
+ * Camera framing for the companion view.
+ *
+ * All values are normalized:
+ * - `zoom`: 0 (widest) .. 1 (closest). `VrmEngine.setCompanionZoomNormalized`
+ *   maps this to the underlying camera distance. Default 0.95 matches
+ *   the legacy `DEFAULT_COMPANION_ZOOM` constant in CompanionSceneHost.
+ * - `yaw` / `pitch`: radians, applied to the camera orbit target.
+ *   Default 0 — the VRM model centered straight-on.
+ * - `pan`: horizontal camera offset used by the character editor; 0
+ *   means no offset. Most scenes leave this untouched.
+ */
+export interface CompanionStageCamera {
+  zoom: number;
+  yaw: number;
+  pitch: number;
+  pan: number;
+}
+
+export interface CompanionStageState {
+  camera: CompanionStageCamera;
+}
+
+/**
+ * Partial mutation shape — clients send this to the server; the server
+ * deep-merges it into the persistent state. Missing fields are left
+ * unchanged.
+ */
+export interface PartialCompanionStageState {
+  camera?: Partial<CompanionStageCamera>;
+}
+
+/**
+ * Defaults applied both server-side (when `stage.json` is missing) and
+ * client-side (before hydration completes). The zoom default matches
+ * the legacy `DEFAULT_COMPANION_ZOOM = 0.95` constant so existing
+ * captures don't visually jump on the first deploy.
+ */
+export const DEFAULT_COMPANION_STAGE_STATE: CompanionStageState = {
+  camera: {
+    zoom: 0.95,
+    yaw: 0,
+    pitch: 0,
+    pan: 0,
+  },
+};
+
+/**
+ * Deep-merge a partial patch into a full state, producing a new full
+ * state. Used both on the server (to persist the merged result) and on
+ * the client (for optimistic local updates before the echo arrives).
+ *
+ * Intentionally shallow — we only have one nested slice (`camera`) so
+ * a recursive merge would be overkill. When Phase 2+ adds more slices,
+ * extend this by spreading each slice individually.
+ */
+export function mergeCompanionStageState(
+  base: CompanionStageState,
+  patch: PartialCompanionStageState,
+): CompanionStageState {
+  return {
+    camera: {
+      ...base.camera,
+      ...(patch.camera ?? {}),
+    },
+  };
+}
+
+/**
+ * Clamp helpers kept alongside the state module so client and server
+ * agree on the bounds. A rejected clamp just silently snaps into
+ * range — we trust both sides to behave, but defend against clients
+ * sending `Infinity` or `NaN`.
+ */
+export function clampCompanionStageCamera(
+  camera: CompanionStageCamera,
+): CompanionStageCamera {
+  return {
+    zoom: clamp01(camera.zoom, DEFAULT_COMPANION_STAGE_STATE.camera.zoom),
+    yaw: clampFinite(camera.yaw, 0, -Math.PI, Math.PI),
+    pitch: clampFinite(camera.pitch, 0, -Math.PI / 2, Math.PI / 2),
+    pan: clampFinite(camera.pan, 0, -5, 5),
+  };
+}
+
+function clamp01(value: number, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+function clampFinite(
+  value: number,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (!Number.isFinite(value)) return fallback;
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}


### PR DESCRIPTION
## Summary

First slice of the unified `CompanionStageState` architecture: make camera **zoom** server-authoritative so the operator's browser and the 555stream capture-service's headless Chromium render identical framing.

Before: zoom lived in per-browser `localStorage["milady.companion.zoom.v1"]`. Two independent browser processes = two independent stores, so operator zoom interactions never crossed to the stream. The broadcast Chromium was pinned to `DEFAULT_COMPANION_ZOOM` forever.

After: zoom lives at `$ELIZA_DATA_DIR/companion/stage.json` on the alice-bot pod, served by `GET /api/companion/stage` for initial hydration and mutated by `POST /api/companion/stage` with a `{ patch }` body. Every mutation is broadcast to all `/ws` subscribers as a `"companion-stage-state"` event — reusing the exact same `broadcastWs()` infrastructure that already carries `"emote"`, `"avatar-face-frame"`, `"status"`, `"proactive-message"`, and `"heartbeat_event"`. No new pipes; new cargo on an existing pipe.

## Why this shape

The architectural principle (from the expert review that kicked off this phased migration): **any companion state that's visible on the rendered frame should be server-authoritative; any state that's only operator ergonomics stays local.** Zoom is on the rendered frame. It was the last operator-controlled visual parameter that wasn't on the WS pipe. Fixing it alone would be a band-aid — fixing it *via* a reusable `CompanionStageState` service lays the groundwork for Phase 2+ (character swap, scene preset, pose/expression, etc.) to drop in without new infrastructure.

The 30-80ms latency between wheel tick and stream update is masked on the operator side by **optimistic local apply**: `setCompanionZoom` updates the local \`VrmEngine\` immediately, then fires the POST in the background. The operator never waits. The stream receives the WS echo and applies it. The operator's own WS echo is a no-op because the values already match.

## Scope

### What this PR does

- **Server**: two new routes + persistence helpers in \`packages/agent/src/api/misc-routes.ts\` (next to the existing \`/api/emote\` route, same file, same pattern).
- **Client types**: new \`packages/app-core/src/components/companion/companion-stage-state.ts\` with \`CompanionStageState\`, \`PartialCompanionStageState\`, \`DEFAULT_COMPANION_STAGE_STATE\`, and clamp helpers.
- **Client API**: new \`getCompanionStageState()\` + \`setCompanionStageState(patch)\` methods on the \`MiladyClient\` class in \`packages/app-core/src/api/client.ts\`, right next to \`playEmote()\`.
- **Client wiring**: \`CompanionSceneHost.tsx\` rewires \`setCompanionZoom\` to optimistic-local + server commit. Adds a mount-time \`useEffect\` that hydrates via REST and subscribes to the \`"companion-stage-state"\` WS echo for subsequent updates (reconciliation loop). Deletes \`loadStoredCompanionZoom\`, \`persistCompanionZoom\`, and the \`COMPANION_ZOOM_STORAGE_KEY\` constant.
- **Test**: updates \`CompanionSceneHost.scroll-guard.test.ts\` to assert a POST to \`/api/companion/stage\` instead of a \`localStorage.setItem\` call.

### What this PR explicitly does NOT do

- **Drag orbit (yaw/pitch)** stays local. The drag rotation in \`CompanionSceneHost\` resets back to zero at pointerup — it's gestural operator peek-around input, not persistent rotation intended for the viewer. If we want persistent rotation later, the \`camera.yaw\` / \`camera.pitch\` fields are already reserved in the state type.
- **Emotes** stay on \`/api/emote\`. I was going to migrate them until deeper investigation revealed the \`/api/emote\` → \`broadcastWs({ type: "emote" })\` → \`onWsEvent("emote", ...)\` → \`VrmStage.playEmote()\` loop is already fully server-authoritative and already reaches the broadcast Chromium. Migrating it would be pure duplication. The ported-to-\`COMPANION_STAGE_CUE\` pattern is Phase 4 cleanup work for architectural consistency, not a correctness fix.
- **Character swap** still uses the legacy \`/api/stream/settings\` endpoint. Phase 3.
- **Scene preset / theme override** still uses \`useCompanionSceneConfig\`. Phase 3.

## Test plan

- [x] \`packages/app-core\` typecheck — zero new errors in edited files. Baseline 479 pre-existing errors in unrelated \`../agent/\`, \`../../eliza/\`, and \`src/\` files are untouched.
- [x] \`packages/agent\` typecheck — zero errors in \`misc-routes.ts\`.
- [ ] Webhook deploy builds alice-bot image, rolls deployment.
- [ ] Visit \`https://alice.rndrntwrk.com\`, open Network panel, scroll-zoom on companion view. Confirm \`POST /api/companion/stage\` fires with \`{ patch: { camera: { zoom } } }\` body.
- [ ] Confirm the scroll ALSO works locally (optimistic apply is immediate — no lag waiting on the POST).
- [ ] Reload the operator's browser. Confirm zoom is restored from the server, not the deleted \`localStorage["milady.companion.zoom.v1"]\` key. Verify the legacy key is no longer present in DevTools → Application → Local Storage.
- [ ] Run \`STREAM555_GO_LIVE\` smoke against \`?broadcast=1\`. On Twitch/Kick, zoom the operator's view in/out. Confirm the stream camera framing mirrors it within one WS round-trip (should look like a single frame of delay).
- [ ] Restart the alice-bot pod. Confirm the zoom persists across the restart (reads from \`\$ELIZA_DATA_DIR/companion/stage.json\` on the PVC).
- [ ] Open two operator tabs. Zoom in one. Confirm the other tab receives the WS echo and updates. (Both operator tabs and the broadcast Chromium are just different subscribers of the same channel.)

## Related

- Builds on #68–#72 (broadcast view end-to-end)
- Stacks orthogonally with #73 (scene overlay bridge mount — that's the chat panel fix; this is camera state)
- Next up — Phase 2: persistent pose / idle animation selection
- Phase 3: character swap + scene preset
- Phase 4: emote pipe cleanup (migrate to \`COMPANION_STAGE_CUE\` for consistency, even though functionality already works)