### PR TITLE
fix(startup): never auto-land on character-select tab

### DIFF
--- a/packages/app-core/src/state/startup-phase-hydrate.ts
+++ b/packages/app-core/src/state/startup-phase-hydrate.ts
@@ -27,7 +27,6 @@ import {
   tabFromPath,
   type Tab,
 } from "../navigation";
-import { shouldStartAtCharacterSelectOnLaunch } from "./shell-routing";
 import { resolveApiUrl } from "../utils";
 import type { StartupEvent } from "./startup-coordinator";
 import type { AgentStatus, WalletAddresses } from "../api";
@@ -256,21 +255,18 @@ export async function runHydrating(
   const navPath = getNavigationPathFromWindow();
   const urlTab = tabFromPath(navPath);
   const isRoot = isRouteRootPath(navPath);
-  const shouldCharSelect =
-    deps.onboardingCompletionCommittedRef.current ||
-    shouldStartAtCharacterSelectOnLaunch({
-      onboardingNeedsOptions: false,
-      onboardingMode: deps.onboardingMode,
-      navPath,
-      urlTab,
-    });
+  // For the single-character alice surface, the post-onboarding character
+  // picker is obsolete — there is only ever one persona (Alice) and the
+  // scene already renders her. Showing the picker at launch confused users
+  // into thinking onboarding was restarting. Clear the committed ref and
+  // always land on the default tab; never trigger the character-select
+  // redirect automatically. The character-select tab is still reachable
+  // via explicit URL navigation (`/character-select`) — see the urlTab
+  // handling below — so the dedicated settings flow is unaffected.
   if (!deps.initialTabSetRef.current) {
     deps.initialTabSetRef.current = true;
-    if (shouldCharSelect) {
-      deps.onboardingCompletionCommittedRef.current = false;
-      deps.setTab("character-select");
-      void deps.loadCharacter();
-    } else if (isRoot) deps.setTab(DEFAULT_LANDING_TAB);
+    deps.onboardingCompletionCommittedRef.current = false;
+    if (isRoot) deps.setTab(DEFAULT_LANDING_TAB);
   }
   if (urlTab && urlTab !== "chat" && urlTab !== "companion") {
     deps.setTabRaw(urlTab);


### PR DESCRIPTION
## Why

The post-onboarding character picker is a holdover from the multi-character milady days. Alice is the only persona in the alice surface — the scene already renders her VRM unconditionally — and showing a picker at launch made every fresh browser look like it was restarting onboarding, which it wasn't.

## What

`runHydrating` was gating on:

```ts
const shouldCharSelect =
  deps.onboardingCompletionCommittedRef.current ||
  shouldStartAtCharacterSelectOnLaunch({ ... });
```

`shouldStartAtCharacterSelectOnLaunch` already hardcodes `return false` (see `shell-routing.ts:28`), so the remaining trigger was the committed ref — set to `true` by `completeOnboarding()` and never cleared on cold start. For any user whose in-session state had it set (either from completing onboarding once or from a lingering in-memory flag), hydrate would `setTab("character-select")` and drop them into the roster view with no visible path back to companion.

Remove the gate. Clear the ref unconditionally on first tab-set so future logic always starts from a clean slate, and land on `DEFAULT_LANDING_TAB` (chat/companion) as the single canonical entry point.

The character-select tab stays reachable via explicit URL navigation (`/character-select`) for the settings flow that genuinely wants it — that path is handled separately a few lines below and is untouched.

## Verification

- Fresh browser → SSO → land on companion (no roster interlude)
- `/character-select` URL still routes to the roster (by explicit navigation)
- No effect on broadcast capture view, desktop, or mobile

Net change: +10/-13 in `packages/app-core/src/state/startup-phase-hydrate.ts` including the dropped `shouldStartAtCharacterSelectOnLaunch` import.