### PR TITLE
feat(broadcast): publish VRM canvas to LiveKit room (frontier architecture step 1)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -615,6 +615,7 @@
         "@stwd/sdk": "^0.3.0",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
+        "livekit-client": "^2.17.1",
         "lucide-react": "^0.575.0",
         "three": "^0.183.2",
         "zod": "^4.3.6",
@@ -8288,5 +8289,31 @@
     "@elizaos/plugin-secrets-manager-root/@vitest/coverage-v8/test-exclude/glob/jackspeak/@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "@elizaos/plugin-secrets-manager-root/@vitest/coverage-v8/test-exclude/glob/jackspeak/@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "@livekit/mutex": ["@livekit/mutex@1.1.1", "", {}, "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw=="],
+
+    "@livekit/protocol": ["@livekit/protocol@1.45.3", "", { "dependencies": { "@bufbuild/protobuf": "^1.10.0" } }, "sha512-WmMxBTsy4dRBqcrswFwUUlgq3Z0nnhOqKR6tX749Rb/PcB1yBMUtrHxZvcsS6qi3/5+86zHeVG+exmu1sZqfJg=="],
+
+    "@types/dom-mediacapture-record": ["@types/dom-mediacapture-record@1.0.22", "", {}, "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
+
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "livekit-client": ["livekit-client@2.18.3", "", { "dependencies": { "@livekit/mutex": "1.1.1", "@livekit/protocol": "1.45.3", "events": "^3.3.0", "jose": "^6.1.0", "loglevel": "^1.9.2", "sdp-transform": "^2.15.0", "tslib": "2.8.1", "typed-emitter": "^2.1.0", "webrtc-adapter": "^9.0.1" }, "peerDependencies": { "@types/dom-mediacapture-record": "^1" } }, "sha512-A8QDaVPo+Ye35bJFyKe6PjMOtY33dmdRXGKP/3+BG48ynEES3YwFzHbsPHJiScgI4OZouNef3Ew/BPazXKwo8Q=="],
+
+    "loglevel": ["loglevel@1.9.2", "", {}, "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg=="],
+
+    "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
+
+    "sdp": ["sdp@3.2.2", "", {}, "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA=="],
+
+    "sdp-transform": ["sdp-transform@2.15.0", "", { "bin": { "sdp-verify": "checker.js" } }, "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw=="],
+
+    "typed-emitter": ["typed-emitter@2.1.0", "", { "optionalDependencies": { "rxjs": "*" } }, "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA=="],
+
+    "webrtc-adapter": ["webrtc-adapter@9.0.4", "", { "dependencies": { "sdp": "^3.2.0" } }, "sha512-5ZZY1+lGq8LEKuDlg9M2RPJHlH3R7OVwyHqMcUsLKCgd9Wvf+QrFTCItkXXYPmrJn8H6gRLXbSgxLLdexiqHxw=="],
+
+    "@livekit/protocol/@bufbuild/protobuf": ["@bufbuild/protobuf@1.10.1", "", {}, "sha512-Aebz25eN8NwX0ngvWMnLtUeCqVGWPSqd0L5hkNAcMhl9mYGACAUj7iiEl9aBl3nmIqu7rUKXjIhcOOTfOh1cog=="],
   }
 }

--- a/packages/agent/src/api/misc-routes.ts
+++ b/packages/agent/src/api/misc-routes.ts
@@ -324,13 +324,48 @@ export async function handleMiscRoutes(
       error(res, `Unknown emote: ${body.emoteId ?? "(none)"}`);
       return true;
     }
-    state.broadcastWs?.({
-      type: "emote",
+    const emotePayload = {
       emoteId: emote.id,
       path: emote.path,
       duration: emote.duration,
       loop: false,
-    });
+    };
+    // Existing operator-UI path: browser clients listening on the WS
+    // receive the emote and dispatch it to their local VrmStage. This
+    // is how the operator's tab sees an emote when they click it.
+    state.broadcastWs?.({ type: "emote", ...emotePayload });
+
+    // New broadcast path: when a 555stream session is currently live
+    // with the LiveKit broadcast flag, forward the emote as a LiveKit
+    // data message so the capture-service's headless Chromium
+    // (subscribing via LiveKitBroadcastPublisher's DataReceived
+    // handler) dispatches the same `eliza:app-emote` window event and
+    // VrmStage plays the animation on the rendered video track going
+    // to Cloudflare → Twitch/Kick. Fire-and-forget: if the 555stream
+    // plugin isn't installed, isn't initialized, or the call fails,
+    // the operator UI still gets the emote via the WS path above.
+    // Service name matches StreamControlService.serviceType in
+    // 555stream's plugin-555stream package.
+    const streamControl =
+      (state.runtime?.getService?.("stream555") as
+        | {
+            broadcastEvent?: (
+              topic: string,
+              payload: unknown,
+            ) => Promise<unknown>;
+          }
+        | undefined) ?? undefined;
+    if (streamControl && typeof streamControl.broadcastEvent === "function") {
+      void streamControl
+        .broadcastEvent("emote", emotePayload)
+        .catch((err: unknown) => {
+          logger.debug?.(
+            "[misc-routes] LiveKit emote broadcast failed (non-fatal):",
+            err instanceof Error ? err.message : err,
+          );
+        });
+    }
+
     json(res, { ok: true });
     return true;
   }

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -86,6 +86,7 @@
     "@miladyai/ui": "workspace:*",
     "@miladyai/vrm-utils": "workspace:*",
     "@stwd/sdk": "^0.3.0",
+    "livekit-client": "^2.17.1",
     "lucide-react": "^0.575.0",
     "three": "^0.183.2",
     "zod": "^4.3.6",

