### PR TITLE
feat(broadcast): path-based /broadcast/:channel with public/capture transport split

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -618,6 +618,24 @@ async function runMain(): Promise<void> {
       // REST need credentials so scene-state sync + emote replay
       // work. Public viewers never authenticate — any apiToken
       // query on the public URL is rejected here explicitly.
+      //
+      // KNOWN GAP — capture auth vs alice-bot auth enforcement.
+      // The URL `?apiToken=` path is the canonical credential. The
+      // `__injectedShowConfig.wsToken` fallback is a control-plane-
+      // issued renderer JWT, which alice-bot's auth middleware does
+      // NOT validate — it only accepts the static API token set via
+      // ELIZA_SERVER_AUTH_TOKEN. With alice-bot running with
+      // MILAIDY_AUTH_DISABLED=1 (current prod state) any token is
+      // accepted and this distinction doesn't matter. The day
+      // MILAIDY_AUTH_DISABLED flips off, the capture transport will
+      // start hitting 401s on /api/companion/stage and the WS handshake
+      // unless one of these lands first:
+      //   (a) CP injects the real alice-bot API token (k8s secret
+      //       mirrored to both the CP and capture-service), OR
+      //   (b) alice-bot's auth middleware learns to accept renderer-
+      //       scoped JWTs signed by the CP.
+      // Tracked as a follow-up; do not enable alice-bot auth until
+      // one of those ships.
       {
         const params = new URLSearchParams(
           window.location.search || window.location.hash.split("?")[1] || "",

--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -37,9 +37,12 @@ import {
   applyForceFreshOnboardingReset,
   applyLaunchConnectionFromUrl,
   dispatchQueuedLifeOpsGithubCallbackFromUrl,
+  getBroadcastChannel,
+  getBroadcastMode,
   installDesktopPermissionsClientPatch,
   installForceFreshOnboardingClientPatch,
   installLocalProviderCloudPreferencePatch,
+  isBroadcastWindow as isBroadcastWindowShared,
   isDetachedWindowShell,
   resolveWindowShellRoute,
   shouldInstallMainWindowOnboardingPatches,
@@ -467,21 +470,14 @@ function isPopoutWindow(): boolean {
 }
 
 /**
- * Broadcast window detection — see app-core/platform/init.ts for the
- * full justification. Mirrors `isPopoutWindow()` but matches `?broadcast`
- * (any value other than `false`/`0`). Used by the boot path to skip the
- * heavy native platform init while still mounting the React app, so the
- * capture-service's headless Chromium gets a clean CompanionSceneHost
- * render instead of the full app shell.
+ * Broadcast window detection is shared across the codebase via
+ * `@miladyai/app-core/platform` — `isBroadcastWindowShared` wraps the
+ * canonical path-aware + query-fallback detector so this file doesn't
+ * maintain its own duplicate. Use `getBroadcastMode()` to distinguish
+ * public viewer from internal capture below.
  */
 function isBroadcastWindow(): boolean {
-  if (typeof window === "undefined") return false;
-  const params = new URLSearchParams(
-    window.location.search || window.location.hash.split("?")[1] || "",
-  );
-  if (!params.has("broadcast")) return false;
-  const value = params.get("broadcast");
-  return value !== "false" && value !== "0";
+  return isBroadcastWindowShared();
 }
 
 /**
@@ -557,107 +553,110 @@ async function runMain(): Promise<void> {
   }
 
   if (isBroadcastWindow()) {
-    // Broadcast mode reuses the popout apiBase injection (same query
-    // semantics) and skips the heavy native platform init: the broadcast
-    // shell only needs the React app, AppContext, and CompanionSceneHost
-    // to come up. App.tsx's `useIsBroadcast()` gate routes the render to
-    // BroadcastShell once the startup coordinator reaches "ready".
+    // Broadcast mode is served by two transports that share the same
+    // renderer code (BroadcastShell → CompanionSceneHost) but have
+    // opposite trust levels:
     //
-    // Set the 555stream capture-service "React mounted" handshake marker
-    // SYNCHRONOUSLY here, before the React app even mounts. The capture
-    // worker uses
-    //   page.waitForFunction(
-    //     () => typeof window.__agentShowControl !== 'undefined',
-    //     { timeout: 20000 }
-    //   )
-    // as its primary "is the page ready" gate (see
-    // services/capture-service/src/worker.js:2161). Setting the global at
-    // the boot path means the worker's first poll catches it within
-    // ~100ms of the page loading — eliminating any race window between
-    // the React commit phase and the worker's 20s timeout, which is the
-    // failure mode that was making the worker fall back to its legacy
-    // DOM-injected agent-show standalone page.
+    //   PUBLIC  — alice.rndrntwrk.com/broadcast/:channel
+    //     Unauthenticated. Cloudflare Access bypass on /broadcast/*.
+    //     Must not mount LiveKitBroadcastPublisher, must not call
+    //     mutation APIs, must not consume apiToken (there is no
+    //     intended auth for this surface), must not mark onboarding
+    //     complete via the shared localStorage flag.
     //
-    // BroadcastShell's <CaptureHandshake/> child still runs the same
-    // assignment from a useEffect for the in-React lifecycle (and adds
-    // the .avatar-ready class once useCompanionSceneStatus().avatarReady
-    // flips true), but the boot-path assignment is the primary path
-    // because it can't race with React commit timing.
-    if (typeof window !== "undefined") {
+    //   CAPTURE — http://alice-bot:3000/broadcast/:channel
+    //     Internal-only. Never reaches Cloudflare. Puppeteer injects
+    //     `window.__injectedShowConfig` before navigation.
+    //     Needs the onboarding-skip marker, the __agentShowControl
+    //     handshake global, and the apiToken bridge so LiveKit
+    //     publishing and WS-backed scene sync work.
+    //
+    // `getBroadcastMode()` distinguishes them purely by the presence
+    // of `window.__injectedShowConfig` (which the browser runtime
+    // sets before any script runs when Puppeteer calls
+    // evaluateOnNewDocument). A public viewer cannot spoof it —
+    // document content and query params have no way to produce a
+    // pre-script global.
+    const broadcastMode = getBroadcastMode();
+    console.log(
+      `[boot] broadcast mode=${broadcastMode} channel=${getBroadcastChannel() ?? "(none)"}`,
+    );
+
+    if (broadcastMode === "capture") {
+      // Set the 555stream capture-service "React mounted" handshake
+      // marker SYNCHRONOUSLY, before React mounts. The capture worker
+      // uses `page.waitForFunction(() => typeof window.__agentShowControl
+      // !== 'undefined')` as its primary ready gate. Setting the
+      // global here eliminates the race between React commit and the
+      // worker's 20s timeout.
+      //
+      // Only the capture transport sets this — a public viewer has no
+      // capture-service on the other side waiting for a handshake.
       (
         window as unknown as { __agentShowControl?: Record<string, unknown> }
       ).__agentShowControl = { source: "broadcast-boot" };
-    }
 
-    // Teach the startup coordinator that onboarding is already complete.
-    //
-    // milaidy's StartupCoordinator seeds its `onboardingComplete` flag
-    // from `localStorage["eliza:onboarding-complete"]` (see
-    // packages/app-core/src/state/persistence.ts:417 +
-    // useLifecycleState.ts:48). A fresh headless Chromium has empty
-    // localStorage, so the coordinator transitions to
-    // `onboarding-required` and App.tsx renders StartupShell →
-    // OnboardingWizard — the character-select screen with the EN
-    // language chip that was appearing on stream instead of the
-    // companion view.
-    //
-    // For alice-bot specifically this is an architectural mismatch:
-    // milaidy's SPA treats each browser as a personal install to
-    // onboard, but alice-bot is a server-side, always-on, single-
-    // tenant agent whose state lives in /home/node/.milaidy/milaidy.json
-    // on the PVC. Every browser that connects should behave like an
-    // already-onboarded viewer.
-    //
-    // For broadcast captures specifically we force the marker so the
-    // coordinator skips onboarding and goes straight through
-    // `starting-runtime` → `hydrating` → `ready`, at which point
-    // BroadcastShell mounts CompanionSceneHost with whatever character
-    // AppContext resolves. The proper long-term fix is to have the
-    // coordinator consult a server-side `/api/agent/v1/onboarding-state`
-    // endpoint before falling back to localStorage — tracked as a
-    // follow-up.
-    try {
-      localStorage.setItem("eliza:onboarding-complete", "1");
-    } catch {
-      /* storage unavailable — the coordinator's own try/catch handles this */
-    }
-
-    // Bridge the alice-bot's auth token into the SPA's API client.
-    //
-    // The broadcast Chromium needs ELIZA_SERVER_AUTH_TOKEN to authenticate
-    // REST + WS. Token resolution:
-    //   1. URL param ?apiToken= — primary. The go-live flow appends the
-    //      alice-bot's own token. Secure: ClusterIP, internal only.
-    //   2. __injectedShowConfig.wsToken — fallback. Currently a 555stream
-    //      JWT (wrong type), kept for forward-compat.
-    {
-      const params = new URLSearchParams(
-        window.location.search || window.location.hash.split("?")[1] || "",
-      );
-      const urlToken = params.get("apiToken");
-      if (urlToken) {
-        setBootConfig({ ...getBootConfig(), apiToken: urlToken });
+      // Teach the startup coordinator that onboarding is already
+      // complete. milaidy's SPA treats each browser as a personal
+      // install to onboard, but alice-bot is server-side/single-
+      // tenant/always-on — a fresh Chromium in the capture-service
+      // pod has empty localStorage, so the coordinator would
+      // transition to `onboarding-required` and render the character-
+      // select screen instead of the companion.
+      //
+      // Only the capture transport flips this flag — public viewers
+      // are non-operator surfaces and we don't want writing to the
+      // browser's own localStorage under a user-visible URL.
+      try {
+        localStorage.setItem("eliza:onboarding-complete", "1");
+      } catch {
+        /* storage unavailable — coordinator has its own try/catch */
       }
-      if (!urlToken) {
-        try {
-          const injectedConfig = (
-            window as unknown as {
-              __injectedShowConfig?: { wsToken?: string };
+
+      // Bridge alice-bot's auth token into the SPA's API client.
+      // Only meaningful under the capture transport: WS + privileged
+      // REST need credentials so scene-state sync + emote replay
+      // work. Public viewers never authenticate — any apiToken
+      // query on the public URL is rejected here explicitly.
+      {
+        const params = new URLSearchParams(
+          window.location.search || window.location.hash.split("?")[1] || "",
+        );
+        const urlToken = params.get("apiToken");
+        if (urlToken) {
+          setBootConfig({ ...getBootConfig(), apiToken: urlToken });
+        } else {
+          try {
+            const injectedConfig = (
+              window as unknown as {
+                __injectedShowConfig?: { wsToken?: string };
+              }
+            ).__injectedShowConfig;
+            if (injectedConfig?.wsToken) {
+              setBootConfig({
+                ...getBootConfig(),
+                apiToken: injectedConfig.wsToken,
+              });
             }
-          ).__injectedShowConfig;
-          if (injectedConfig?.wsToken) {
-            setBootConfig({
-              ...getBootConfig(),
-              apiToken: injectedConfig.wsToken,
-            });
+          } catch {
+            /* injectedShowConfig not available */
           }
-        } catch {
-          /* injectedShowConfig not available */
         }
       }
+
+      injectPopoutApiBase();
+    } else {
+      // PUBLIC broadcast viewer. Intentionally skip the capture-only
+      // side-effects above. No apiToken bridge even if the URL carries
+      // one — any `?apiToken=` on the public surface is refused by
+      // ignoring it here, which closes one obvious exfiltration shape.
+      //
+      // Still call the apiBase injector for development flexibility
+      // (it only accepts same-origin / private-network / HTTPS bases
+      // per its own allowlist, so this is safe for a public URL).
+      injectPopoutApiBase();
     }
 
-    injectPopoutApiBase();
     mountReactApp();
     return;
   }

--- a/packages/agent/src/api/misc-routes.ts
+++ b/packages/agent/src/api/misc-routes.ts
@@ -378,9 +378,48 @@ export async function handleMiscRoutes(
   // match the authoritative server state before the first WS push
   // arrives. This avoids the "first frame shows default zoom, second
   // frame snaps to the operator's zoom" glitch on reconnect.
+  //
+  // Lives under `/api/*` which is Cloudflare-Access-gated for operator
+  // surfaces. Public broadcast viewers hitting
+  // `alice.rndrntwrk.com/broadcast/*` cannot reach this — they use
+  // `/api/broadcast/:channel/stage` below instead.
   if (method === "GET" && pathname === "/api/companion/stage") {
     json(res, { ok: true, state: readCompanionStageState() });
     return true;
+  }
+
+  // ── GET /api/broadcast/:channel/stage ────────────────────────────────
+  //
+  // Public, read-only variant of `/api/companion/stage`. Served under
+  // the `/api/broadcast/*` prefix which — paired with Cloudflare Access
+  // bypass on the same prefix — is reachable by unauthenticated
+  // broadcast viewers at `alice.rndrntwrk.com/broadcast/:channel`.
+  //
+  // Payload is identical: camera zoom/yaw/pitch/pan framing state.
+  // That's viewport configuration, not user data — safe to expose
+  // publicly. POST/DELETE on this path is intentionally NOT added:
+  // mutations stay on the authenticated `/api/companion/stage` path.
+  //
+  // Channel is only used for routing validation today. Multi-channel
+  // support (separate per-channel stages) is a future extension.
+  {
+    const publicStageMatch = pathname.match(
+      /^\/api\/broadcast\/([a-zA-Z0-9-]+)\/stage$/,
+    );
+    if (method === "GET" && publicStageMatch) {
+      // Hardcoded allowlist mirror of
+      // packages/app-core/src/platform/init.ts BROADCAST_CHANNEL_ALLOWLIST.
+      // Keep these two in sync — adding a new channel requires a change
+      // in both files. An unknown channel 404s instead of leaking.
+      const allowed = new Set(["alice-cam"]);
+      const channel = publicStageMatch[1];
+      if (!allowed.has(channel)) {
+        error(res, "Unknown broadcast channel", 404);
+        return true;
+      }
+      json(res, { ok: true, channel, state: readCompanionStageState() });
+      return true;
+    }
   }
 
   // ── POST /api/companion/stage ────────────────────────────────────────

--- a/packages/agent/src/api/misc-routes.ts
+++ b/packages/agent/src/api/misc-routes.ts
@@ -11,6 +11,7 @@ import {
   registerCustomActionLive,
 } from "../runtime/custom-actions.js";
 import { EMOTE_BY_ID, EMOTE_CATALOG } from "../emotes/catalog.js";
+import { resolveStateDir } from "../config/paths.js";
 import { readStreamSettings } from "./stream-persistence.js";
 import { resolveTerminalRunLimits } from "./terminal-run-limits.js";
 import {
@@ -460,12 +461,14 @@ export async function handleMiscRoutes(
         return true;
       }
       const settings = readStreamSettings();
-      const avatarDir = path.join(
-        process.env.MILAIDY_HOME ||
-          process.env.ELIZA_DATA_DIR ||
-          path.join(process.cwd(), "data"),
-        "avatars",
-      );
+      // Share the same avatar root resolution as /api/avatar/*
+      // (avatar-routes.ts) so the public surface reports the exact
+      // same custom-asset presence the authenticated/capture path
+      // sees. resolveStateDir honors MILADY_STATE_DIR / ELIZA_STATE_DIR
+      // (the canonical state-dir env vars); a divergent inline env
+      // chain here would make public hasCustomVrm=false while the
+      // authed path still serves the file correctly.
+      const avatarDir = path.join(resolveStateDir(), "avatars");
       let hasCustomVrm = false;
       try {
         hasCustomVrm = fs.statSync(path.join(avatarDir, "custom.vrm")).isFile();
@@ -520,13 +523,9 @@ export async function handleMiscRoutes(
         error(res, "Unknown broadcast channel", 404);
         return true;
       }
-      const vrmPath = path.join(
-        process.env.MILAIDY_HOME ||
-          process.env.ELIZA_DATA_DIR ||
-          path.join(process.cwd(), "data"),
-        "avatars",
-        "custom.vrm",
-      );
+      // Share the same avatar root resolution as /api/avatar/vrm —
+      // see note on the /scene handler above.
+      const vrmPath = path.join(resolveStateDir(), "avatars", "custom.vrm");
       try {
         const stat = fs.statSync(vrmPath);
         if (!stat.isFile()) {
@@ -567,12 +566,14 @@ export async function handleMiscRoutes(
         error(res, "Unknown broadcast channel", 404);
         return true;
       }
-      const avatarDir = path.join(
-        process.env.MILAIDY_HOME ||
-          process.env.ELIZA_DATA_DIR ||
-          path.join(process.cwd(), "data"),
-        "avatars",
-      );
+      // Share the same avatar root resolution as /api/avatar/*
+      // (avatar-routes.ts) so the public surface reports the exact
+      // same custom-asset presence the authenticated/capture path
+      // sees. resolveStateDir honors MILADY_STATE_DIR / ELIZA_STATE_DIR
+      // (the canonical state-dir env vars); a divergent inline env
+      // chain here would make public hasCustomVrm=false while the
+      // authed path still serves the file correctly.
+      const avatarDir = path.join(resolveStateDir(), "avatars");
       const MIME: Record<string, string> = {
         png: "image/png",
         jpg: "image/jpeg",

--- a/packages/agent/src/api/misc-routes.ts
+++ b/packages/agent/src/api/misc-routes.ts
@@ -11,6 +11,7 @@ import {
   registerCustomActionLive,
 } from "../runtime/custom-actions.js";
 import { EMOTE_BY_ID, EMOTE_CATALOG } from "../emotes/catalog.js";
+import { readStreamSettings } from "./stream-persistence.js";
 import { resolveTerminalRunLimits } from "./terminal-run-limits.js";
 import {
   ensurePrivyWalletsForCustomUser,
@@ -418,6 +419,192 @@ export async function handleMiscRoutes(
         return true;
       }
       json(res, { ok: true, channel, state: readCompanionStageState() });
+      return true;
+    }
+  }
+
+  // ── GET /api/broadcast/:channel/scene ────────────────────────────────
+  //
+  // Public, read-only scene configuration for the broadcast renderer.
+  // Mirrors the subset of data that `GET /api/stream/settings` +
+  // `GET /api/avatar/vrm` + `GET /api/avatar/background` (all auth-gated)
+  // expose to the operator surface. Without this, public viewers would
+  // fall back to localStorage/bundled defaults and drift from the
+  // capture renderer whenever the server was configured with a custom
+  // VRM or background.
+  //
+  // Returns:
+  //   selectedVrmIndex     — server-selected bundled VRM index, or 0 if custom
+  //   hasCustomVrm         — true if `avatars/custom.vrm` exists
+  //   hasCustomBackground  — true if `avatars/custom-background.{png,jpg,webp}` exists
+  //
+  // When `hasCustomVrm` / `hasCustomBackground` is true, the client
+  // should hit `/api/broadcast/:channel/vrm` and
+  // `/api/broadcast/:channel/background` (public file-serve routes
+  // below) to load the assets — the authenticated
+  // `/api/avatar/{vrm,background}` endpoints are unreachable from the
+  // Cloudflare-Access-bypassed public surface.
+  //
+  // Payload is intentionally minimal: no character bio, persona, or
+  // any other operator-private configuration. Just what the 3D scene
+  // needs to render.
+  {
+    const publicSceneMatch = pathname.match(
+      /^\/api\/broadcast\/([a-zA-Z0-9-]+)\/scene$/,
+    );
+    if (method === "GET" && publicSceneMatch) {
+      const allowed = new Set(["alice-cam"]);
+      const channel = publicSceneMatch[1];
+      if (!allowed.has(channel)) {
+        error(res, "Unknown broadcast channel", 404);
+        return true;
+      }
+      const settings = readStreamSettings();
+      const avatarDir = path.join(
+        process.env.MILAIDY_HOME ||
+          process.env.ELIZA_DATA_DIR ||
+          path.join(process.cwd(), "data"),
+        "avatars",
+      );
+      let hasCustomVrm = false;
+      try {
+        hasCustomVrm = fs.statSync(path.join(avatarDir, "custom.vrm")).isFile();
+      } catch {
+        /* no custom VRM */
+      }
+      let hasCustomBackground = false;
+      for (const ext of ["png", "jpg", "webp"]) {
+        try {
+          if (
+            fs
+              .statSync(path.join(avatarDir, `custom-background.${ext}`))
+              .isFile()
+          ) {
+            hasCustomBackground = true;
+            break;
+          }
+        } catch {
+          /* none at this extension */
+        }
+      }
+      json(res, {
+        ok: true,
+        channel,
+        scene: {
+          selectedVrmIndex:
+            typeof settings.avatarIndex === "number"
+              ? settings.avatarIndex
+              : null,
+          hasCustomVrm,
+          hasCustomBackground,
+        },
+      });
+      return true;
+    }
+  }
+
+  // ── GET /api/broadcast/:channel/vrm ──────────────────────────────────
+  //
+  // Public, read-only variant of `/api/avatar/vrm`. Serves the same
+  // `avatars/custom.vrm` file so public broadcast viewers can render
+  // the server-selected custom avatar. HEAD is also supported so the
+  // client can check existence without downloading.
+  {
+    const publicVrmMatch = pathname.match(
+      /^\/api\/broadcast\/([a-zA-Z0-9-]+)\/vrm$/,
+    );
+    if ((method === "GET" || method === "HEAD") && publicVrmMatch) {
+      const allowed = new Set(["alice-cam"]);
+      const channel = publicVrmMatch[1];
+      if (!allowed.has(channel)) {
+        error(res, "Unknown broadcast channel", 404);
+        return true;
+      }
+      const vrmPath = path.join(
+        process.env.MILAIDY_HOME ||
+          process.env.ELIZA_DATA_DIR ||
+          path.join(process.cwd(), "data"),
+        "avatars",
+        "custom.vrm",
+      );
+      try {
+        const stat = fs.statSync(vrmPath);
+        if (!stat.isFile()) {
+          error(res, "VRM not found", 404);
+          return true;
+        }
+        res.writeHead(200, {
+          "Content-Type": "model/gltf-binary",
+          "Content-Length": stat.size,
+          "Cache-Control": "public, max-age=60",
+        });
+        if (method === "HEAD") {
+          res.end();
+          return true;
+        }
+        fs.createReadStream(vrmPath).pipe(res);
+        return true;
+      } catch {
+        error(res, "VRM not found", 404);
+        return true;
+      }
+    }
+  }
+
+  // ── GET /api/broadcast/:channel/background ───────────────────────────
+  //
+  // Public, read-only variant of `/api/avatar/background`. Finds the
+  // custom-background.{png,jpg,webp} file the operator uploaded and
+  // serves it with the correct MIME type.
+  {
+    const publicBgMatch = pathname.match(
+      /^\/api\/broadcast\/([a-zA-Z0-9-]+)\/background$/,
+    );
+    if ((method === "GET" || method === "HEAD") && publicBgMatch) {
+      const allowed = new Set(["alice-cam"]);
+      const channel = publicBgMatch[1];
+      if (!allowed.has(channel)) {
+        error(res, "Unknown broadcast channel", 404);
+        return true;
+      }
+      const avatarDir = path.join(
+        process.env.MILAIDY_HOME ||
+          process.env.ELIZA_DATA_DIR ||
+          path.join(process.cwd(), "data"),
+        "avatars",
+      );
+      const MIME: Record<string, string> = {
+        png: "image/png",
+        jpg: "image/jpeg",
+        webp: "image/webp",
+      };
+      let found: { filePath: string; ext: string } | null = null;
+      for (const ext of ["png", "jpg", "webp"]) {
+        const filePath = path.join(avatarDir, `custom-background.${ext}`);
+        try {
+          if (fs.statSync(filePath).isFile()) {
+            found = { filePath, ext };
+            break;
+          }
+        } catch {
+          /* none at this extension */
+        }
+      }
+      if (!found) {
+        error(res, "Background not found", 404);
+        return true;
+      }
+      const stat = fs.statSync(found.filePath);
+      res.writeHead(200, {
+        "Content-Type": MIME[found.ext],
+        "Content-Length": stat.size,
+        "Cache-Control": "public, max-age=60",
+      });
+      if (method === "HEAD") {
+        res.end();
+        return true;
+      }
+      fs.createReadStream(found.filePath).pipe(res);
       return true;
     }
   }

--- a/packages/app-core/src/App.tsx
+++ b/packages/app-core/src/App.tsx
@@ -4,7 +4,12 @@
 
 import { Keyboard } from "@capacitor/keyboard";
 import { subscribeDesktopBridgeEvent } from "@miladyai/app-core/bridge";
-import { isIOS, isNative } from "@miladyai/app-core/platform";
+import {
+  isBroadcastWindow as isBroadcastWindowShared,
+  isIOS,
+  isNative,
+  isUnknownBroadcastRoute as isUnknownBroadcastRouteShared,
+} from "@miladyai/app-core/platform";
 import {
   Button,
   DrawerSheet,
@@ -107,16 +112,25 @@ function useIsPopout(): boolean {
  * parallel renderer.
  */
 function useIsBroadcast(): boolean {
-  const [broadcast] = useState(() => {
-    if (typeof window === "undefined") return false;
-    const params = new URLSearchParams(
-      window.location.search || window.location.hash.split("?")[1] || "",
-    );
-    if (!params.has("broadcast")) return false;
-    const value = params.get("broadcast");
-    return value !== "false" && value !== "0";
-  });
+  // Delegate to the shared detector in `@miladyai/app-core/platform`
+  // so path-based `/broadcast/:channel`, allowlist enforcement, and
+  // the query-param rollback fallback are in exactly one place. This
+  // hook's only job now is snapshotting the boot-time value so React
+  // renders stay stable across effects.
+  const [broadcast] = useState(() => isBroadcastWindowShared());
   return broadcast;
+}
+
+/**
+ * True if the URL is under `/broadcast/*` but the channel is NOT in
+ * the allowlist. Used to render an explicit 404 surface below instead
+ * of falling through to the normal app under a Cloudflare-Access-
+ * bypassed path. Without this, `/broadcast/anything` would boot the
+ * full operator app unauthenticated — a real exposure risk.
+ */
+function useIsUnknownBroadcastRoute(): boolean {
+  const [unknown] = useState(() => isUnknownBroadcastRouteShared());
+  return unknown;
 }
 
 function TabScrollView({
@@ -307,6 +321,7 @@ export function App() {
 
   const isPopout = useIsPopout();
   const isBroadcast = useIsBroadcast();
+  const isUnknownBroadcast = useIsUnknownBroadcastRoute();
   const companionShellVisible = activeOverlayApp !== null;
   // Don't initialize the 3D scene while the system is still booting — this
   // prevents VrmEngine's Three.js setup from blocking the JS thread and
@@ -785,6 +800,37 @@ export function App() {
   // capture worker's first frame grab fires — the VRM scene still
   // renders via AppContext defaults, which AppProvider hydrates
   // independently of the coordinator state machine.
+  // Broadcast namespace but unknown channel → explicit 404.
+  // `/broadcast/*` is Access-bypassed at Cloudflare, so ANY React code
+  // served under that prefix is reachable unauthenticated. We must not
+  // fall through to the full app here — render a minimal 404 and stop.
+  if (isUnknownBroadcast) {
+    return (
+      <div
+        style={{
+          position: "fixed",
+          inset: 0,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#08080a",
+          color: "#e2e8f0",
+          fontFamily:
+            "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+          fontSize: 14,
+          letterSpacing: 0.25,
+        }}
+      >
+        <div style={{ textAlign: "center" }}>
+          <div style={{ fontSize: 48, fontWeight: 700, marginBottom: 8 }}>
+            404
+          </div>
+          <div>broadcast channel not found</div>
+        </div>
+      </div>
+    );
+  }
+
   if (isBroadcast) {
     return <BroadcastShell />;
   }

--- a/packages/app-core/src/api/client.ts
+++ b/packages/app-core/src/api/client.ts
@@ -2599,15 +2599,46 @@ export class MiladyClient {
   }
 
   /**
-   * Hydrate the current companion stage state from the alice-bot server.
-   * Called on mount by the operator's browser and the 555stream
-   * capture-service headless Chromium to align their local camera refs
-   * with the persistent server state before the first WS push arrives.
+   * Hydrate the current companion stage state from the alice-bot
+   * server. Called on mount by all renderer surfaces to align their
+   * local camera refs with the persistent server state before the
+   * first WS push arrives.
+   *
+   * Routes to the PUBLIC endpoint when the current window is the
+   * public broadcast transport (alice.rndrntwrk.com/broadcast/:channel)
+   * — the authenticated `/api/companion/stage` is Cloudflare-Access-
+   * gated and public viewers cannot reach it. The public variant at
+   * `/api/broadcast/:channel/stage` returns the same payload shape
+   * with no auth required (camera framing only; no PII).
+   *
+   * The CAPTURE transport and operator surfaces use the authenticated
+   * endpoint so the same token powers both reads and subsequent
+   * POSTs (mutation is not exposed on the public path).
    */
   async getCompanionStageState(): Promise<{
     ok: boolean;
     state: CompanionStageState;
   }> {
+    // Inlined detection to avoid a cross-package import cycle (client
+    // is in api/, the platform helpers are in platform/). The shape
+    // mirrors BROADCAST_CHANNEL_ALLOWLIST in platform/init.ts — if you
+    // add a channel there, add it here too.
+    if (typeof window !== "undefined") {
+      const pathMatch = window.location.pathname.match(
+        /^\/broadcast\/([a-zA-Z0-9-]+)\/?$/,
+      );
+      const hasInjectedConfig = !!(
+        window as unknown as { __injectedShowConfig?: unknown }
+      ).__injectedShowConfig;
+      if (pathMatch && !hasInjectedConfig) {
+        const channel = pathMatch[1];
+        if (channel === "alice-cam") {
+          return this.fetch(
+            `/api/broadcast/${encodeURIComponent(channel)}/stage`,
+          );
+        }
+      }
+    }
     return this.fetch("/api/companion/stage");
   }
 

--- a/packages/app-core/src/api/client.ts
+++ b/packages/app-core/src/api/client.ts
@@ -2615,6 +2615,27 @@ export class MiladyClient {
    * endpoint so the same token powers both reads and subsequent
    * POSTs (mutation is not exposed on the public path).
    */
+  /**
+   * Fetch public scene configuration for a broadcast channel. Used by
+   * AppProvider's public-broadcast short-circuit to restore the
+   * server-selected avatar + background before marking the renderer
+   * ready. Unauthenticated — served by the milaidy agent under
+   * `/api/broadcast/:channel/scene`. Payload is intentionally minimal
+   * (just what the 3D scene needs): the operator's character bio,
+   * persona, etc. are never exposed on this path.
+   */
+  async getBroadcastScene(channel: string): Promise<{
+    ok: boolean;
+    channel: string;
+    scene: {
+      selectedVrmIndex: number | null;
+      hasCustomVrm: boolean;
+      hasCustomBackground: boolean;
+    };
+  }> {
+    return this.fetch(`/api/broadcast/${encodeURIComponent(channel)}/scene`);
+  }
+
   async getCompanionStageState(): Promise<{
     ok: boolean;
     state: CompanionStageState;

--- a/packages/app-core/src/components/companion/LiveKitBroadcastPublisher.tsx
+++ b/packages/app-core/src/components/companion/LiveKitBroadcastPublisher.tsx
@@ -71,11 +71,20 @@ import {
 } from "livekit-client";
 import { dispatchAppEmoteEvent } from "../../events";
 import type { AppEmoteEventDetail } from "../../events";
+import { getBroadcastMode } from "../../platform/init";
 
 interface InjectedLiveKitConfig {
   url?: string;
   roomName?: string;
   token?: string;
+  /**
+   * Transport signal set by CP's alice VRM broadcast path (stream.js
+   * when STREAM555_ALICE_LIVEKIT_BROADCAST=true). Must equal
+   * 'publisher' for this component to do anything. Any other value
+   * (including undefined) is a Hedra subscriber context or a misuse
+   * and we stay idle.
+   */
+  mode?: "publisher" | "subscriber";
 }
 
 interface InjectedShowConfig {
@@ -84,18 +93,31 @@ interface InjectedShowConfig {
 
 /**
  * Read the LiveKit config injected by the capture-service worker.
- * Returns null if this window isn't running in the capture context
- * (e.g., a developer opening the broadcast URL directly in their own
- * browser without the Puppeteer injection).
+ * Returns null if this window isn't running in the capture context,
+ * doesn't have all three credentials, or isn't marked publisher mode.
+ *
+ * Defense-in-depth: the CALL-SITE in BroadcastShell already gates on
+ * `getBroadcastMode() === "capture"` before mounting this component.
+ * The publisher itself STILL refuses to activate unless every gate
+ * agrees — if any future caller mounts this component in a non-capture
+ * context, we no-op instead of publishing into the room.
  */
 function readInjectedLiveKitConfig(): InjectedLiveKitConfig | null {
   if (typeof window === "undefined") return null;
+  // Hard gate: only run under the internal capture transport. The
+  // public broadcast transport on alice.rndrntwrk.com/broadcast/* MUST
+  // never reach this branch.
+  if (getBroadcastMode() !== "capture") return null;
   const injected = (window as unknown as { __injectedShowConfig?: InjectedShowConfig })
     .__injectedShowConfig;
   if (!injected?.liveKit) return null;
-  const { url, roomName, token } = injected.liveKit;
+  const { url, roomName, token, mode } = injected.liveKit;
   if (!url || !roomName || !token) return null;
-  return { url, roomName, token };
+  // Hedra subscriber path also populates liveKit config. Without
+  // explicit `mode === "publisher"`, stay idle so we don't fight
+  // that flow over publishing rights.
+  if (mode !== "publisher") return null;
+  return { url, roomName, token, mode };
 }
 
 /**

--- a/packages/app-core/src/components/shell/BroadcastShell.tsx
+++ b/packages/app-core/src/components/shell/BroadcastShell.tsx
@@ -45,6 +45,7 @@ import { memo, useEffect } from "react";
 import { CompanionSceneHost } from "../companion/CompanionSceneHost";
 import { useCompanionSceneStatus } from "../companion/companion-scene-status-context";
 import { LiveKitBroadcastPublisher } from "../companion/LiveKitBroadcastPublisher";
+import { getBroadcastMode } from "../../platform/init";
 import { SceneOverlayDataBridge } from "../companion/scene-overlay-bridge";
 
 declare global {
@@ -113,16 +114,17 @@ export const BroadcastShell = memo(function BroadcastShell() {
       */}
       <SceneOverlayDataBridge />
       {/*
-        LiveKitBroadcastPublisher captures the VRM canvas via
-        `canvas.captureStream(30)` and publishes it as a WebRTC video
-        track to the LiveKit room provisioned by the control-plane. The
-        capture-service worker injects the room URL + publish token as
-        `window.__injectedShowConfig.liveKit` before navigation.
-        Control-plane Egress picks up the published track and forwards
-        it to Cloudflare → Twitch/Kick. No-op if the injected config
-        is absent (e.g., developer opens the broadcast URL directly).
+        LiveKitBroadcastPublisher captures the VRM canvas and publishes
+        it as a WebRTC track. Mount ONLY when the transport is the
+        internal capture context — `getBroadcastMode() === "capture"`
+        keys off `window.__injectedShowConfig`, which Puppeteer injects
+        before any page script runs. Public viewers at
+        `alice.rndrntwrk.com/broadcast/*` don't have that global and
+        this component is not mounted, so there is no publishTrack
+        call, no LocalAudioTrack tap, and no way for an unauthenticated
+        viewer to become a publisher.
       */}
-      <LiveKitBroadcastPublisher />
+      {getBroadcastMode() === "capture" ? <LiveKitBroadcastPublisher /> : null}
     </div>
   );
 });

--- a/packages/app-core/src/platform/index.ts
+++ b/packages/app-core/src/platform/index.ts
@@ -38,8 +38,11 @@ export { applyLaunchConnectionFromUrl } from "./browser-launch";
 export * from "./cloud-preference-patch";
 export * from "./desktop-permissions-client";
 export {
+  type BroadcastMode,
   type DeepLinkHandlers,
   dispatchShareTarget,
+  getBroadcastChannel,
+  getBroadcastMode,
   handleDeepLink,
   injectBroadcastApiBase,
   injectPopoutApiBase,
@@ -49,6 +52,7 @@ export {
   isIOS,
   isNative,
   isPopoutWindow,
+  isUnknownBroadcastRoute,
   isWebPlatform,
   platform,
   type ShareTargetFile,

--- a/packages/app-core/src/platform/init.ts
+++ b/packages/app-core/src/platform/init.ts
@@ -196,28 +196,126 @@ export function isPopoutWindow(): boolean {
 // ── Broadcast helpers ───────────────────────────────────────────────
 //
 // Broadcast mode is a chrome-free render of CompanionSceneHost (VRM stage
-// + chat/action overlays) intended for the capture-service's headless
-// Chromium to grab as the "camera" frame when Alice goes live. Unlike the
-// popout (which renders only the StreamView operator panel), broadcast
-// mode renders the same VRM stage you see on the companion tab — so
-// model, scene, animations, and overlays stay in lockstep with whatever
-// the user has configured in the live app.
+// + chat/action overlays). Two transports share the same renderer:
 //
-// Activation: any non-empty `broadcast` URL parameter on `window.location`,
-// for example `http://alice-bot:3000/?broadcast=1` or
-// `https://alice.rndrntwrk.com/?broadcast=alice-cam`. The value is treated
-// as opaque so future capture pipelines can pass a tag without breaking
-// the gate. `broadcast=false` is rejected (mirroring the popout convention)
-// so the URL flag can be cleanly toggled off.
+//   1. PUBLIC  — `https://alice.rndrntwrk.com/broadcast/:channel`
+//      Read-only. Unauthenticated (Cloudflare Access bypass for
+//      /broadcast/*). No operator controls, no WS write, no publish.
+//      Public viewers see the same scene the capture browser sees,
+//      minus mutation rights.
+//
+//   2. CAPTURE — `http://alice-bot:3000/broadcast/:channel`
+//      Internal cluster URL only. Never reaches Cloudflare. Navigated
+//      by the capture-service's headless Chromium, which injects
+//      `window.__injectedShowConfig` via `evaluateOnNewDocument`
+//      before navigation. This is the sole signal that distinguishes
+//      a capture session from a public viewer — we do NOT rely on
+//      hostname sniffing or query params a public viewer could spoof.
+//
+// Activation is path-based: `/broadcast/alice-cam` (path takes
+// precedence). An allowlist of known channels rejects unknown paths
+// — `/broadcast/attacker-controlled` will NOT activate broadcast mode.
+//
+// Legacy `?broadcast=...` query activation is retained for rollback
+// during migration. It will be removed after path-based broadcast has
+// proven stable per the burn-in criteria.
 
-export function isBroadcastWindow(): boolean {
-  if (typeof window === "undefined") return false;
+/**
+ * Channels allowed to activate broadcast mode. Adding a channel here is
+ * the only way to enable a new broadcast route. The ingress and Access
+ * bypass also need corresponding updates.
+ */
+const BROADCAST_CHANNEL_ALLOWLIST = new Set<string>(["alice-cam"]);
+
+/**
+ * Broadcast transport mode. `null` = not a broadcast window.
+ *
+ *   public  — unauthenticated viewer on alice.rndrntwrk.com/broadcast/*.
+ *             Must not mount publisher, must not call mutation APIs.
+ *   capture — headless Chromium under capture-service. Has
+ *             `window.__injectedShowConfig` pre-seeded by Puppeteer.
+ *             Mounts LiveKitBroadcastPublisher, publishes canvas to
+ *             the LiveKit room pointed to by the injected config.
+ */
+export type BroadcastMode = "public" | "capture" | null;
+
+function readBroadcastChannelFromPath(pathname: string): string | null {
+  // Exact match on /broadcast/:channel (trailing slash tolerated). The
+  // regex refuses extra segments so /broadcast/foo/bar does not leak
+  // through — cleaner than consumers having to validate.
+  const match = pathname.match(/^\/broadcast\/([a-zA-Z0-9-]+)\/?$/);
+  if (!match) return null;
+  const channel = match[1];
+  return BROADCAST_CHANNEL_ALLOWLIST.has(channel) ? channel : null;
+}
+
+function readBroadcastChannelFromQuery(): string | null {
+  // Legacy fallback. Accepts any non-empty, non-`false`, non-`0` value
+  // and maps it to 'alice-cam' (the only legal channel today). This
+  // preserves the old `?broadcast=1` behavior during rollback without
+  // expanding the allowlist.
   const params = new URLSearchParams(
     window.location.search || window.location.hash.split("?")[1] || "",
   );
-  if (!params.has("broadcast")) return false;
+  if (!params.has("broadcast")) return null;
   const value = params.get("broadcast");
-  return value !== "false" && value !== "0";
+  if (!value || value === "false" || value === "0") return null;
+  return "alice-cam";
+}
+
+/**
+ * Resolve the active broadcast channel. Path-based detection takes
+ * precedence; query fallback is a rollback hatch only.
+ *
+ * @returns channel string (e.g. 'alice-cam') or null if not broadcasting
+ */
+export function getBroadcastChannel(): string | null {
+  if (typeof window === "undefined") return null;
+  const fromPath = readBroadcastChannelFromPath(window.location.pathname);
+  if (fromPath) return fromPath;
+  return readBroadcastChannelFromQuery();
+}
+
+/**
+ * Resolve the broadcast transport mode. The split is what makes a
+ * single renderer safe for both public viewers and internal capture
+ * under the same URL shape.
+ *
+ * Capture detection keys SOLELY off `window.__injectedShowConfig`
+ * existence. Puppeteer's evaluateOnNewDocument runs before any page
+ * script, so the capture context always has this set before our code
+ * runs. A public viewer cannot spoof it because the field is set by
+ * the browser runtime injecting the script, not by document content
+ * or query params.
+ */
+export function getBroadcastMode(): BroadcastMode {
+  if (!getBroadcastChannel()) return null;
+  const w = window as unknown as { __injectedShowConfig?: unknown };
+  return w.__injectedShowConfig ? "capture" : "public";
+}
+
+/**
+ * Back-compat: `isBroadcastWindow()` used to be a single bool for
+ * "render BroadcastShell." Keep it as a thin wrapper over the new
+ * helpers so existing call sites don't need to change today. New
+ * code should prefer `getBroadcastChannel()` + `getBroadcastMode()`.
+ */
+export function isBroadcastWindow(): boolean {
+  return getBroadcastChannel() !== null;
+}
+
+/**
+ * True if the request URL matches the broadcast path namespace
+ * (`/broadcast/*`) but the channel is NOT in the allowlist. Used by
+ * the boot path to render an explicit 404 instead of falling through
+ * to the normal app (which would load operator bundles under a
+ * URL that's Access-bypassed — a real leak risk).
+ */
+export function isUnknownBroadcastRoute(): boolean {
+  if (typeof window === "undefined") return false;
+  const path = window.location.pathname;
+  if (!/^\/broadcast\/?/.test(path)) return false;
+  return readBroadcastChannelFromPath(path) === null;
 }
 
 export function injectBroadcastApiBase(): void {

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -7018,6 +7018,58 @@ function AppProviderInner({
       console.log(
         "[AppProvider] Public broadcast mode — skipping authenticated startup probes",
       );
+      // Hydrate the server-selected scene config from the public
+      // /api/broadcast/:channel/scene endpoint so the public viewer
+      // renders the SAME avatar + background the capture transport
+      // is rendering. Without this step, public viewers would fall
+      // back to localStorage/bundled defaults and drift from the
+      // authoritative stream whenever alice-bot is configured with a
+      // custom VRM or background.
+      //
+      // Fire-and-forget from the effect's perspective — we mark
+      // `ready` immediately so BroadcastShell mounts and can display
+      // a bundled default while the scene config is being fetched;
+      // when the fetch resolves, the setState calls apply the real
+      // config and the renderer re-renders.
+      const publicChannel = (() => {
+        const match = window.location.pathname.match(
+          /^\/broadcast\/([a-zA-Z0-9-]+)\/?$/,
+        );
+        return match ? match[1] : null;
+      })();
+      if (publicChannel) {
+        void client
+          .getBroadcastScene(publicChannel)
+          .then((resp) => {
+            if (cancelled || !resp?.scene) return;
+            const { selectedVrmIndex, hasCustomVrm, hasCustomBackground } =
+              resp.scene;
+            // If the server has a custom VRM, point the local state at
+            // the public file-serve endpoint (same on-disk file as
+            // /api/avatar/vrm but reachable without auth). The VRM
+            // loader reads this URL and fetches the binary.
+            if (hasCustomVrm) {
+              setCustomVrmUrl(`/api/broadcast/${publicChannel}/vrm?t=${Date.now()}`);
+              setSelectedVrmIndex(0); // 0 = custom
+            } else if (
+              typeof selectedVrmIndex === "number" &&
+              Number.isFinite(selectedVrmIndex)
+            ) {
+              setSelectedVrmIndex(normalizeAvatarIndex(selectedVrmIndex));
+            }
+            if (hasCustomBackground) {
+              setCustomBackgroundUrl(
+                `/api/broadcast/${publicChannel}/background?t=${Date.now()}`,
+              );
+            }
+          })
+          .catch((err) => {
+            console.warn(
+              "[AppProvider] Public broadcast scene hydration failed — rendering bundled defaults:",
+              err instanceof Error ? err.message : err,
+            );
+          });
+      }
       setStartupPhase("ready");
       setOnboardingComplete(true);
       setOnboardingLoading(false);

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -6990,6 +6990,16 @@ function AppProviderInner({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: t is stable but defined later
   useEffect(() => {
+    // Hoisted above the public broadcast short-circuit because the
+    // scene-hydration `.then` closure captures this binding. Leaving
+    // the declaration in its original position below the short-circuit
+    // would put `cancelled` in TDZ when the public branch's async
+    // callback resolves — reading it would throw ReferenceError and
+    // silently swallow the hydration. Keep the single source-of-truth
+    // declaration here; do not reintroduce a second `let cancelled`
+    // further down.
+    let cancelled = false;
+
     // PUBLIC BROADCAST SHORT-CIRCUIT — defense-in-depth for the path-
     // based public surface at alice.rndrntwrk.com/broadcast/:channel.
     //
@@ -7088,7 +7098,8 @@ function AppProviderInner({
     let unbindSystemWarnings: (() => void) | null = null;
     let unbindRestartRequired: (() => void) | null = null;
     let ptyPollInterval: ReturnType<typeof setInterval> | null = null;
-    let cancelled = false;
+    // `cancelled` hoisted to the top of this effect — see comment
+    // above the public broadcast short-circuit. Not redeclared here.
     const describeBackendFailure = (
       err: unknown,
       timedOut: boolean,

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -7083,7 +7083,16 @@ function AppProviderInner({
       setStartupPhase("ready");
       setOnboardingComplete(true);
       setOnboardingLoading(false);
-      return;
+      // Return a cleanup that flips `cancelled` so the in-flight
+      // getBroadcastScene .then callback no-ops if the component
+      // unmounts OR this effect re-runs (e.g. startupRetryNonce
+      // changes). Without this, the public branch would skip the
+      // shared cleanup at the bottom of the effect, leaving the
+      // cancellation guard inert and the setState calls racing with
+      // a later re-mount.
+      return () => {
+        cancelled = true;
+      };
     }
 
     const startupRunId = startupRetryNonce;

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -90,6 +90,7 @@ import {
   markPendingAutonomyGapsPartial,
   mergeAutonomyEvents,
 } from "../autonomy";
+import { getBroadcastMode } from "../platform/init";
 import {
   getBackendStartupTimeoutMs,
   inspectExistingElizaInstall,
@@ -6989,6 +6990,40 @@ function AppProviderInner({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: t is stable but defined later
   useEffect(() => {
+    // PUBLIC BROADCAST SHORT-CIRCUIT — defense-in-depth for the path-
+    // based public surface at alice.rndrntwrk.com/broadcast/:channel.
+    //
+    // The public transport must not hit authenticated APIs at all:
+    //   - /api/auth/status            (auth probe)
+    //   - /api/onboarding/status      (onboarding probe)
+    //   - /api/config                 (character/config hydration)
+    //   - /ws                         (websocket connect)
+    //
+    // The normal startup effect below performs all of those. Without
+    // this early return, a public viewer would fire 401s against each
+    // endpoint as Cloudflare Access rejects the unauthenticated call,
+    // spamming error logs and leaving the viewer with stale defaults.
+    //
+    // In public broadcast mode we skip the entire startup effect and
+    // transition directly to `ready`. CompanionSceneHost hydrates
+    // stage state via the public GET /api/broadcast/:channel/stage
+    // endpoint (see client.getCompanionStageState() mode-aware
+    // routing below).
+    //
+    // The CAPTURE transport (http://alice-bot:3000/broadcast/...)
+    // correctly falls through to the authenticated startup — its
+    // apiToken is injected via __injectedShowConfig so the probes
+    // succeed.
+    if (getBroadcastMode() === "public") {
+      console.log(
+        "[AppProvider] Public broadcast mode — skipping authenticated startup probes",
+      );
+      setStartupPhase("ready");
+      setOnboardingComplete(true);
+      setOnboardingLoading(false);
+      return;
+    }
+
     const startupRunId = startupRetryNonce;
     let unbindStatus: (() => void) | null = null;
     let unbindAgentEvents: (() => void) | null = null;


### PR DESCRIPTION
## Summary

Replaces query-string broadcast activation with path-based routing under `/broadcast/:channel`, and splits the boot path into two transports that share one renderer.

## Architecture

```
same renderer (BroadcastShell)
    ├── PUBLIC  — https://alice.rndrntwrk.com/broadcast/alice-cam
    │   ├── Cloudflare Access bypass for /broadcast/* AND /api/broadcast/*
    │   ├── read-only, no operator mutations, no publish, no apiToken
    │   ├── AppProvider startup short-circuits — no auth/onboarding/WS probes
    │   ├── scene config via GET /api/broadcast/:channel/scene
    │   ├── stage state via GET /api/broadcast/:channel/stage
    │   └── custom VRM/BG via GET /api/broadcast/:channel/{vrm,background}
    └── CAPTURE — http://alice-bot:3000/broadcast/alice-cam (cluster-internal)
        ├── Puppeteer injects window.__injectedShowConfig before nav
        ├── mounts LiveKitBroadcastPublisher (triple-gated)
        ├── __agentShowControl + .avatar-ready handshake
        └── apiToken bridge (see KNOWN GAP below)
```

## KNOWN GAP — capture auth vs alice-bot auth enforcement

The `__injectedShowConfig.wsToken` used as fallback in the capture boot is a control-plane renderer JWT that alice-bot's auth middleware does NOT validate — it only accepts the static API token set via `ELIZA_SERVER_AUTH_TOKEN`. Today `MILAIDY_AUTH_DISABLED=1` in prod so any token is accepted. The day that flips off, the capture transport will hit 401s on `/api/companion/stage` and the WS handshake unless one of these lands first:

- (a) CP injects the real alice-bot API token via a shared k8s secret mirrored to both CP and capture-service, OR
- (b) alice-bot teaches its auth middleware to accept renderer-scoped JWTs signed by the CP.

Neither is scoped for this PR. Inline comment at `apps/app/src/main.tsx` above the apiToken bridge block spells this out. **Do not enable alice-bot auth until one of (a) or (b) ships.**

## Deploy runbook

1. Land this PR on milaidy `alice`.
2. Land paired stream PR: Render-Network-OS/stream#252.
3. **Cloudflare Access bypass** — add bypass rules for BOTH prefixes on the `alice.rndrntwrk.com` Access app:
   - `Path matches /broadcast/*` → Bypass / Allow everyone
   - `Path matches /api/broadcast/*` → Bypass / Allow everyone
   Other paths (`/`, `/companion`, `/api/*`) keep current policy.
4. Verify public: `curl https://alice.rndrntwrk.com/broadcast/alice-cam` → HTML 200, no login redirect. `curl https://alice.rndrntwrk.com/api/broadcast/alice-cam/scene` → JSON 200.
5. Verify private: `curl https://alice.rndrntwrk.com/companion` → still 302 to Access login. `curl https://alice.rndrntwrk.com/api/companion/stage` → still 302.
6. Burn-in: 7 days, ≥20 sessions, no 5xx on start/stop, P95 publisher attach <20s, A+V present, no stuck Egress/room teardown, no `/companion` regressions.

## Paired with

Render-Network-OS/stream `feat/alice-bot-renderer-cutover` (#252).

## Known follow-ups (tracked, not in this PR)

- Capture-auth gap above (required before flipping `MILAIDY_AUTH_DISABLED=0`).
- Proper public-broadcast-only render tree — CompanionSceneHost's `client.onWsEvent` subscriptions are inert but noisy under public mode. A separate minimal provider would eliminate that surface.
- Remove the query-string broadcast activation fallback after burn-in.