### PR TITLE
fix(broadcast): inject `<base href="/">` for /broadcast/:channel HTML

### DIFF
--- a/packages/agent/src/api/static-file-server.test.ts
+++ b/packages/agent/src/api/static-file-server.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   injectApiBaseIntoHtml,
+  injectBaseHrefIntoHtml,
   isPublicBroadcastUiPath,
 } from "./static-file-server";
 
@@ -28,5 +29,71 @@ describe("injectApiBaseIntoHtml", () => {
 
     expect(injected).toContain("window.__ELIZA_API_TOKEN__");
     expect(withoutToken).not.toContain("window.__ELIZA_API_TOKEN__");
+  });
+});
+
+describe("injectBaseHrefIntoHtml", () => {
+  it("injects <base href> as the first child of <head>", () => {
+    const html = Buffer.from(
+      '<!doctype html><html><head><meta charset="utf-8" /><script src="./assets/main.js"></script></head><body></body></html>',
+    );
+    const out = injectBaseHrefIntoHtml(html, "/").toString("utf8");
+
+    // Base tag is present and points at the supplied href.
+    expect(out).toContain('<base href="/" />');
+    // Base appears before any other element so relative URLs that follow
+    // resolve against it (charset meta, script src, etc.).
+    const baseIdx = out.indexOf("<base ");
+    const charsetIdx = out.indexOf('<meta charset="utf-8"');
+    const scriptIdx = out.indexOf('<script src="./assets/main.js"');
+    expect(baseIdx).toBeGreaterThan(0);
+    expect(baseIdx).toBeLessThan(charsetIdx);
+    expect(baseIdx).toBeLessThan(scriptIdx);
+  });
+
+  it("works on a head tag with attributes", () => {
+    const html = Buffer.from(
+      '<html><head lang="en"><title>x</title></head></html>',
+    );
+    const out = injectBaseHrefIntoHtml(html, "/foo/").toString("utf8");
+    expect(out).toContain('<head lang="en">');
+    expect(out).toContain('<base href="/foo/" />');
+    expect(out.indexOf("<base ")).toBeLessThan(out.indexOf("<title>"));
+  });
+
+  it("returns the html unchanged when href is empty or missing", () => {
+    const html = Buffer.from("<html><head></head></html>");
+    expect(injectBaseHrefIntoHtml(html, "").toString("utf8")).toBe(
+      html.toString("utf8"),
+    );
+    expect(injectBaseHrefIntoHtml(html, "   ").toString("utf8")).toBe(
+      html.toString("utf8"),
+    );
+  });
+
+  it("returns the html unchanged when there is no <head> tag", () => {
+    const html = Buffer.from("<html><body>no head here</body></html>");
+    expect(injectBaseHrefIntoHtml(html, "/").toString("utf8")).toBe(
+      html.toString("utf8"),
+    );
+  });
+
+  it("html-escapes the href so a hostile value cannot break out of the attribute", () => {
+    const html = Buffer.from("<html><head></head></html>");
+    const out = injectBaseHrefIntoHtml(html, '" onload="x').toString("utf8");
+    // The inner `"` becomes `&quot;`, so the attribute value stays a
+    // single token. The literal text "onload=" inside the value is harmless
+    // because both surrounding `"` belong to the original attribute.
+    expect(out).toContain('<base href="&quot; onload=&quot;x" />');
+    // There is exactly one <base ...> tag and it carries only one attribute.
+    const matches = out.match(/<base\s[^>]*?\/>/g) ?? [];
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatch(/^<base href="[^"]*" \/>$/);
+  });
+
+  it("html-escapes <, >, and & in the href", () => {
+    const html = Buffer.from("<html><head></head></html>");
+    const out = injectBaseHrefIntoHtml(html, "/?a=b&c<d>e").toString("utf8");
+    expect(out).toContain('<base href="/?a=b&amp;c&lt;d&gt;e" />');
   });
 });

--- a/packages/agent/src/api/static-file-server.ts
+++ b/packages/agent/src/api/static-file-server.ts
@@ -164,6 +164,55 @@ export function injectApiBaseIntoHtml(
   ]);
 }
 
+/**
+ * Inject `<base href="...">` as the first child of `<head>` so the document's
+ * relative URL resolution uses `href` as the base instead of the document URL.
+ *
+ * The SPA bundle (apps/app) is built with Vite `base: "./"` for desktop +
+ * mobile compatibility, which emits relative asset URLs like
+ * `<script src="./assets/main.js">`. When that HTML is served at a non-root
+ * URL such as `/broadcast/alice-cam` (no trailing slash), the browser
+ * resolves `./assets/main.js` relative to the document directory — i.e.
+ * `/broadcast/assets/main.js` — but the actual built assets live at
+ * `/assets/*` on the server. Without `<base>`, the SPA bundle 404s and the
+ * page renders blank.
+ *
+ * Injecting `<base href="/">` for broadcast HTML re-anchors all relative
+ * URLs to the document root, so `./assets/main.js` resolves to
+ * `/assets/main.js` regardless of the served path. The base tag is inserted
+ * immediately after the opening `<head>` tag — required by the spec to
+ * affect URLs that appear later in the document (which includes the entire
+ * `<head>` and `<body>`).
+ */
+export function injectBaseHrefIntoHtml(html: Buffer, href: string): Buffer {
+  const trimmed = href.trim();
+  if (!trimmed) return html;
+
+  const headOpenStart = html.indexOf("<head");
+  if (headOpenStart < 0) return html;
+  const headOpenEnd = html.indexOf(">", headOpenStart);
+  if (headOpenEnd < 0) return html;
+
+  // HTML-attribute encode the href so that no caller (or future regression)
+  // can inject extra attributes or markup by passing a string containing
+  // `"`, `<`, `>`, or `&`. Backslash escapes from JSON encoding are NOT
+  // honored by HTML parsers, so JSON.stringify alone is unsafe here.
+  const escaped = trimmed
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+  const insertAt = headOpenEnd + 1;
+  const baseTag = Buffer.from(`\n  <base href="${escaped}" />`);
+
+  return Buffer.concat([
+    html.subarray(0, insertAt),
+    baseTag,
+    html.subarray(insertAt),
+  ]);
+}
+
 // ---------------------------------------------------------------------------
 // SPA serving
 // ---------------------------------------------------------------------------
