### PR TITLE
fix(broadcast): prefer real alice-bot apiToken over renderer JWT

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -613,29 +613,18 @@ async function runMain(): Promise<void> {
         /* storage unavailable — coordinator has its own try/catch */
       }
 
-      // Bridge alice-bot's auth token into the SPA's API client.
+      // Bridge alice-bot auth into the SPA's API client.
       // Only meaningful under the capture transport: WS + privileged
       // REST need credentials so scene-state sync + emote replay
       // work. Public viewers never authenticate — any apiToken
       // query on the public URL is rejected here explicitly.
       //
-      // KNOWN GAP — capture auth vs alice-bot auth enforcement.
-      // The URL `?apiToken=` path is the canonical credential. The
-      // `__injectedShowConfig.wsToken` fallback is a control-plane-
-      // issued renderer JWT, which alice-bot's auth middleware does
-      // NOT validate — it only accepts the static API token set via
-      // ELIZA_SERVER_AUTH_TOKEN. With alice-bot running with
-      // MILAIDY_AUTH_DISABLED=1 (current prod state) any token is
-      // accepted and this distinction doesn't matter. The day
-      // MILAIDY_AUTH_DISABLED flips off, the capture transport will
-      // start hitting 401s on /api/companion/stage and the WS handshake
-      // unless one of these lands first:
-      //   (a) CP injects the real alice-bot API token (k8s secret
-      //       mirrored to both the CP and capture-service), OR
-      //   (b) alice-bot's auth middleware learns to accept renderer-
-      //       scoped JWTs signed by the CP.
-      // Tracked as a follow-up; do not enable alice-bot auth until
-      // one of those ships.
+      // Precedence:
+      //   1. `?apiToken=` — explicit override for internal debugging
+      //   2. `__injectedShowConfig.apiToken` — the real alice-bot API token
+      //      injected by capture-service/control-plane
+      //   3. `__injectedShowConfig.wsToken` — legacy renderer JWT fallback
+      //      kept only for auth-disabled migrations
       {
         const params = new URLSearchParams(
           window.location.search || window.location.hash.split("?")[1] || "",
@@ -647,10 +636,15 @@ async function runMain(): Promise<void> {
           try {
             const injectedConfig = (
               window as unknown as {
-                __injectedShowConfig?: { wsToken?: string };
+                __injectedShowConfig?: { apiToken?: string; wsToken?: string };
               }
             ).__injectedShowConfig;
-            if (injectedConfig?.wsToken) {
+            if (injectedConfig?.apiToken) {
+              setBootConfig({
+                ...getBootConfig(),
+                apiToken: injectedConfig.apiToken,
+              });
+            } else if (injectedConfig?.wsToken) {
               setBootConfig({
                 ...getBootConfig(),
                 apiToken: injectedConfig.wsToken,


### PR DESCRIPTION
Paired with Render-Network-OS/stream \`feat/alice-bot-api-token\`.

The capture-service will soon inject the real alice-bot \`ELIZA_SERVER_AUTH_TOKEN\` as \`__injectedShowConfig.apiToken\`. The SPA boot needs to prefer that over the \`wsToken\` renderer JWT — otherwise the real token would be injected but ignored in favor of the token alice-bot doesn't validate.

## Precedence after this PR

1. URL \`?apiToken=\` — explicit override for manual debugging
2. \`__injectedShowConfig.apiToken\` — real alice-bot server token (canonical credential)
3. \`__injectedShowConfig.wsToken\` — legacy renderer JWT, fallback only during migration

## Why the KNOWN GAP comment is gone

The previous head on \`alice\` had a long KNOWN GAP block describing the capture-auth mismatch. That follow-up is this PR + the paired stream PR. Replaced with the actual precedence contract.

## Safety during rollout

\`wsToken\` fallback retained so the transition works regardless of which paired PR deploys first:

- Stream first: capture injects both tokens. SPA reads \`apiToken\` → authed REST works.
- Milaidy first: capture still only injects \`wsToken\` (old code). SPA falls through to fallback → same as today.
- Both deployed: SPA reads \`apiToken\`, real auth.

After \`MILAIDY_AUTH_DISABLED=0\` flip and stable burn-in, the \`wsToken\` fallback becomes inert and can be removed in a cleanup PR.