### PR TITLE
fix(broadcast): extract alice-bot auth token from URL param, not 555stream JWT

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -622,6 +622,48 @@ async function runMain(): Promise<void> {
       /* storage unavailable — the coordinator's own try/catch handles this */
     }
 
+    // Bridge the alice-bot's auth token into the SPA's API client.
+    //
+    // The broadcast Chromium needs the alice-bot's ELIZA_SERVER_AUTH_TOKEN
+    // to authenticate REST calls (/api/status, /api/companion/stage) and
+    // the WS handshake ({type:"auth", token}). Without it, AppContext's
+    // setup effect hits 401, never reaches client.connectWs(), and no WS
+    // events (emotes, face frames, zoom sync) reach the stream.
+    //
+    // Token resolution:
+    //   1. URL param ?apiToken= — primary. The go-live flow runs inside
+    //      the alice-bot pod and appends ELIZA_SERVER_AUTH_TOKEN to the
+    //      broadcast URL. Secure: alice-bot:3000 is ClusterIP, internal.
+    //   2. __injectedShowConfig.wsToken — fallback. Currently a 555stream
+    //      JWT (wrong token type), kept for forward-compat if the capture-
+    //      service is updated to inject the correct token here.
+    {
+      const params = new URLSearchParams(
+        window.location.search || window.location.hash.split("?")[1] || "",
+      );
+      const urlToken = params.get("apiToken");
+      if (urlToken) {
+        setBootConfig({ ...getBootConfig(), apiToken: urlToken });
+      }
+      if (!urlToken) {
+        try {
+          const injectedConfig = (
+            window as unknown as {
+              __injectedShowConfig?: { wsToken?: string };
+            }
+          ).__injectedShowConfig;
+          if (injectedConfig?.wsToken) {
+            setBootConfig({
+              ...getBootConfig(),
+              apiToken: injectedConfig.wsToken,
+            });
+          }
+        } catch {
+          /* injectedShowConfig not available */
+        }
+      }
+    }
+
     injectPopoutApiBase();
     mountReactApp();
     return;


### PR DESCRIPTION
## The bug in PR #76

PR #76 correctly identified that the broadcast Chromium needs an auth token to connect to the alice-bot's WS. It bridged `__injectedShowConfig.wsToken` into the boot config. But that token is a **555stream-scoped renderer JWT** (`jwt.sign({id, scope:"renderer"}, JWT_SECRET)`), NOT the alice-bot's `ELIZA_SERVER_AUTH_TOKEN`.

The alice-bot's auth check (`isAuthorized(req)`) does a simple string comparison: `x-eliza-token === ELIZA_SERVER_AUTH_TOKEN`. A 555stream JWT will never match. Result: still 401 on `/api/status`, still no WS connection, still no emotes on stream.

## The fix

The go-live flow runs inside the alice-bot pod, which has `ELIZA_SERVER_AUTH_TOKEN` in its env. The smoke script now appends `&apiToken=$ELIZA_SERVER_AUTH_TOKEN` to the broadcast URL. The SPA extracts it via `URLSearchParams` as the primary token source.

```
http://alice-bot:3000/?broadcast=1&apiToken=<ELIZA_SERVER_AUTH_TOKEN>
```

This is secure: `alice-bot:3000` is a ClusterIP service, internal to the k8s cluster, never exposed to the internet. The token only travels within the pod network.

The `__injectedShowConfig.wsToken` fallback is kept for forward-compat in case the capture-service is later updated to inject the correct token.

## Test plan

- [ ] Deploy new alice-bot image
- [ ] Stop any existing stream, run updated smoke script (already staged on host)
- [ ] Verify capture-service-gpu logs show `[AgentShow:Browser]` console activity BEYOND the initial 5 boot messages (proves WS connected + AppContext setup completed)
- [ ] Fire wave emote, see `[retargetMixamoFbx]` in browser console (proves emote reached Chromium via WS)
- [ ] Visual check on Twitch: Alice waves