### PR TITLE
fix(broadcast): override assetBaseUrl to document origin under /broadcast/*

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -174,9 +174,30 @@ const MILADY_VRM_ASSETS = MILADY_STYLE_PRESETS.slice()
     ...(p.avatarIndex === 9 ? { cameraDistanceScale: 1.3 } : {}),
   }));
 
+// When the SPA is served at `/broadcast/:channel` (no trailing slash), the
+// document base URL is `<origin>/broadcast/`, and `resolveAppAssetUrl()`'s
+// runtime fallback would build asset URLs like
+// `<origin>/broadcast/vrm-decoders/draco/...` — which 404 because public
+// assets live at `<origin>/<asset>`. Pin the asset base to the document
+// root so DRACO / Meshopt decoders, fonts, VRMs, and any other
+// `resolveAppAssetUrl()` consumer load from `/<asset>` instead of
+// `/broadcast/<asset>`. The companion `<base href="/">` injection in
+// static-file-server only fixes HTML-level relative URLs (script src,
+// link href); JS code that resolves relative paths against
+// `window.location.href` (e.g. via `import.meta.env.BASE_URL`, which is
+// `"./"` for this Vite build) bypasses `<base>` and needs this override.
+// Same SPA bundle ships across desktop / mobile / web, so this only
+// kicks in for the web broadcast surface.
+const broadcastAssetBaseOverride =
+  typeof window !== "undefined" &&
+  window.location.pathname.startsWith("/broadcast/")
+    ? `${window.location.origin}/`
+    : undefined;
+
 const miladyBootConfig: AppBootConfig = {
   branding: MILADY_BRANDING,
   assetBaseUrl:
+    broadcastAssetBaseOverride ||
     (import.meta.env.VITE_ASSET_BASE_URL as string | undefined)?.trim() ||
     undefined,
   cloudApiBase:


### PR DESCRIPTION
## Why (companion to #84)

PR #84 injected `<base href="/">` so the bundled HTML's relative asset URLs (`<script src="./assets/...">`) resolve to `/assets/*` instead of `/broadcast/assets/*`. That gets the SPA bundle loading. But JS code that builds URLs against `window.location.href` ignores `<base>` entirely, so the next layer of asset resolution still breaks.

`packages/app-core/src/utils/asset-url.ts:78 resolveAppAssetUrl()` falls back to:

```ts
new URL(import.meta.env.BASE_URL /* "./" */, window.location.href)
```

When `window.location.href = "<origin>/broadcast/alice-cam"`, that resolves to `<origin>/broadcast/`, and the VRM loader's DRACO + Meshopt decoder URLs become `<origin>/broadcast/vrm-decoders/draco/...` — which 404. Repro from a clean capture-service navigation to `http://alice-bot:3000/broadcast/alice-cam` after #84 + the alice-access-gateway BYPASS_PATHS fix:

```
[AgentShow:Browser] [VrmEngine] Using WebGLRenderer
[AgentShow:Browser] PAGE ERROR: fetch for
  "http://alice-bot:3000/broadcast/vrm-decoders/draco/draco_wasm_wrapper.js"
  responded with 404: Not Found
[AgentShow:Browser] Failed to load VRM: JSHandle@error
```

## What

`resolveAppAssetUrl()` checks `getBootConfig().assetBaseUrl` first (boot-config.ts:74, asset-url.ts:88) before any runtime fallback, so overriding the boot config at SPA entry is enough. When `window.location.pathname` starts with `/broadcast/`, set `assetBaseUrl` to `${window.location.origin}/`. That makes `resolveAppAssetUrl("vrm-decoders/draco/")` return `<origin>/vrm-decoders/draco/` instead of `<origin>/broadcast/vrm-decoders/draco/`.

The override only fires for the web broadcast surface — desktop (Electrobun `electrobun://`), mobile (Capacitor `file://`), and the web homepage all keep their existing resolution behavior.

## Verification after merge

1. Webhook deploys a fresh alice-bot image (~5-7 min via on-host `alice-webhook-deployer.service`; the GitHub Actions deploy workflow is broken since 2026-02-27, separate issue).
2. Smoke `STREAM555_GO_LIVE` against `http://alice-bot:3000/broadcast/alice-cam` and tail capture-service-gpu logs:
   - Expect `[VrmEngine] Using WebGLRenderer` (already passing)
   - Expect **NO** `Failed to load VRM`
   - Expect **NO** `vrm-decoders/draco/...: 404`
   - Expect `Avatar ready CSS class detected` (proves VRM rendered)
3. After that passes, flip `STREAM555_ALICE_LIVEKIT_BROADCAST=true` on control-plane.

## Stack

- PR #69: three.js bump — fixed `GPUShaderStage` headless crash (merged, deployed)
- PR #84: `<base href="/">` HTML injection — fixed bundle script tag asset paths (merged, deployed)
- This PR: `assetBaseUrl` boot-config override — fixes JS-level asset path resolution