### PR TITLE
fix(broadcast): hide SYS: diagnostic overlays in capture mode

### DIFF
--- a/packages/app-core/src/components/companion/scene-overlay-bridge.ts
+++ b/packages/app-core/src/components/companion/scene-overlay-bridge.ts
@@ -8,6 +8,7 @@
 
 import { useApp, usePtySessions } from "@miladyai/app-core/state";
 import { useCallback, useEffect, useRef } from "react";
+import { getBroadcastMode } from "../../platform/init";
 import type { SceneOverlayManager } from "../avatar/SceneOverlayManager";
 import type {
   AgentStatusOverlay,
@@ -62,12 +63,20 @@ export function SceneOverlayDataBridge(): null {
     manager.setChatMessages(mapped);
   }, [conversationMessages, getManager]);
 
+  // SYS: panels (agent status, heartbeats/triggers) are operator-facing
+  // diagnostics — useful in the personal companion view but noise on the
+  // Twitch/Kick broadcast. Suppress them when the SPA is running inside
+  // capture-service so viewers see a clean scene without the SYS:STATUS
+  // chrome. Chat messages are still propagated because viewers DO want
+  // to see the live chat bubbles.
+  const isBroadcastCapture = getBroadcastMode() === "capture";
+
   // Agent status + coding sessions
   useEffect(() => {
     const manager = getManager();
     if (!manager) return;
 
-    if (!agentStatus) {
+    if (isBroadcastCapture || !agentStatus) {
       manager.setAgentStatus(null);
       return;
     }
@@ -83,12 +92,17 @@ export function SceneOverlayDataBridge(): null {
       })),
     };
     manager.setAgentStatus(status);
-  }, [agentStatus, ptySessions, getManager]);
+  }, [agentStatus, ptySessions, getManager, isBroadcastCapture]);
 
   // Heartbeats / triggers
   useEffect(() => {
     const manager = getManager();
     if (!manager) return;
+
+    if (isBroadcastCapture) {
+      manager.setHeartbeats([]);
+      return;
+    }
 
     const mapped: TriggerOverlay[] = triggers.map((t) => ({
       id: t.id,
@@ -100,7 +114,7 @@ export function SceneOverlayDataBridge(): null {
       intervalMs: t.intervalMs,
     }));
     manager.setHeartbeats(mapped);
-  }, [triggers, getManager]);
+  }, [triggers, getManager, isBroadcastCapture]);
 
   return null;
 }


### PR DESCRIPTION
## Why

The SYS:STATUS + heartbeats HUD panels in the companion scene (`scene-overlay-renderer.ts`, fed by `SceneOverlayDataBridge`) are operator diagnostics — useful to know whether the agent runtime is alive. They show up in every companion mount including the Twitch/Kick broadcast, which is unwanted noise for viewers.

## What

In `scene-overlay-bridge.ts`, short-circuit the two SYS effects when `getBroadcastMode() === "capture"`:

- `setAgentStatus(null)` on broadcast — renderer shows empty/offline panel, which is then fully transparent
- `setHeartbeats([])` on broadcast — panel opacity drops to 0 per the existing fade logic

Chat overlay (`setChatMessages`) is intentionally NOT gated — viewers want to see the live chat bubbles on the stream.

## What stays unchanged

- Personal companion view (`alice.rndrntwrk.com/`) still shows the HUD exactly as before — operator utility preserved
- Desktop + mobile shells (Electrobun, Capacitor) unaffected — they never hit capture mode
- `CompanionView` mount, `SceneOverlayManager` lifecycle, renderer internals all untouched