### PR TITLE
fix(broadcast): bridge capture-service auth token so WS events reach the stream

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -622,6 +622,43 @@ async function runMain(): Promise<void> {
       /* storage unavailable — the coordinator's own try/catch handles this */
     }
 
+    // Bridge the capture-service's auth token into the SPA's API client.
+    //
+    // The 555stream capture-service worker injects
+    //   window.__injectedShowConfig = { wsToken: "...", ... }
+    // into the page via page.evaluateOnNewDocument() before navigating
+    // to the broadcast URL. The wsToken is the same ELIZA_SERVER_AUTH_TOKEN
+    // the server uses — it proves to the alice-bot API that this browser
+    // is authorized.
+    //
+    // Without this bridge, the SPA's API client has no token. REST calls
+    // to /api/status fail with 401, the AppContext setup effect returns
+    // early before reaching client.connectWs(), and the WS connection is
+    // never established. Result: broadcastWs() iterates zero clients, no
+    // emotes / face frames / companion-stage-state / status events ever
+    // reach the broadcast Chromium, and the stream shows a static avatar
+    // that never reacts to operator actions.
+    //
+    // By setting the token here (before mountReactApp), it's available to
+    // the API client's first getStatus() call and to the subsequent
+    // connectWs() → {type:"auth", token} handshake. This unblocks EVERY
+    // WS event type at once: emote, avatar-face-frame,
+    // companion-stage-state, status, proactive-message, heartbeat_event.
+    try {
+      const injectedConfig = (
+        window as unknown as {
+          __injectedShowConfig?: { wsToken?: string };
+        }
+      ).__injectedShowConfig;
+      if (injectedConfig?.wsToken) {
+        setBootConfig({ ...getBootConfig(), apiToken: injectedConfig.wsToken });
+      }
+    } catch {
+      /* injectedShowConfig not available — capture-service may not have
+         injected it (local dev, direct browser access to ?broadcast). The
+         SPA falls back to its normal token resolution chain. */
+    }
+
     injectPopoutApiBase();
     mountReactApp();
     return;


### PR DESCRIPTION
## The bug

Operator clicks WAVE on the Action Log panel. Alice waves on the operator's browser. Alice does NOT wave on Twitch/Kick. Same for every emote, every face frame, every zoom change (PR #74), every agent status update. The stream shows a static avatar that never reacts to operator actions.

## Root cause

The 555stream capture-service injects \`window.__injectedShowConfig = { wsToken: "..." }\` into the headless Chromium before navigating to \`/?broadcast=1\`. **The SPA never reads it.**

Without the token:
1. AppContext's setup effect polls \`/api/status\` with no \`x-eliza-token\` header
2. Server returns 401
3. Effect returns early, never reaching \`client.connectWs()\` (line 7541)
4. WS connection is never established
5. \`broadcastWs()\` iterates zero clients on every event
6. \`POST /api/emote\` returns \`{ok: true}\` but nobody receives the broadcast

## The fix

One \`setBootConfig()\` call in the broadcast boot path at \`apps/app/src/main.tsx\`:

\`\`\`ts
const injectedConfig = (window as any).__injectedShowConfig;
if (injectedConfig?.wsToken) {
  setBootConfig({ ...getBootConfig(), apiToken: injectedConfig.wsToken });
}
\`\`\`

Placed after the onboarding localStorage seed and before \`mountReactApp()\`, so the token is available to the API client's first REST call and the subsequent WS auth handshake.

## What this unblocks

Everything that flows through the \`/ws\` channel:

| Event type | Source | Before this fix | After |
|---|---|---|---|
| \`emote\` | Action Log gestures | Static avatar | Alice waves/dances/emotes on stream |
| \`avatar-face-frame\` | Speech/expression | No facial animation | Lip sync + expressions on stream |
| \`companion-stage-state\` | PR #74 zoom | Zoom stuck at default | Stream mirrors operator zoom |
| \`status\` | Agent lifecycle | No status updates | Stream overlay shows agent state |
| \`proactive-message\` | Agent chat | No chat updates | Chat panel overlay updates on stream |
| \`heartbeat_event\` | Triggers | No heartbeat updates | Trigger overlay updates on stream |

## Industry validation

Research into LiveKit Web Egress, OBS Browser Source VTuber patterns, and Colyseus game server state sync all confirm: WebSocket relay between operator and headless capture renderer is the standard architecture. The pipe was correctly wired end-to-end from PRs #68-75. It just wasn't pressurized because the auth token handoff was missing.

## Test plan

- [ ] Webhook deploy builds new alice-bot image
- [ ] Run \`STREAM555_GO_LIVE\` against \`?broadcast=1\`
- [ ] Check capture-service-gpu logs for \`[AgentShow:Browser]\` console messages — should now see VrmEngine activity, WS connection logs, emote retarget logs (previously ZERO browser console messages appeared after initial boot)
- [ ] Click WAVE on operator's Action Log panel → confirm Alice waves on Twitch/Kick within ~15s (stream latency)
- [ ] Scroll-zoom on operator's companion view → confirm stream camera framing changes (PR #74 zoom sync, previously broken for the same auth reason)
- [ ] Verify agent status overlay updates on stream (if SceneOverlayDataBridge from PR #73 is working)

## Related

- #68-#72 — broadcast view pipeline
- #73 — scene overlay bridge mount (chat panel)
- #74 — companion stage service (camera zoom)
- #75 — persistence path fix

This is the keystone fix that makes #73 and #74 actually functional on the stream.