### PR TITLE
fix(companion-stage): persist state to MILAIDY_HOME PVC, not ephemeral layer

### DIFF
--- a/packages/agent/src/api/misc-routes.ts
+++ b/packages/agent/src/api/misc-routes.ts
@@ -55,8 +55,31 @@ const DEFAULT_COMPANION_STAGE_STATE: CompanionStageState = {
   },
 };
 
+/**
+ * Persistence root for the companion stage state file.
+ *
+ * Resolution order:
+ *   1. `MILAIDY_HOME` — the alice-bot k8s deployment mounts its PVC at
+ *      `/home/node/.milaidy` and exports this env var to every process
+ *      in the container. This is the ONLY path that survives pod
+ *      rollouts and restarts.
+ *   2. `ELIZA_DATA_DIR` — legacy fallback used by `stream-persistence.ts`
+ *      and other persistence modules. Not currently set on the
+ *      alice-bot pod (both variables are resolved, but the first wins).
+ *   3. `process.cwd() + "/data"` — final fallback for local development
+ *      (where neither env var is set). Lands in the repo checkout, not
+ *      in a shared volume — fine for dev, wrong for production.
+ *
+ * Phase 1 of the companion stage service shipped with only options
+ * (2) and (3). On the alice-bot pod that put the file at
+ * `/app/milaidy/data/companion/stage.json`, inside the container's
+ * ephemeral writable layer — functional within a session but wiped on
+ * every deploy. Fixed here by preferring `MILAIDY_HOME` first.
+ */
 const COMPANION_STAGE_DIR = path.join(
-  process.env.ELIZA_DATA_DIR || path.join(process.cwd(), "data"),
+  process.env.MILAIDY_HOME ||
+    process.env.ELIZA_DATA_DIR ||
+    path.join(process.cwd(), "data"),
   "companion",
 );
 const COMPANION_STAGE_FILE = path.join(COMPANION_STAGE_DIR, "stage.json");


### PR DESCRIPTION
## Summary

One-line fix for a persistence path bug discovered during PR #74 smoke testing on production.

PR #74 shipped `COMPANION_STAGE_DIR` resolving via:

```ts
const COMPANION_STAGE_DIR = path.join(
  process.env.ELIZA_DATA_DIR || path.join(process.cwd(), "data"),
  "companion",
);
```

On the alice-bot production pod:
- \`ELIZA_DATA_DIR\` is not set as an env var
- \`process.cwd()\` is \`/app/milaidy\`
- Result: \`/app/milaidy/data/companion/stage.json\` — **inside the container's ephemeral writable layer**

The only PVC mount on the pod is \`/home/node/.milaidy\`, exported via \`MILAIDY_HOME\` to every process. Anything outside that prefix does not survive deploys.

Verified on the running pod:

\`\`\`
\$ kubectl exec alice-bot-dc868bbd5-kvln8 -- find / -name stage.json -type f
/app/milaidy/data/companion/stage.json

\$ kubectl exec alice-bot-dc868bbd5-kvln8 -- mount | grep milaidy
/dev/nvme0n1p4 on /home/node/.milaidy type ext4 (rw,relatime)
\`\`\`

## Symptom

In-memory state works correctly through a pod's lifetime — operator zoom → server merge → WS broadcast → capture Chromium → stream, all within one session. Verified end-to-end during PR #74 smoke testing.

But the next deploy wipes \`stage.json\` and every browser that reconnects re-hydrates from \`DEFAULT_COMPANION_STAGE_STATE\` (\`camera.zoom = 0.95\`). The operator's carefully tuned framing resets on every rollout.

## Fix

Prefer \`MILAIDY_HOME\` in the env resolution chain:

\`\`\`diff
 const COMPANION_STAGE_DIR = path.join(
-  process.env.ELIZA_DATA_DIR || path.join(process.cwd(), "data"),
+  process.env.MILAIDY_HOME ||
+    process.env.ELIZA_DATA_DIR ||
+    path.join(process.cwd(), "data"),
   "companion",
 );
\`\`\`

On alice-bot this resolves to \`/home/node/.milaidy/companion/stage.json\` — on the ext4 PVC, survives rollouts. On local dev (neither env var set) it still falls through to the repo checkout. On any ElizaOS deployment that sets \`ELIZA_DATA_DIR\` but not \`MILAIDY_HOME\`, behavior is unchanged from PR #74.

No migration. \`stage.json\` has only existed for ~30 minutes on prod since PR #74 deployed, and the single zoom value it holds is one scroll tick away from being reset by the operator anyway.

## Known pre-existing bug, not fixed here

\`packages/agent/src/api/stream-persistence.ts:36-41\` has the same shape:

\`\`\`ts
const OVERLAY_DIR = path.join(
  process.env.ELIZA_DATA_DIR || path.join(process.cwd(), "data"),
  "stream",
);
\`\`\`

Which means \`/api/stream/settings\` (theme, avatarIndex, voice config) lands in the ephemeral layer too and gets wiped on every deploy. Nobody's noticed because:
1. Most operator changes route through \`/api/companion/stage\` now
2. The few that still use \`/api/stream/settings\` are re-set manually after each deploy
3. \`avatarIndex\` defaults to a reasonable value and nobody cares about voice config drift

Out of scope here to keep this a one-line surgical fix. Worth a sibling follow-up that adds \`MILAIDY_HOME\` to that path too, and probably introduces a shared \`resolveMilaidyDataDir()\` helper so the two paths don't drift.

## Test plan

- [x] \`packages/app-core\` typecheck — zero new errors in \`misc-routes.ts\`.
- [ ] Webhook deploy rolls new alice-bot image with this fix.
- [ ] On the new pod: \`kubectl exec -- cat \$MILAIDY_HOME/companion/stage.json\` returns \`{camera:{...}}\` after first \`POST\`.
- [ ] Force a second rollout (\`kubectl rollout restart deployment/alice-bot\`) and confirm the file survives.
- [ ] Visit \`https://alice.rndrntwrk.com\`, scroll-zoom to a non-default value, wait for deploy cycle, reload, confirm zoom is restored from the persistent file.

## Related

- PR #74 — shipped the buggy path
- Pre-existing bug in \`stream-persistence.ts\` — file as follow-up after this merges