@@ -264,15 +313,29 @@ export function serveStaticUi(
   // Do NOT inject the API token into the public broadcast surface:
   // alice.rndrntwrk.com/broadcast/* is intentionally public and the capture
   // transport now receives its token through injected boot config instead.
+  const isBroadcastPath = isPublicBroadcastUiPath(pathname);
   const cloudToken =
-    isCloudProvisionedContainer() && !isPublicBroadcastUiPath(pathname)
+    isCloudProvisionedContainer() && !isBroadcastPath
       ? resolveApiToken(process.env)
       : null;
-  const html = injectApiBaseIntoHtml(
+  let html = injectApiBaseIntoHtml(
     uiIndexHtml,
     process.env.ELIZA_EXTERNAL_BASE_URL,
     cloudToken ? { apiToken: cloudToken } : undefined,
   );
+
+  // SPA is built with Vite `base: "./"` for Electrobun + Capacitor
+  // compatibility. When served at `/broadcast/:channel` (no trailing slash),
+  // relative asset URLs in the bundled HTML — `<script src="./assets/...">`
+  // and friends — resolve against the document directory and end up at
+  // `/broadcast/assets/...`, which 404s. The actual assets are at `/assets/*`
+  // on the same host, so re-anchor to the root with `<base href="/">` for
+  // broadcast HTML responses. This keeps the desktop / mobile builds (which
+  // need `./` to load from `electrobun://` or `file://`) untouched while
+  // making the same bundled HTML work as a web SPA at a sub-path.
+  if (isBroadcastPath) {
+    html = injectBaseHrefIntoHtml(html, "/");
+  }
 
   sendStaticResponse(
     req,


### PR DESCRIPTION
## Why

The SPA bundle in `apps/app` is built with Vite `base: "./"` for Electrobun + Capacitor compatibility, which emits relative asset URLs in the bundled `index.html`:

```html
<script src="./assets/main-m6cf9qRo.js"></script>
<link href="./assets/vendor-three-CdArJL33.js" rel="modulepreload">
```

When that same HTML is served as a web SPA at `/broadcast/:channel` (no trailing slash), the browser resolves `./assets/main.js` against the document directory and ends up requesting `/broadcast/assets/main.js`. The actual built assets live at `/assets/*` on the same host, so every script tag 404s, the bundle never executes, BroadcastShell never mounts, and capture-service falls back to the legacy agent-show.

Confirmed live against alice-bot in production:

```
$ curl -I http://alice-bot:3000/broadcast/assets/main-m6cf9qRo.js
HTTP/1.1 404 Not Found
$ curl -I http://alice-bot:3000/assets/main-m6cf9qRo.js
HTTP/1.1 200 OK
```

This is a hard blocker for flipping `STREAM555_ALICE_LIVEKIT_BROADCAST=true`, which routes capture-service through the path-based `/broadcast/:channel` URL instead of the legacy `?broadcast=1` query mode.

## What

Inject `<base href="/">` as the first child of `<head>` for any path matched by `isPublicBroadcastUiPath()`. This re-anchors all relative URLs to the document root regardless of where the page is served, so `./assets/main.js` resolves to `/assets/main.js`.

The desktop and mobile builds (which need `./` to load from `electrobun://` or `file://`) are untouched.

The helper uses HTML-attribute encoding (entities, not backslash escapes) because HTML parsers don't honor backslash escapes — `JSON.stringify` would produce a syntactically valid JS string but an unsafe HTML attribute value.

## Tests

`packages/agent/src/api/static-file-server.test.ts` adds:
- Injects `<base href>` as the first child of `<head>` (before `<meta charset>` and the script tag)
- Works on a `<head>` tag with attributes (`<head lang="en">`)
- Returns the html unchanged when href is empty / whitespace-only
- Returns the html unchanged when there is no `<head>` tag
- HTML-escapes hostile values containing `"`, `<`, `>`, `&` so the attribute value can't break out

## Verification after merge

1. Webhook deploys a fresh alice-bot image (~15-20 min).
2. Confirm internal:
   ```sh
   POD=$(kubectl -n production get pod -l app=alice-bot -o jsonpath='{.items[0].metadata.name}')
   kubectl -n production exec $POD -- curl -s http://127.0.0.1:3000/broadcast/alice-cam | grep -o '<base href="/" />'
   ```
   Expect: `<base href="/" />`.
3. Smoke STREAM555_GO_LIVE against `http://alice-bot:3000/broadcast/alice-cam` — expect `[boot] broadcast mode=capture channel=alice-cam`, `Avatar ready CSS class detected`, no `PAGE ERROR`, no fallback.
4. External browser confirm at `https://alice.rndrntwrk.com/broadcast/alice-cam`: SPA actually paints (CF Access bypass + Worker BYPASS_PATHS already in place).

## Stack

- PR #69: three.js bump (merged) — fixed GPUShaderStage crash
- This PR: base-href injection — fixes asset path resolution
- Follow-up: flip `STREAM555_ALICE_LIVEKIT_BROADCAST=true` on control-plane.