--- a/packages/app-core/src/components/avatar/VrmViewer.tsx
+++ b/packages/app-core/src/components/avatar/VrmViewer.tsx
@@ -580,6 +580,12 @@ export function VrmViewer(props: VrmViewerProps) {
   return (
     <canvas
       ref={canvasRef}
+      // Stable marker so the broadcast-mode LiveKit publisher can find
+      // this canvas via `document.querySelector("canvas[data-vrm-canvas]")`.
+      // Without this, the publisher would rely on tag-name queries which
+      // match other canvases (MathEnvironment shadow canvas, blend-shape
+      // debug canvas, etc.).
+      data-vrm-canvas="true"
       onPointerDown={(event) => {
         if (!pointerParallaxRef.current) return;
         pointerStateRef.current = {

--- a/packages/app-core/src/components/companion/LiveKitBroadcastPublisher.tsx
+++ b/packages/app-core/src/components/companion/LiveKitBroadcastPublisher.tsx
@@ -60,12 +60,17 @@
 
 import { memo, useEffect, useRef, useState } from "react";
 import {
+  DataPacket_Kind,
   LocalVideoTrack,
   Room,
+  RoomEvent,
   Track,
   VideoPresets,
+  type RemoteParticipant,
   type RoomConnectOptions,
 } from "livekit-client";
+import { dispatchAppEmoteEvent } from "../../events";
+import type { AppEmoteEventDetail } from "../../events";
 
 interface InjectedLiveKitConfig {
   url?: string;
@@ -130,11 +135,107 @@ type PublisherStatus =
   | "error"
   | "disconnected";
 
+/**
+ * Shape of every message sent by the CP via
+ * `POST /api/agent/v1/sessions/:id/livekit/broadcast-event` and
+ * `LiveKitService.sendDataToRoom()`. The CP guarantees `topic` is a
+ * non-empty string; everything else is opaque JSON.
+ */
+interface BroadcastDataMessage {
+  topic: string;
+  payload?: unknown;
+  ts?: number;
+}
+
+/**
+ * Decode a LiveKit DataReceived payload (Uint8Array of UTF-8 JSON)
+ * into our `{topic,payload,ts}` envelope. Returns `null` if the
+ * message is malformed — protects the renderer from crashing on
+ * garbage from a misbehaving publisher.
+ */
+function decodeBroadcastDataMessage(
+  payload: Uint8Array,
+): BroadcastDataMessage | null {
+  try {
+    const text = new TextDecoder().decode(payload);
+    const parsed = JSON.parse(text) as unknown;
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      typeof (parsed as Record<string, unknown>).topic !== "string"
+    ) {
+      return null;
+    }
+    return parsed as BroadcastDataMessage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Route an incoming data message to the correct window CustomEvent
+ * so the existing GlobalEmoteOverlay / VrmStage / ChatAvatar listeners
+ * pick it up. Adding a new topic means (a) declaring its payload
+ * shape here and (b) dispatching the matching event — the operator
+ * UI remains the source of truth for what topics exist.
+ *
+ * Topics currently handled:
+ *   - "emote"           → window "eliza:app-emote" (AppEmoteEventDetail)
+ *   - "trigger"         → window "eliza:app-trigger" (forward-compat; not yet consumed)
+ *   - "scene-update"    → window "eliza:scene-update" (forward-compat; not yet consumed)
+ *
+ * Unknown topics are logged once at debug level and dropped so an
+ * operator adding a new topic can see it land in the headless
+ * Chromium without the renderer throwing.
+ */
+function dispatchBroadcastDataMessage(msg: BroadcastDataMessage): void {
+  if (typeof window === "undefined") return;
+
+  switch (msg.topic) {
+    case "emote": {
+      const detail = msg.payload as AppEmoteEventDetail | undefined;
+      if (
+        !detail ||
+        typeof detail.emoteId !== "string" ||
+        typeof detail.path !== "string" ||
+        typeof detail.duration !== "number" ||
+        typeof detail.loop !== "boolean"
+      ) {
+        console.warn(
+          "[LiveKitBroadcastPublisher] emote payload missing required fields",
+          detail,
+        );
+        return;
+      }
+      dispatchAppEmoteEvent(detail);
+      return;
+    }
+    case "trigger": {
+      window.dispatchEvent(
+        new CustomEvent("eliza:app-trigger", { detail: msg.payload }),
+      );
+      return;
+    }
+    case "scene-update": {
+      window.dispatchEvent(
+        new CustomEvent("eliza:scene-update", { detail: msg.payload }),
+      );
+      return;
+    }
+    default: {
+      console.debug(
+        `[LiveKitBroadcastPublisher] unhandled data topic "${msg.topic}"`,
+      );
+    }
+  }
+}
+
 export const LiveKitBroadcastPublisher = memo(function LiveKitBroadcastPublisher(): null {
   const [status, setStatus] = useState<PublisherStatus>("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const roomRef = useRef<Room | null>(null);
   const trackRef = useRef<LocalVideoTrack | null>(null);
+  const dataListenerDetachRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     const config = readInjectedLiveKitConfig();
@@ -175,7 +276,12 @@ export const LiveKitBroadcastPublisher = memo(function LiveKitBroadcastPublisher
         roomRef.current = room;
 
         const connectOptions: RoomConnectOptions = {
-          autoSubscribe: false,
+          // autoSubscribe=true so the room delivers server-pushed data
+          // messages (emote / trigger / scene-update pushed by the CP
+          // via sendDataToRoom). We don't actually receive any
+          // participant-published AV tracks in the alice broadcast
+          // (single-publisher room), so this doesn't cost bandwidth.
+          autoSubscribe: true,
         };
         await room.connect(config.url, config.token, connectOptions);
         if (cancelled) {
@@ -185,6 +291,39 @@ export const LiveKitBroadcastPublisher = memo(function LiveKitBroadcastPublisher
         console.log(
           `[LiveKitBroadcastPublisher] connected to ${config.url} room=${config.roomName} participant=${room.localParticipant.identity}`,
         );
+
+        // Wire operator→stream event propagation. The CP pushes JSON
+        // envelopes via RoomServiceClient.sendData; we re-dispatch
+        // them as window CustomEvents so GlobalEmoteOverlay / VrmStage
+        // / overlays pick them up without knowing anything about
+        // LiveKit. This is the piece that makes "operator clicks
+        // WAVE" visible on the stream in real time.
+        const onData = (
+          payload: Uint8Array,
+          _participant?: RemoteParticipant,
+          _kind?: DataPacket_Kind,
+        ) => {
+          const msg = decodeBroadcastDataMessage(payload);
+          if (!msg) {
+            console.warn(
+              "[LiveKitBroadcastPublisher] DataReceived: malformed payload, dropping",
+            );
+            return;
+          }
+          dispatchBroadcastDataMessage(msg);
+        };
+        room.on(RoomEvent.DataReceived, onData);
+        // Stash the unsubscribe so cleanup can detach it explicitly —
+        // room.disconnect() also clears listeners, but detaching
+        // first guards against a late post-unmount message leaking
+        // into the window event bus.
+        dataListenerDetachRef.current = () => {
+          try {
+            room.off(RoomEvent.DataReceived, onData);
+          } catch {
+            /* ignore — room may already be disposed */
+          }
+        };
 
         setStatus("awaiting-canvas");
         const canvas = await waitForVrmCanvas(abortController.signal);
@@ -234,6 +373,10 @@ export const LiveKitBroadcastPublisher = memo(function LiveKitBroadcastPublisher
       abortController.abort();
       const room = roomRef.current;
       const track = trackRef.current;
+      const detachData = dataListenerDetachRef.current;
+      if (detachData) {
+        detachData();
+      }
       void (async () => {
         try {
           if (track) {
@@ -250,6 +393,7 @@ export const LiveKitBroadcastPublisher = memo(function LiveKitBroadcastPublisher
       })();
       roomRef.current = null;
       trackRef.current = null;
+      dataListenerDetachRef.current = null;
     };
   }, []);
 

--- a/packages/app-core/src/components/companion/LiveKitBroadcastPublisher.tsx
+++ b/packages/app-core/src/components/companion/LiveKitBroadcastPublisher.tsx
@@ -142,14 +142,25 @@ async function waitForVrmCanvas(
  * to Cloudflare, and viewers on Twitch see a gray/black background
  * for several seconds before the VRM model appears.
  *
- * Falls through after 30s so a broken scene-status signal can't
- * permanently stall the broadcast — the existing FFmpeg path has
- * the same timeout semantics (see worker.js:2174-2178 where it
- * force-adds .avatar-ready after 20s).
+ * ## Why the 20s cap (not 30s)
+ *
+ * The control-plane's Egress-start path
+ * (stream.js post-ready-gate) polls checkRoomPublisher for exactly 30
+ * one-second iterations — ~30s wall-clock total — before giving up
+ * and skipping Egress for this session. If this client-side wait
+ * also capped at 30s, a slow-loading VRM could publish AT t=30s,
+ * after the CP's final poll completed and the loop exited: the
+ * publish lands in a dead room and Egress never starts.
+ *
+ * Matching the FFmpeg path's 20s cap at capture-service/worker.js:2174
+ * leaves a clear ~10-second margin for publishTrack + the CP's next
+ * poll to catch the late-published track. Same semantics as FFmpeg:
+ * after 20s we force-publish whatever's in the canvas (blank avatar
+ * is better than no stream).
  */
 async function waitForAvatarReady(
   abortSignal: AbortSignal,
-  timeoutMs = 30_000,
+  timeoutMs = 20_000,
   pollMs = 250,
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;

--- a/packages/app-core/src/components/companion/LiveKitBroadcastPublisher.tsx
+++ b/packages/app-core/src/components/companion/LiveKitBroadcastPublisher.tsx
@@ -60,12 +60,12 @@
 
 import { memo, useEffect, useRef, useState } from "react";
 import {
-  DataPacket_Kind,
   LocalVideoTrack,
   Room,
   RoomEvent,
   Track,
   VideoPresets,
+  type DataPacket_Kind,
   type RemoteParticipant,
   type RoomConnectOptions,
 } from "livekit-client";

--- a/packages/app-core/src/components/companion/LiveKitBroadcastPublisher.tsx
+++ b/packages/app-core/src/components/companion/LiveKitBroadcastPublisher.tsx
@@ -127,10 +127,52 @@ async function waitForVrmCanvas(
   throw new Error("[LiveKitBroadcastPublisher] aborted waiting for canvas");
 }
 
+/**
+ * Wait for the VRM avatar to finish loading and rendering its first
+ * real frame. BroadcastShell adds `.avatar-ready` to
+ * `document.documentElement` only after `useCompanionSceneStatus()
+ * .avatarReady` flips true — the same signal the capture-service's
+ * FFmpeg path waits for via `page.waitForSelector('.avatar-ready')`
+ * (worker.js:2174).
+ *
+ * Without this gate, canvas.captureStream + publishTrack start
+ * delivering frames to the LiveKit room as soon as the Three.js
+ * renderer paints the first frame — which is an empty scene with
+ * just the clear color. Egress picks those frames up and pushes them
+ * to Cloudflare, and viewers on Twitch see a gray/black background
+ * for several seconds before the VRM model appears.
+ *
+ * Falls through after 30s so a broken scene-status signal can't
+ * permanently stall the broadcast — the existing FFmpeg path has
+ * the same timeout semantics (see worker.js:2174-2178 where it
+ * force-adds .avatar-ready after 20s).
+ */
+async function waitForAvatarReady(
+  abortSignal: AbortSignal,
+  timeoutMs = 30_000,
+  pollMs = 250,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!abortSignal.aborted) {
+    if (document.documentElement.classList.contains("avatar-ready")) {
+      return;
+    }
+    if (Date.now() > deadline) {
+      console.warn(
+        `[LiveKitBroadcastPublisher] .avatar-ready not detected within ${timeoutMs}ms — publishing anyway to avoid stalling the broadcast`,
+      );
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  throw new Error("[LiveKitBroadcastPublisher] aborted waiting for avatar-ready");
+}
+
 type PublisherStatus =
   | "idle"
   | "connecting"
   | "awaiting-canvas"
+  | "awaiting-avatar"
   | "publishing"
   | "error"
   | "disconnected";
@@ -327,6 +369,22 @@ export const LiveKitBroadcastPublisher = memo(function LiveKitBroadcastPublisher
 
         setStatus("awaiting-canvas");
         const canvas = await waitForVrmCanvas(abortController.signal);
+        if (cancelled) {
+          await room.disconnect();
+          return;
+        }
+
+        // Gate on avatar-ready BEFORE publishing the track. The CP's
+        // checkRoomPublisher poll only confirms "video track exists in
+        // room" — if we publish before the VRM model is loaded, the
+        // first frames are an empty Three.js scene (gray/black).
+        // Egress picks those up immediately and viewers see a blank
+        // background for several seconds. Matching the FFmpeg path's
+        // .avatar-ready gate (capture-service/worker.js:2174) means
+        // the very first frame on the wire already has the avatar
+        // rendered.
+        setStatus("awaiting-avatar");
+        await waitForAvatarReady(abortController.signal);
         if (cancelled) {
           await room.disconnect();
           return;

--- a/packages/app-core/src/components/companion/LiveKitBroadcastPublisher.tsx
+++ b/packages/app-core/src/components/companion/LiveKitBroadcastPublisher.tsx
@@ -333,13 +333,11 @@ export const LiveKitBroadcastPublisher = memo(function LiveKitBroadcastPublisher
         }
 
         const mediaStream = canvas.captureStream(30);
-        const videoTracks = mediaStream.getVideoTracks();
-        if (videoTracks.length === 0) {
-          throw new Error("[LiveKitBroadcastPublisher] captureStream produced no video tracks");
-        }
-        const mediaStreamTrack = videoTracks[0];
+        const mediaStreamTrack = mediaStream.getVideoTracks()[0];
         if (!mediaStreamTrack) {
-          throw new Error("[LiveKitBroadcastPublisher] captureStream produced no video tracks");
+          throw new Error(
+            "[LiveKitBroadcastPublisher] captureStream produced no video tracks",
+          );
         }
         const localVideoTrack = new LocalVideoTrack(mediaStreamTrack, undefined, false);
         trackRef.current = localVideoTrack;

--- a/packages/app-core/src/components/companion/LiveKitBroadcastPublisher.tsx
+++ b/packages/app-core/src/components/companion/LiveKitBroadcastPublisher.tsx
@@ -1,0 +1,278 @@
+/**
+ * LiveKitBroadcastPublisher — publishes the VRM Three.js canvas as a
+ * WebRTC video track to a LiveKit room. Used by BroadcastShell in the
+ * capture-service's headless Chromium.
+ *
+ * ## Why this exists
+ *
+ * Prior architecture ran a second React tree in the capture-service's
+ * headless Chromium that was supposed to sync with the operator's
+ * browser via WebSocket events (emotes, state deltas). That sync path
+ * didn't work reliably in the headless environment — the AppContext
+ * setup effect never established its WS connection, leaving the
+ * broadcast scene static even though the page loaded.
+ *
+ * The frontier architecture (matching HeyGen LiveAvatar, D-ID, Anam
+ * real-time rendering) is: one canonical renderer, one video track,
+ * all consumers subscribe. This component implements the publisher
+ * half of that architecture — the headless Chromium's canvas becomes
+ * the sole source of truth for stream video.
+ *
+ * ## How it works
+ *
+ * 1. On mount, reads LiveKit connection details from
+ *    `window.__injectedShowConfig.liveKit` (injected by the
+ *    capture-service worker at page load — see
+ *    `services/capture-service/src/worker.js:2118`).
+ * 2. Uses `livekit-client` to connect to the provided room URL with
+ *    the provided token. The token must have `canPublish: true`.
+ * 3. Locates the VRM canvas via `document.querySelector("canvas[data-vrm-canvas]")`
+ *    — VrmViewer renders the canvas with this attribute.
+ * 4. Calls `canvas.captureStream(30)` to get a MediaStream at 30 fps.
+ * 5. Publishes the video track via `room.localParticipant.publishTrack`.
+ * 6. On unmount, unpublishes cleanly and disconnects.
+ *
+ * ## Why canvas.captureStream
+ *
+ * It's the native browser API for turning a canvas into a MediaStream.
+ * Works in Playwright-controlled headless Chromium with the existing
+ * Chrome flags (--use-gl=angle --use-angle=swiftshader
+ * --use-fake-device-for-media-stream). No polyfill or workaround needed.
+ *
+ * Frame rate matches whatever rate the Three.js renderer is actively
+ * drawing to the canvas. VrmEngine uses `renderer.setAnimationLoop`
+ * which drives continuous 60 Hz rendering (capped to 30 Hz by the
+ * capture request).
+ *
+ * ## Scope
+ *
+ * This component ONLY publishes video. Audio, data messages, and
+ * Egress-to-RTMPS are handled elsewhere:
+ * - Audio: the livekit-agent-worker publishes TTS audio to the same
+ *   room separately (existing premium/Hedra pattern).
+ * - Data messages: a separate LiveKitActionSubscriber (future) will
+ *   receive operator actions and dispatch them to VrmStage via the
+ *   existing `eliza:app-emote` CustomEvent path.
+ * - Egress: the control-plane starts a `startRoomCompositeEgress`
+ *   job targeting this room's published tracks, outputting to the
+ *   Cloudflare Live Input that fans out to Twitch/Kick.
+ */
+
+import { memo, useEffect, useRef, useState } from "react";
+import {
+  LocalVideoTrack,
+  Room,
+  Track,
+  VideoPresets,
+  type RoomConnectOptions,
+} from "livekit-client";
+
+interface InjectedLiveKitConfig {
+  url?: string;
+  roomName?: string;
+  token?: string;
+}
+
+interface InjectedShowConfig {
+  liveKit?: InjectedLiveKitConfig | null;
+}
+
+/**
+ * Read the LiveKit config injected by the capture-service worker.
+ * Returns null if this window isn't running in the capture context
+ * (e.g., a developer opening the broadcast URL directly in their own
+ * browser without the Puppeteer injection).
+ */
+function readInjectedLiveKitConfig(): InjectedLiveKitConfig | null {
+  if (typeof window === "undefined") return null;
+  const injected = (window as unknown as { __injectedShowConfig?: InjectedShowConfig })
+    .__injectedShowConfig;
+  if (!injected?.liveKit) return null;
+  const { url, roomName, token } = injected.liveKit;
+  if (!url || !roomName || !token) return null;
+  return { url, roomName, token };
+}
+
+/**
+ * Wait for the VRM canvas to exist and to have non-zero dimensions.
+ * VrmEngine populates the canvas asynchronously; we poll at a modest
+ * cadence (every 250 ms for up to 30 s) to avoid racing the renderer
+ * init.
+ */
+async function waitForVrmCanvas(
+  abortSignal: AbortSignal,
+  timeoutMs = 30_000,
+  pollMs = 250,
+): Promise<HTMLCanvasElement> {
+  const deadline = Date.now() + timeoutMs;
+  while (!abortSignal.aborted) {
+    const canvas = document.querySelector<HTMLCanvasElement>(
+      "canvas[data-vrm-canvas]",
+    );
+    if (canvas && canvas.width > 0 && canvas.height > 0) {
+      return canvas;
+    }
+    if (Date.now() > deadline) {
+      throw new Error(
+        `[LiveKitBroadcastPublisher] VRM canvas did not appear within ${timeoutMs}ms`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  throw new Error("[LiveKitBroadcastPublisher] aborted waiting for canvas");
+}
+
+type PublisherStatus =
+  | "idle"
+  | "connecting"
+  | "awaiting-canvas"
+  | "publishing"
+  | "error"
+  | "disconnected";
+
+export const LiveKitBroadcastPublisher = memo(function LiveKitBroadcastPublisher(): null {
+  const [status, setStatus] = useState<PublisherStatus>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const roomRef = useRef<Room | null>(null);
+  const trackRef = useRef<LocalVideoTrack | null>(null);
+
+  useEffect(() => {
+    const config = readInjectedLiveKitConfig();
+    if (!config) {
+      // Not running in capture-service context — stay idle. This lets
+      // developers open the broadcast URL directly without triggering
+      // a failed publish attempt. Log once so the absence is visible
+      // in devtools console if the developer expected a publish.
+      console.log(
+        "[LiveKitBroadcastPublisher] no __injectedShowConfig.liveKit — publisher disabled",
+      );
+      return;
+    }
+
+    const abortController = new AbortController();
+    let cancelled = false;
+
+    void (async () => {
+      setStatus("connecting");
+      try {
+        // Create + connect the Room. adaptiveStream disabled because
+        // we're the only publisher here and always want max fidelity;
+        // dynacast disabled for the same reason (nothing to downgrade).
+        const room = new Room({
+          adaptiveStream: false,
+          dynacast: false,
+          publishDefaults: {
+            videoCodec: "h264",
+            videoEncoding: VideoPresets.h1080.encoding,
+            simulcast: false,
+            // Prefer degradation of spatial layers over frame drops for
+            // avatar scenes — viewers tolerate resolution dips better
+            // than janky animation.
+            degradationPreference: "maintain-framerate",
+          },
+        });
+        if (cancelled) return;
+        roomRef.current = room;
+
+        const connectOptions: RoomConnectOptions = {
+          autoSubscribe: false,
+        };
+        await room.connect(config.url, config.token, connectOptions);
+        if (cancelled) {
+          await room.disconnect();
+          return;
+        }
+        console.log(
+          `[LiveKitBroadcastPublisher] connected to ${config.url} room=${config.roomName} participant=${room.localParticipant.identity}`,
+        );
+
+        setStatus("awaiting-canvas");
+        const canvas = await waitForVrmCanvas(abortController.signal);
+        if (cancelled) {
+          await room.disconnect();
+          return;
+        }
+
+        const mediaStream = canvas.captureStream(30);
+        const videoTracks = mediaStream.getVideoTracks();
+        if (videoTracks.length === 0) {
+          throw new Error("[LiveKitBroadcastPublisher] captureStream produced no video tracks");
+        }
+        const mediaStreamTrack = videoTracks[0];
+        if (!mediaStreamTrack) {
+          throw new Error("[LiveKitBroadcastPublisher] captureStream produced no video tracks");
+        }
+        const localVideoTrack = new LocalVideoTrack(mediaStreamTrack, undefined, false);
+        trackRef.current = localVideoTrack;
+
+        await room.localParticipant.publishTrack(localVideoTrack, {
+          name: "vrm-canvas",
+          source: Track.Source.Camera,
+          simulcast: false,
+          videoEncoding: VideoPresets.h1080.encoding,
+        });
+        if (cancelled) return;
+
+        setStatus("publishing");
+        console.log(
+          `[LiveKitBroadcastPublisher] publishing canvas (${canvas.width}x${canvas.height} @ 30fps) as track ${localVideoTrack.sid}`,
+        );
+      } catch (err) {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(
+          "[LiveKitBroadcastPublisher] publish failed:",
+          message,
+        );
+        setErrorMessage(message);
+        setStatus("error");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      abortController.abort();
+      const room = roomRef.current;
+      const track = trackRef.current;
+      void (async () => {
+        try {
+          if (track) {
+            await room?.localParticipant.unpublishTrack(track).catch(() => {});
+            track.stop();
+          }
+          await room?.disconnect().catch(() => {});
+        } catch (err) {
+          console.warn(
+            "[LiveKitBroadcastPublisher] cleanup error:",
+            err instanceof Error ? err.message : err,
+          );
+        }
+      })();
+      roomRef.current = null;
+      trackRef.current = null;
+    };
+  }, []);
+
+  // Mirror the current publishing state onto document.documentElement as
+  // a data attribute. This is a lightweight signal the capture-service
+  // worker or a test harness can read via `page.evaluate` without
+  // relying on console output (which we've seen get dropped in headless).
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    document.documentElement.setAttribute("data-livekit-publisher", status);
+    if (errorMessage) {
+      document.documentElement.setAttribute(
+        "data-livekit-publisher-error",
+        errorMessage,
+      );
+    } else {
+      document.documentElement.removeAttribute("data-livekit-publisher-error");
+    }
+    return () => {
+      document.documentElement.removeAttribute("data-livekit-publisher");
+      document.documentElement.removeAttribute("data-livekit-publisher-error");
+    };
+  }, [status, errorMessage]);
+
+  return null;
+});

--- a/packages/app-core/src/components/companion/LiveKitBroadcastSubscriber.tsx
+++ b/packages/app-core/src/components/companion/LiveKitBroadcastSubscriber.tsx
@@ -210,6 +210,19 @@ export const LiveKitBroadcastSubscriber = memo(function LiveKitBroadcastSubscrib
 
         const onDisconnected = () => {
           if (cancelled) return;
+          // Clear the track ref so we don't hold a reference to a
+          // dead track until the component unmounts. The video
+          // element's `srcObject` is also reset here so the frozen
+          // last frame doesn't linger on screen under the placeholder.
+          const videoEl = videoRef.current;
+          if (attachedTrackRef.current && videoEl) {
+            try {
+              attachedTrackRef.current.detach(videoEl);
+            } catch {
+              /* ignore */
+            }
+          }
+          attachedTrackRef.current = null;
           setStatus("disconnected");
           onStatusChangeRef.current?.("disconnected");
         };

--- a/packages/app-core/src/components/companion/LiveKitBroadcastSubscriber.tsx
+++ b/packages/app-core/src/components/companion/LiveKitBroadcastSubscriber.tsx
@@ -1,0 +1,330 @@
+/**
+ * LiveKitBroadcastSubscriber — plays the live broadcast video track
+ * from the current session's LiveKit room into a `<video>` element.
+ *
+ * ## Why this exists
+ *
+ * Prior architecture: operator's tab renders its OWN copy of the VRM
+ * scene via CompanionShell → CompanionSceneHost → VrmEngine. The
+ * broadcast-to-Twitch path is ENTIRELY separate (capture-service's
+ * headless Chromium running BroadcastShell). The two renders are only
+ * loosely synced via WS events, which is fragile:
+ *   - Any animation/lighting/shader glitch in the headless render is
+ *     invisible to the operator.
+ *   - Any state that drifts between operator's local React state and
+ *     the broadcast Chromium shows different things to Alice vs
+ *     viewers.
+ *   - Debugging live-stream issues requires watching Twitch/Kick
+ *     separately.
+ *
+ * Frontier architecture (matching HeyGen LiveAvatar, D-ID, Anam):
+ * there is ONE canonical renderer (the capture-service's Chromium
+ * running BroadcastShell, publishing via LiveKitBroadcastPublisher)
+ * and BOTH the Twitch/Kick Egress consumer AND the operator's tab
+ * subscribe to that single video source. What the operator sees is
+ * literally what viewers see (modulo Egress encode + RTMPS delivery
+ * latency).
+ *
+ * This component is the operator-side subscriber. Mount it in any
+ * operator shell where a "what's going to air" preview is wanted. It
+ * fetches a subscriber token from the CP, connects to the LiveKit
+ * room, subscribes to the first published video track, and routes it
+ * into the provided `<video>` ref (or a fallback internal element).
+ *
+ * ## Scope (what's in / out)
+ *
+ * IN:
+ *   - Connect + subscribe to the current session's room.
+ *   - Play the first video track in a `<video>` element.
+ *   - Graceful handling of "no session yet" / "session not using flag"
+ *     — both produce a dimmed placeholder instead of crashing.
+ *
+ * OUT (deferred to future PRs):
+ *   - Audio track playback (alice TTS will come via a separate Hedra
+ *     path for now).
+ *   - Stats overlay (bitrate, resolution, latency).
+ *   - Multi-session switching — the component takes a `sessionId`
+ *     prop and re-subscribes when it changes; the outer shell is
+ *     responsible for deciding which session is current.
+ *
+ * ## Props
+ *
+ *   sessionId: the 555stream session ID to subscribe to. Pass `null`
+ *     to render the placeholder without attempting a connection.
+ *   fetchSubscriberToken: async callback that hits
+ *     `GET /api/agent/v1/sessions/:id/livekit/subscriber-token` and
+ *     returns the parsed JSON. Injected by the outer shell so this
+ *     component stays framework-agnostic (no direct API client
+ *     dependency) — the outer shell already owns the agent bearer
+ *     resolution for other calls.
+ *   className / style: forwarded to the outer `<div>`. The internal
+ *     `<video>` fills the container with `object-fit: cover` so
+ *     callers control aspect ratio / size.
+ *   onStatusChange: optional callback fired whenever the subscriber
+ *     status transitions (idle → connecting → subscribed → error).
+ *     Useful for the outer shell to render its own status chip.
+ */
+
+import {
+  memo,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
+import {
+  Room,
+  RoomEvent,
+  Track,
+  type RemoteParticipant,
+  type RemoteTrack,
+  type RemoteTrackPublication,
+  type RoomConnectOptions,
+} from "livekit-client";
+
+export interface SubscriberTokenResponse {
+  ok: boolean;
+  url: string;
+  roomName: string;
+  token: string;
+  identity: string;
+  expiresInSec: number;
+}
+
+export type SubscriberStatus =
+  | "idle"
+  | "connecting"
+  | "waiting-for-publisher"
+  | "subscribed"
+  | "error"
+  | "disconnected";
+
+export interface LiveKitBroadcastSubscriberProps {
+  sessionId: string | null;
+  fetchSubscriberToken: (sessionId: string) => Promise<SubscriberTokenResponse>;
+  className?: string;
+  style?: CSSProperties;
+  onStatusChange?: (status: SubscriberStatus, error?: string) => void;
+}
+
+export const LiveKitBroadcastSubscriber = memo(function LiveKitBroadcastSubscriber({
+  sessionId,
+  fetchSubscriberToken,
+  className,
+  style,
+  onStatusChange,
+}: LiveKitBroadcastSubscriberProps) {
+  const [status, setStatus] = useState<SubscriberStatus>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const roomRef = useRef<Room | null>(null);
+  const attachedTrackRef = useRef<RemoteTrack | null>(null);
+
+  // Notify the parent of status transitions. Ref-wrap the callback so
+  // identity changes don't re-run the connect effect below.
+  const onStatusChangeRef = useRef(onStatusChange);
+  useEffect(() => {
+    onStatusChangeRef.current = onStatusChange;
+  }, [onStatusChange]);
+
+  useEffect(() => {
+    // No session → stay idle with placeholder. Don't even touch the
+    // network.
+    if (!sessionId) {
+      setStatus("idle");
+      setErrorMessage(null);
+      onStatusChangeRef.current?.("idle");
+      return;
+    }
+
+    let cancelled = false;
+
+    void (async () => {
+      setStatus("connecting");
+      setErrorMessage(null);
+      onStatusChangeRef.current?.("connecting");
+
+      try {
+        const tokenResp = await fetchSubscriberToken(sessionId);
+        if (cancelled) return;
+        if (!tokenResp?.ok || !tokenResp.token || !tokenResp.url) {
+          throw new Error("subscriber token response missing required fields");
+        }
+
+        const room = new Room({
+          adaptiveStream: true,
+          // Dynacast doesn't apply to single-publisher broadcast, but
+          // leaving enabled as a forward-compat default.
+          dynacast: true,
+        });
+        roomRef.current = room;
+
+        // Attach publisher track when it arrives. For the alice
+        // broadcast the first published camera track IS the canvas
+        // composite — attach and pin.
+        const onTrackSubscribed = (
+          track: RemoteTrack,
+          _publication: RemoteTrackPublication,
+          _participant: RemoteParticipant,
+        ) => {
+          if (track.kind !== Track.Kind.Video) return;
+          const videoEl = videoRef.current;
+          if (!videoEl) return;
+          // Detach any previous track (room churn / re-publish).
+          if (attachedTrackRef.current && attachedTrackRef.current !== track) {
+            try {
+              attachedTrackRef.current.detach(videoEl);
+            } catch {
+              /* ignore */
+            }
+          }
+          track.attach(videoEl);
+          attachedTrackRef.current = track;
+          setStatus("subscribed");
+          onStatusChangeRef.current?.("subscribed");
+        };
+
+        const onTrackUnsubscribed = (track: RemoteTrack) => {
+          if (track !== attachedTrackRef.current) return;
+          const videoEl = videoRef.current;
+          if (videoEl) {
+            try {
+              track.detach(videoEl);
+            } catch {
+              /* ignore */
+            }
+          }
+          attachedTrackRef.current = null;
+          setStatus("waiting-for-publisher");
+          onStatusChangeRef.current?.("waiting-for-publisher");
+        };
+
+        const onDisconnected = () => {
+          if (cancelled) return;
+          setStatus("disconnected");
+          onStatusChangeRef.current?.("disconnected");
+        };
+
+        room.on(RoomEvent.TrackSubscribed, onTrackSubscribed);
+        room.on(RoomEvent.TrackUnsubscribed, onTrackUnsubscribed);
+        room.on(RoomEvent.Disconnected, onDisconnected);
+
+        const connectOptions: RoomConnectOptions = {
+          autoSubscribe: true,
+        };
+        await room.connect(tokenResp.url, tokenResp.token, connectOptions);
+        if (cancelled) {
+          await room.disconnect();
+          return;
+        }
+
+        // If publishers are already in the room, iterate their video
+        // tracks and attach the first one. LiveKit fires
+        // TrackSubscribed for late-arriving tracks, but for tracks
+        // already subscribed at connect time we need to walk the
+        // current state.
+        const walkExisting = () => {
+          for (const participant of room.remoteParticipants.values()) {
+            for (const publication of participant.videoTrackPublications.values()) {
+              const track = publication.track;
+              if (track) {
+                onTrackSubscribed(
+                  track,
+                  publication,
+                  participant,
+                );
+                return true;
+              }
+            }
+          }
+          return false;
+        };
+
+        if (!walkExisting()) {
+          setStatus("waiting-for-publisher");
+          onStatusChangeRef.current?.("waiting-for-publisher");
+        }
+      } catch (err) {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(
+          "[LiveKitBroadcastSubscriber] subscribe failed:",
+          message,
+        );
+        setErrorMessage(message);
+        setStatus("error");
+        onStatusChangeRef.current?.("error", message);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      const videoEl = videoRef.current;
+      const attached = attachedTrackRef.current;
+      if (attached && videoEl) {
+        try {
+          attached.detach(videoEl);
+        } catch {
+          /* ignore */
+        }
+      }
+      attachedTrackRef.current = null;
+      void roomRef.current?.disconnect().catch(() => {});
+      roomRef.current = null;
+    };
+  }, [sessionId, fetchSubscriberToken]);
+
+  return (
+    <div
+      className={className}
+      style={{
+        position: "relative",
+        width: "100%",
+        height: "100%",
+        backgroundColor: "#000",
+        overflow: "hidden",
+        ...style,
+      }}
+      data-livekit-subscriber={status}
+      data-livekit-subscriber-error={errorMessage ?? undefined}
+    >
+      <video
+        ref={videoRef}
+        autoPlay
+        playsInline
+        muted
+        style={{
+          width: "100%",
+          height: "100%",
+          objectFit: "cover",
+        }}
+      />
+      {status !== "subscribed" ? (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "rgba(255,255,255,0.6)",
+            fontSize: 14,
+            letterSpacing: 0.25,
+            textAlign: "center",
+            pointerEvents: "none",
+          }}
+        >
+          {status === "error"
+            ? `Broadcast unavailable — ${errorMessage ?? "unknown error"}`
+            : status === "waiting-for-publisher"
+              ? "Waiting for broadcast to start…"
+              : status === "connecting"
+                ? "Connecting to broadcast…"
+                : status === "disconnected"
+                  ? "Broadcast disconnected"
+                  : "Broadcast idle"}
+        </div>
+      ) : null}
+    </div>
+  );
+});

--- a/packages/app-core/src/components/companion/LiveKitBroadcastSubscriber.tsx
+++ b/packages/app-core/src/components/companion/LiveKitBroadcastSubscriber.tsx
@@ -127,6 +127,15 @@ export const LiveKitBroadcastSubscriber = memo(function LiveKitBroadcastSubscrib
     onStatusChangeRef.current = onStatusChange;
   }, [onStatusChange]);
 
+  // Same pattern for the token fetcher — if the parent passes a fresh
+  // function literal every render (common React footgun), we don't
+  // want the effect below to tear down the room + reconnect every
+  // time. The only thing that should drive reconnection is sessionId.
+  const fetchSubscriberTokenRef = useRef(fetchSubscriberToken);
+  useEffect(() => {
+    fetchSubscriberTokenRef.current = fetchSubscriberToken;
+  }, [fetchSubscriberToken]);
+
   useEffect(() => {
     // No session → stay idle with placeholder. Don't even touch the
     // network.
@@ -145,7 +154,7 @@ export const LiveKitBroadcastSubscriber = memo(function LiveKitBroadcastSubscrib
       onStatusChangeRef.current?.("connecting");
 
       try {
-        const tokenResp = await fetchSubscriberToken(sessionId);
+        const tokenResp = await fetchSubscriberTokenRef.current(sessionId);
         if (cancelled) return;
         if (!tokenResp?.ok || !tokenResp.token || !tokenResp.url) {
           throw new Error("subscriber token response missing required fields");
@@ -272,7 +281,11 @@ export const LiveKitBroadcastSubscriber = memo(function LiveKitBroadcastSubscrib
       void roomRef.current?.disconnect().catch(() => {});
       roomRef.current = null;
     };
-  }, [sessionId, fetchSubscriberToken]);
+    // Intentionally exclude fetchSubscriberToken — we read it via
+    // fetchSubscriberTokenRef so a new function identity on re-render
+    // doesn't tear down the room. Only sessionId should drive reconnect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId]);
 
   return (
     <div

--- a/packages/app-core/src/components/shell/BroadcastShell.tsx
+++ b/packages/app-core/src/components/shell/BroadcastShell.tsx
@@ -44,6 +44,7 @@ import { useRenderGuard } from "@miladyai/app-core/hooks";
 import { memo, useEffect } from "react";
 import { CompanionSceneHost } from "../companion/CompanionSceneHost";
 import { useCompanionSceneStatus } from "../companion/companion-scene-status-context";
+import { LiveKitBroadcastPublisher } from "../companion/LiveKitBroadcastPublisher";
 import { SceneOverlayDataBridge } from "../companion/scene-overlay-bridge";
 
 declare global {
@@ -111,6 +112,17 @@ export const BroadcastShell = memo(function BroadcastShell() {
         capture had no chat bubbles after PR #68.
       */}
       <SceneOverlayDataBridge />
+      {/*
+        LiveKitBroadcastPublisher captures the VRM canvas via
+        `canvas.captureStream(30)` and publishes it as a WebRTC video
+        track to the LiveKit room provisioned by the control-plane. The
+        capture-service worker injects the room URL + publish token as
+        `window.__injectedShowConfig.liveKit` before navigation.
+        Control-plane Egress picks up the published track and forwards
+        it to Cloudflare → Twitch/Kick. No-op if the injected config
+        is absent (e.g., developer opens the broadcast URL directly).
+      */}
+      <LiveKitBroadcastPublisher />
     </div>
   );
 });


### PR DESCRIPTION
Step 1 of the frontier architecture revamp. Headless Chromium becomes the canonical renderer — publishes its VRM canvas as a WebRTC video track to a LiveKit room. See commit message for full context.

Scope: ADD the publisher only. Existing FFmpeg x11grab path untouched. Control-plane changes (Phase 3/4/5) follow in separate PRs.

Dependencies: adds `livekit-client ^2.17.1` to app-core. Same SDK proven working in the capture-service's headless Chromium by the existing agent-show path in 555stream.