### PR TITLE
fix(chat): restore POST /api/conversations/:id/operator-action

### DIFF
--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -8,6 +8,7 @@
  *   POST   /api/conversations/:id/messages/truncate – truncate
  *   POST   /api/conversations/:id/messages/stream   – stream message
  *   POST   /api/conversations/:id/messages           – send message
+ *   POST   /api/conversations/:id/operator-action    – log operator action pill
  *   POST   /api/conversations/:id/greeting            – get/store greeting
  *   PATCH  /api/conversations/:id         – update/rename
  *   DELETE /api/conversations/:id         – delete
@@ -403,6 +404,18 @@ function buildPersistedAssistantContent(
       }
     : { text };
 }
+
+/**
+ * Operator-action pill block persisted with the user-turn memory so the SPA
+ * renders an action badge (Go Live, Change Avatar, Launch) for moderator
+ * actions that bypass the normal chat input.
+ */
+type OperatorActionBlock = {
+  type: "action-pill";
+  label: string;
+  kind: "stream" | "avatar" | "launch";
+  detail?: string;
+};
 
 async function getConversationWithRestore(
   state: ConversationRouteState,
@@ -1177,6 +1190,107 @@ export async function handleConversationRoutes(
     } finally {
       clearInterval(heartbeatInterval);
       res.end();
+    }
+    return true;
+  }
+
+  // ── POST /api/conversations/:id/operator-action ────────────────────
+  // Logs a moderator action (Go Live, change avatar, launch) as a user-turn
+  // memory with an `action-pill` block. The SPA's WebSocket listener receives
+  // a `proactive-message` event and renders the pill bubble immediately.
+  if (
+    method === "POST" &&
+    /^\/api\/conversations\/[^/]+\/operator-action$/.test(pathname)
+  ) {
+    const convId = decodeURIComponent(pathname.split("/")[3]);
+    const conv = await getConversationWithRestore(state, convId);
+    if (!conv) {
+      error(res, "Conversation not found", 404);
+      return true;
+    }
+    const runtime = state.runtime;
+    if (!runtime) {
+      error(res, "Agent is not running", 503);
+      return true;
+    }
+
+    const body = await readJsonBody<{
+      label?: string;
+      kind?: string;
+      detail?: string;
+      fallbackText?: string;
+    }>(req, res);
+    if (!body) return true;
+
+    const label = typeof body.label === "string" ? body.label.trim() : "";
+    if (!label) {
+      error(res, "label is required", 400);
+      return true;
+    }
+    if (
+      body.kind !== "stream" &&
+      body.kind !== "avatar" &&
+      body.kind !== "launch"
+    ) {
+      error(res, "kind must be 'stream', 'avatar', or 'launch'", 400);
+      return true;
+    }
+
+    try {
+      const userId = ensureAdminEntityId(state);
+      await ensureConversationRoom(state, conv);
+
+      const actionBlock: OperatorActionBlock = {
+        type: "action-pill",
+        label,
+        kind: body.kind,
+      };
+      if (typeof body.detail === "string" && body.detail.trim().length > 0) {
+        actionBlock.detail = body.detail.trim();
+      }
+
+      const fallbackText =
+        typeof body.fallbackText === "string" &&
+        body.fallbackText.trim().length > 0
+          ? body.fallbackText.trim()
+          : label;
+
+      const message = createMessageMemory({
+        id: crypto.randomUUID() as UUID,
+        entityId: userId,
+        roomId: conv.roomId,
+        content: {
+          text: fallbackText,
+          blocks: [actionBlock],
+          source: "operator_action",
+          channelType: ChannelType.DM,
+        },
+      });
+
+      await runtime.createMemory(message, "messages");
+      conv.updatedAt = new Date().toISOString();
+
+      const responseMessage = {
+        id: message.id ?? (crypto.randomUUID() as UUID),
+        role: "user" as const,
+        text: fallbackText,
+        timestamp: message.createdAt ?? Date.now(),
+        blocks: [actionBlock],
+        source: "operator_action",
+      };
+
+      state.broadcastWs?.({
+        type: "proactive-message",
+        conversationId: conv.id,
+        message: responseMessage,
+      });
+
+      json(res, { message: responseMessage });
+    } catch (err) {
+      logger.warn(
+        `[conversations] POST /operator-action failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      error(res, getErrorMessage(err), 500);
     }
     return true;
   }

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -417,6 +417,41 @@ type OperatorActionBlock = {
   detail?: string;
 };
 
+/**
+ * Validate a single persisted content block pulled from the memory store.
+ * Returns the sanitized block, or null if the entry doesn't match a known
+ * shape. The DB is trusted-ish but the serializer still normalizes so the
+ * client never receives unexpected fields or types.
+ */
+function sanitizePersistedBlock(value: unknown): OperatorActionBlock | null {
+  if (!value || typeof value !== "object") return null;
+  const v = value as Record<string, unknown>;
+  if (v.type !== "action-pill") return null;
+  if (typeof v.label !== "string" || v.label.length === 0) return null;
+  if (v.kind !== "stream" && v.kind !== "avatar" && v.kind !== "launch") {
+    return null;
+  }
+  const out: OperatorActionBlock = {
+    type: "action-pill",
+    label: v.label,
+    kind: v.kind,
+  };
+  if (typeof v.detail === "string" && v.detail.trim().length > 0) {
+    out.detail = v.detail.trim();
+  }
+  return out;
+}
+
+function sanitizePersistedBlocks(
+  value: unknown,
+): OperatorActionBlock[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const blocks = value
+    .map((entry) => sanitizePersistedBlock(entry))
+    .filter((entry): entry is OperatorActionBlock => entry !== null);
+  return blocks.length > 0 ? blocks : undefined;
+}
+
 async function getConversationWithRestore(
   state: ConversationRouteState,
   convId: string,
@@ -740,11 +775,18 @@ export async function handleConversationRoutes(
             contentSource !== "client_chat"
               ? contentSource
               : undefined;
+          // Persisted content blocks (currently only action-pill) are
+          // serialized back so that action bubbles survive page reload.
+          // Without this, the pill renders via the immediate WS
+          // `proactive-message` event but vanishes on refresh because
+          // the transcript history fetch returns `text` only.
+          const persistedBlocks = sanitizePersistedBlocks(content.blocks);
           return {
             id: m.id ?? "",
             role: m.entityId === agentId ? "assistant" : "user",
             text: (m.content as { text?: string })?.text ?? "",
             timestamp: m.createdAt ?? 0,
+            ...(persistedBlocks ? { blocks: persistedBlocks } : {}),
             source: normalizedSource,
             from:
               typeof entityName === "string" && entityName.length > 0

--- a/packages/agent/test/api/conversation-operator-action.test.ts
+++ b/packages/agent/test/api/conversation-operator-action.test.ts
@@ -297,3 +297,165 @@ describe("POST /api/conversations/:id/operator-action", () => {
     );
   });
 });
+
+/**
+ * Companion test for the GET /messages serializer path. The POST route above
+ * only handles the live (WS proactive-message) render path — the pill also
+ * has to survive a page reload, which means GET /messages must surface the
+ * persisted `blocks` field.
+ */
+describe("GET /api/conversations/:id/messages — action-pill block survival", () => {
+  function buildGetCtx(
+    state: ConversationRouteState,
+    memories: Memory[],
+  ): {
+    ctx: ConversationRouteContext;
+    jsonMock: ReturnType<typeof vi.fn>;
+  } {
+    const getMemories = vi.fn(async () => memories);
+    if (state.runtime) {
+      (
+        state.runtime as unknown as { getMemories: typeof getMemories }
+      ).getMemories = getMemories;
+    }
+    const pathname = "/api/conversations/conv-1/messages";
+    const { res } = createMockHttpResponse();
+    const jsonMock = vi.fn(
+      (
+        response: Parameters<ConversationRouteContext["json"]>[0],
+        data: object,
+        status = 200,
+      ) => {
+        response.writeHead(status);
+        response.end(JSON.stringify(data));
+      },
+    );
+    const errorMock = vi.fn(
+      (
+        response: Parameters<ConversationRouteContext["error"]>[0],
+        message: string,
+        status = 500,
+      ) => {
+        response.writeHead(status);
+        response.end(JSON.stringify({ error: message }));
+      },
+    );
+    const ctx: ConversationRouteContext = {
+      req: createMockIncomingMessage({ method: "GET", url: pathname }),
+      res,
+      method: "GET",
+      pathname,
+      state,
+      json: jsonMock as unknown as ConversationRouteContext["json"],
+      error: errorMock as unknown as ConversationRouteContext["error"],
+      readJsonBody: vi.fn(
+        async () => null,
+      ) as unknown as ConversationRouteContext["readJsonBody"],
+    };
+    return { ctx, jsonMock };
+  }
+
+  test("includes action-pill blocks from persisted memory so pills survive reload", async () => {
+    const state = buildState();
+    const memory = {
+      id: "00000000-0000-4000-8000-000000000001" as UUID,
+      entityId: "00000000-0000-4000-8000-00000000dead" as UUID,
+      roomId: "00000000-0000-4000-8000-0000000000aa" as UUID,
+      createdAt: 1700000000000,
+      content: {
+        text: "Alice kicked off the stream.",
+        source: "operator_action",
+        blocks: [
+          {
+            type: "action-pill",
+            label: "Go Live",
+            kind: "stream",
+            detail: "Starting broadcast now",
+          },
+        ],
+      },
+    } as unknown as Memory;
+    const { ctx, jsonMock } = buildGetCtx(state, [memory]);
+
+    const handled = await handleConversationRoutes(ctx);
+
+    expect(handled).toBe(true);
+    const response = jsonMock.mock.calls[0]?.[1] as {
+      messages: Array<{
+        id: string;
+        role: string;
+        text: string;
+        source?: string;
+        blocks?: Array<{
+          type: string;
+          label: string;
+          kind: string;
+          detail?: string;
+        }>;
+      }>;
+    };
+    expect(response.messages).toHaveLength(1);
+    const message = response.messages[0];
+    expect(message.role).toBe("user");
+    expect(message.text).toBe("Alice kicked off the stream.");
+    expect(message.source).toBe("operator_action");
+    expect(message.blocks).toEqual([
+      {
+        type: "action-pill",
+        label: "Go Live",
+        kind: "stream",
+        detail: "Starting broadcast now",
+      },
+    ]);
+  });
+
+  test("sanitizes malformed blocks from persisted memory", async () => {
+    const state = buildState();
+    // Two memories: one with a valid block, one with garbage shapes that the
+    // sanitizer must drop. Confirms we don't forward arbitrary DB content.
+    const validMemory = {
+      id: "00000000-0000-4000-8000-000000000002" as UUID,
+      entityId: "00000000-0000-4000-8000-00000000dead" as UUID,
+      roomId: "00000000-0000-4000-8000-0000000000aa" as UUID,
+      createdAt: 1700000001000,
+      content: {
+        text: "ok",
+        source: "operator_action",
+        blocks: [{ type: "action-pill", label: "Launch", kind: "launch" }],
+      },
+    } as unknown as Memory;
+    const malformedMemory = {
+      id: "00000000-0000-4000-8000-000000000003" as UUID,
+      entityId: "00000000-0000-4000-8000-00000000dead" as UUID,
+      roomId: "00000000-0000-4000-8000-0000000000aa" as UUID,
+      createdAt: 1700000002000,
+      content: {
+        text: "garbage",
+        source: "operator_action",
+        blocks: [
+          { type: "action-pill", label: "", kind: "stream" }, // empty label
+          { type: "action-pill", label: "No Kind" }, // missing kind
+          { type: "unknown-block-type", label: "x", kind: "stream" }, // wrong type
+          "not-an-object",
+          null,
+        ],
+      },
+    } as unknown as Memory;
+    const { ctx, jsonMock } = buildGetCtx(state, [validMemory, malformedMemory]);
+
+    const handled = await handleConversationRoutes(ctx);
+
+    expect(handled).toBe(true);
+    const response = jsonMock.mock.calls[0]?.[1] as {
+      messages: Array<{ text: string; blocks?: unknown[] }>;
+    };
+    expect(response.messages).toHaveLength(2);
+    const [valid, malformed] = response.messages;
+    expect(valid.blocks).toEqual([
+      { type: "action-pill", label: "Launch", kind: "launch" },
+    ]);
+    // All entries in the malformed memory's blocks[] fail sanitization,
+    // so the field is omitted entirely from the serialized message.
+    expect(malformed).not.toHaveProperty("blocks");
+  });
+});

--- a/packages/agent/test/api/conversation-operator-action.test.ts
+++ b/packages/agent/test/api/conversation-operator-action.test.ts
@@ -1,0 +1,299 @@
+import type { Memory, UUID } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type {
+  ConversationRouteContext,
+  ConversationRouteState,
+} from "../../src/api/conversation-routes";
+import { handleConversationRoutes } from "../../src/api/conversation-routes";
+import {
+  createMockHttpResponse,
+  createMockIncomingMessage,
+} from "../../src/test-support/test-helpers";
+
+type OperatorActionBody = {
+  label?: string;
+  kind?: string;
+  detail?: string;
+  fallbackText?: string;
+};
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn(async () => ({
+    ok: true,
+    headers: {
+      get: () => null,
+    },
+    arrayBuffer: async () => new ArrayBuffer(0),
+  })) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function buildState(overrides: {
+  hasRuntime?: boolean;
+  ensureConnection?: ReturnType<typeof vi.fn>;
+  createMemory?: ReturnType<typeof vi.fn>;
+  getWorld?: ReturnType<typeof vi.fn>;
+  broadcastWs?: ((data: Record<string, unknown>) => void) | null;
+} = {}): ConversationRouteState {
+  const ensureConnection = overrides.ensureConnection ?? vi.fn(async () => {});
+  const createMemory = overrides.createMemory ?? vi.fn(async () => {});
+  const getWorld = overrides.getWorld ?? vi.fn(async () => null);
+  const runtime = overrides.hasRuntime === false
+    ? null
+    : ({
+        agentId: "agent-1" as UUID,
+        character: { name: "Milady" },
+        ensureConnection,
+        getWorld,
+        updateWorld: vi.fn(async () => {}),
+        createMemory,
+        getMemories: vi.fn(async () => [] as Memory[]),
+      } as unknown as ConversationRouteState["runtime"]);
+
+  return {
+    runtime,
+    config: {} as ConversationRouteState["config"],
+    agentName: "Milady",
+    adminEntityId: "00000000-0000-4000-8000-00000000dead" as UUID,
+    chatUserId: null,
+    logBuffer: [],
+    conversations: new Map([
+      [
+        "conv-1",
+        {
+          id: "conv-1",
+          title: "Operator chat",
+          roomId: "00000000-0000-4000-8000-0000000000aa" as UUID,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+    ]),
+    conversationRestorePromise: null,
+    deletedConversationIds: new Set(),
+    broadcastWs: overrides.broadcastWs ?? vi.fn(),
+  };
+}
+
+function buildCtx(
+  state: ConversationRouteState,
+  options: {
+    pathname: string;
+    body: OperatorActionBody | null;
+  },
+): {
+  ctx: ConversationRouteContext;
+  jsonMock: ReturnType<typeof vi.fn>;
+  errorMock: ReturnType<typeof vi.fn>;
+} {
+  const { res } = createMockHttpResponse();
+  const jsonMock = vi.fn(
+    (response: Parameters<ConversationRouteContext["json"]>[0], data: object, status = 200) => {
+      response.writeHead(status);
+      response.end(JSON.stringify(data));
+    },
+  );
+  const errorMock = vi.fn(
+    (response: Parameters<ConversationRouteContext["error"]>[0], message: string, status = 500) => {
+      response.writeHead(status);
+      response.end(JSON.stringify({ error: message }));
+    },
+  );
+  const ctx: ConversationRouteContext = {
+    req: createMockIncomingMessage({
+      method: "POST",
+      url: options.pathname,
+    }),
+    res,
+    method: "POST",
+    pathname: options.pathname,
+    state,
+    json: jsonMock as unknown as ConversationRouteContext["json"],
+    error: errorMock as unknown as ConversationRouteContext["error"],
+    readJsonBody: vi.fn(
+      async () => options.body,
+    ) as unknown as ConversationRouteContext["readJsonBody"],
+  };
+  return { ctx, jsonMock, errorMock };
+}
+
+describe("POST /api/conversations/:id/operator-action", () => {
+  test("persists a user memory with an action-pill block and broadcasts over WS", async () => {
+    const createMemory = vi.fn(async () => {});
+    const broadcastWs = vi.fn();
+    const state = buildState({ createMemory, broadcastWs });
+    const { ctx, jsonMock } = buildCtx(state, {
+      pathname: "/api/conversations/conv-1/operator-action",
+      body: {
+        label: "Go Live",
+        kind: "stream",
+        detail: "Starting broadcast now",
+        fallbackText: "Alice kicked off the stream.",
+      },
+    });
+
+    const handled = await handleConversationRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(createMemory).toHaveBeenCalledTimes(1);
+    const [persistedMemory, tableName] = createMemory.mock.calls[0] ?? [];
+    expect(tableName).toBe("messages");
+    expect(persistedMemory).toMatchObject({
+      content: {
+        text: "Alice kicked off the stream.",
+        source: "operator_action",
+        blocks: [
+          {
+            type: "action-pill",
+            label: "Go Live",
+            kind: "stream",
+            detail: "Starting broadcast now",
+          },
+        ],
+      },
+    });
+
+    expect(broadcastWs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "proactive-message",
+        conversationId: "conv-1",
+        message: expect.objectContaining({
+          role: "user",
+          text: "Alice kicked off the stream.",
+          source: "operator_action",
+          blocks: [
+            {
+              type: "action-pill",
+              label: "Go Live",
+              kind: "stream",
+              detail: "Starting broadcast now",
+            },
+          ],
+        }),
+      }),
+    );
+
+    const response = jsonMock.mock.calls[0]?.[1] as {
+      message: {
+        role: string;
+        text: string;
+        blocks: Array<{ type: string; label: string; kind: string }>;
+      };
+    };
+    expect(response.message.role).toBe("user");
+    expect(response.message.blocks).toEqual([
+      {
+        type: "action-pill",
+        label: "Go Live",
+        kind: "stream",
+        detail: "Starting broadcast now",
+      },
+    ]);
+  });
+
+  test("falls back to label when fallbackText is missing", async () => {
+    const createMemory = vi.fn(async () => {});
+    const state = buildState({ createMemory });
+    const { ctx, jsonMock } = buildCtx(state, {
+      pathname: "/api/conversations/conv-1/operator-action",
+      body: {
+        label: "Change Avatar",
+        kind: "avatar",
+      },
+    });
+
+    const handled = await handleConversationRoutes(ctx);
+
+    expect(handled).toBe(true);
+    const response = jsonMock.mock.calls[0]?.[1] as {
+      message: { text: string; blocks: Array<{ detail?: string }> };
+    };
+    expect(response.message.text).toBe("Change Avatar");
+    expect(response.message.blocks[0]).not.toHaveProperty("detail");
+  });
+
+  test("returns 404 when the conversation does not exist", async () => {
+    const state = buildState();
+    const { ctx, errorMock } = buildCtx(state, {
+      pathname: "/api/conversations/missing/operator-action",
+      body: {
+        label: "Go Live",
+        kind: "stream",
+      },
+    });
+
+    const handled = await handleConversationRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(errorMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "Conversation not found",
+      404,
+    );
+  });
+
+  test("returns 503 when no runtime is attached", async () => {
+    const state = buildState({ hasRuntime: false });
+    const { ctx, errorMock } = buildCtx(state, {
+      pathname: "/api/conversations/conv-1/operator-action",
+      body: {
+        label: "Go Live",
+        kind: "stream",
+      },
+    });
+
+    const handled = await handleConversationRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(errorMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "Agent is not running",
+      503,
+    );
+  });
+
+  test("returns 400 when label is missing or blank", async () => {
+    const state = buildState();
+    const { ctx, errorMock } = buildCtx(state, {
+      pathname: "/api/conversations/conv-1/operator-action",
+      body: {
+        label: "   ",
+        kind: "stream",
+      },
+    });
+
+    const handled = await handleConversationRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(errorMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "label is required",
+      400,
+    );
+  });
+
+  test("returns 400 when kind is not an allowed value", async () => {
+    const state = buildState();
+    const { ctx, errorMock } = buildCtx(state, {
+      pathname: "/api/conversations/conv-1/operator-action",
+      body: {
+        label: "Go Live",
+        kind: "sudo",
+      },
+    });
+
+    const handled = await handleConversationRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(errorMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "kind must be 'stream', 'avatar', or 'launch'",
+      400,
+    );
+  });
+});

--- a/packages/app-core/src/hooks/useActivityEvents.test.tsx
+++ b/packages/app-core/src/hooks/useActivityEvents.test.tsx
@@ -118,6 +118,46 @@ describe("useActivityEvents", () => {
     expect(wsMocks.unsubscribers.get("agent_event")).toHaveBeenCalledTimes(1);
   });
 
+  it("ignores proactive-message payloads from operator_action", () => {
+    act(() => {
+      TestRenderer.create(React.createElement(Harness));
+    });
+
+    // Real operator click — the server broadcasts the full message object
+    // with source=operator_action. This must NOT show up in the activity
+    // rail; the pill is already rendered as a chat bubble and the activity
+    // rail is reserved for inbound/external signals.
+    act(() => {
+      wsMocks.handlers.get("proactive-message")?.({
+        conversationId: "conv-1",
+        message: {
+          id: "msg-1",
+          role: "user",
+          text: "Alice kicked off the stream.",
+          source: "operator_action",
+          blocks: [
+            { type: "action-pill", label: "Go Live", kind: "stream" },
+          ],
+        },
+      });
+    });
+
+    expect(latestState?.events).toEqual([]);
+
+    // A genuine proactive message (no operator_action source) still records.
+    act(() => {
+      wsMocks.handlers.get("proactive-message")?.({
+        message: "Follow-up issue created",
+      });
+    });
+
+    expect(latestState?.events).toHaveLength(1);
+    expect(latestState?.events[0]).toMatchObject({
+      eventType: "proactive-message",
+      summary: "Follow-up issue created",
+    });
+  });
+
   it("caps the ring buffer at 200 entries", () => {
     act(() => {
       TestRenderer.create(React.createElement(Harness));

--- a/packages/app-core/src/hooks/useActivityEvents.ts
+++ b/packages/app-core/src/hooks/useActivityEvents.ts
@@ -118,6 +118,19 @@ export function useActivityEvents() {
     const unbindProactive = client.onWsEvent(
       "proactive-message",
       (data: Record<string, unknown>) => {
+        // Operator-action pills (Go Live, Change Avatar, Launch) are
+        // broadcast as proactive-message so the chat bubble renders
+        // immediately, but they are internal control actions and must
+        // not populate the global activity rail. Skip them here in
+        // addition to the synthetic-event filters in AppContext and
+        // startup-phase-hydrate.
+        const payload =
+          data.message && typeof data.message === "object"
+            ? (data.message as Record<string, unknown>)
+            : null;
+        if (payload && payload.source === "operator_action") {
+          return;
+        }
         const message =
           typeof data.message === "string"
             ? data.message.slice(0, 120)

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -7804,10 +7804,14 @@ function AppProviderInner({
           }
 
           // Synthesize agent_event for non-client_chat sources (e.g. discord)
-          // so they appear in the StreamView activity feed
+          // so they appear in the StreamView activity feed. Operator-action
+          // pills are internal control actions (Go Live, change avatar, etc.)
+          // and stay chat-only — they must not leak into the inbound-event
+          // feed or the activity log fills up with the operator's own clicks.
           if (
             msg.source &&
             msg.source !== "client_chat" &&
+            msg.source !== "operator_action" &&
             msg.role === "user"
           ) {
             appendAutonomousEvent({

--- a/packages/app-core/src/state/startup-phase-hydrate.ts
+++ b/packages/app-core/src/state/startup-phase-hydrate.ts
@@ -441,7 +441,15 @@ export function bindReadyPhase(
         d.setUnreadConversations(
           (prev: Set<string>) => new Set([...prev, cid]),
         );
-      if (msg.source && msg.source !== "client_chat" && msg.role === "user")
+      // Keep operator_action pills out of the synthetic inbound-event feed
+      // — they are internal control actions (Go Live, change avatar, etc.),
+      // not real inbound messages.
+      if (
+        msg.source &&
+        msg.source !== "client_chat" &&
+        msg.source !== "operator_action" &&
+        msg.role === "user"
+      )
         d.appendAutonomousEvent({
           type: "agent_event",
           version: 1,


### PR DESCRIPTION
## Summary

- Restore the server-side handler for `POST /api/conversations/:id/operator-action` so operator-action pill bubbles (Go Live, Change Avatar, Launch) render again in the SPA transcript.
- The handler was dropped during the packages/agent refactor. The client still posts to the route (see `packages/app-core/src/api/client.ts:5375`) and expects `{ message: ConversationMessage }` back; when the route 404s, the SPA silently drops the pill and no bubble renders.
- Ported the historic handler from commit `e886ca26c` ("Fix pro streamer operator action logging") into `packages/agent/src/api/conversation-routes.ts`, adapted for the current `ConversationRouteState` shape (`ensureAdminEntityId(state)`, `ensureConversationRoom(state, conv)`, `state.broadcastWs`).

## Regression repro (alice-bot)

```
curl -s -X POST https://.../api/conversations/$CONV/operator-action \
  -H 'Content-Type: application/json' \
  -d '{"label":"Go Live","kind":"stream"}'
{"error":"Not found"}
```

After this change the handler persists a user-turn memory with `content.source="operator_action"` + a single `action-pill` block, updates `conv.updatedAt`, broadcasts `{type:"proactive-message", conversationId, message}` over WS so the bubble appears without a reload, and returns the message.

## Validation matrix

| case                              | status |
| --------------------------------- | ------ |
| valid payload                     | 200    |
| unknown conversation id           | 404    |
| no runtime attached               | 503    |
| missing / blank `label`           | 400    |
| `kind` not in {stream,avatar,launch} | 400 |

## Test plan

- [x] Unit tests in `packages/agent/test/api/conversation-operator-action.test.ts` cover the six cases above against `handleConversationRoutes`, asserting `createMemory` payload shape, WS broadcast payload, and response body.
- [ ] Local vitest run failed with the pre-existing workspace `@miladyai/shared/onboarding-presets` resolution error (confirmed by also re-running the pre-existing `conversation-routes.test.ts` — same failure). Trusting CI for the actual run.
- [ ] Manual smoke on alice-bot: POST operator-action and confirm the pill bubble appears in the active conversation via the WS listener.