### PR TITLE
fix(startup): fall through to polling-backend on web when probe fails

### DIFF
--- a/packages/app-core/src/state/startup-phase-restore.test.ts
+++ b/packages/app-core/src/state/startup-phase-restore.test.ts
@@ -23,7 +23,11 @@ vi.mock("./onboarding-bootstrap", () => ({
 }));
 
 vi.mock("./persistence", () => ({
-  createPersistedActiveServer: vi.fn(),
+  createPersistedActiveServer: vi.fn(({ kind }: { kind: string }) => ({
+    id: "local:embedded",
+    kind,
+    label: "This device",
+  })),
   loadPersistedActiveServer: vi.fn(() => null),
   loadPersistedOnboardingComplete: vi.fn(() => false),
 }));
@@ -33,6 +37,7 @@ import {
   getDesktopRuntimeMode,
   inspectExistingElizaInstall,
   invokeDesktopBridgeRequest,
+  isElectrobunRuntime,
 } from "../bridge";
 import { detectExistingOnboardingConnection } from "./onboarding-bootstrap";
 import {
@@ -180,6 +185,87 @@ describe("runRestoringSession", () => {
     expect(dispatch).toHaveBeenCalledWith({
       type: "SESSION_RESTORED",
       target: "embedded-local",
+    });
+  });
+
+  it("falls through to polling-backend on web when probe returns null", async () => {
+    // Simulate fresh web browser: no Electrobun runtime, no persisted server,
+    // no prior onboarding evidence, and the onboarding probe fails/returns
+    // null (e.g. CF cold-start timed out the 3.5s budget).
+    vi.mocked(isElectrobunRuntime).mockReturnValue(false);
+    vi.mocked(loadPersistedActiveServer).mockReturnValue(null);
+    vi.mocked(loadPersistedOnboardingComplete).mockReturnValue(false);
+    vi.mocked(inspectExistingElizaInstall).mockResolvedValue(null);
+    vi.mocked(detectExistingOnboardingConnection).mockResolvedValue(null);
+
+    const dispatch = vi.fn();
+    const ctxRef = { current: null };
+    const deps = {
+      setStartupError: vi.fn(),
+      setAuthRequired: vi.fn(),
+      setConnected: vi.fn(),
+      setOnboardingExistingInstallDetected: vi.fn(),
+      setOnboardingOptions: vi.fn(),
+      setOnboardingComplete: vi.fn(),
+      setOnboardingLoading: vi.fn(),
+      applyDetectedProviders: vi.fn(),
+      forceLocalBootstrapRef: { current: false },
+      onboardingCompletionCommittedRef: { current: false },
+      uiLanguage: "en",
+    };
+
+    await runRestoringSession(deps, dispatch, ctxRef, { current: false });
+
+    // We must NOT show the onboarding wizard — the backend authoritative
+    // check happens in polling-backend which has a generous budget.
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "NO_SESSION" }),
+    );
+    expect(deps.setOnboardingOptions).not.toHaveBeenCalled();
+    expect(deps.setOnboardingComplete).not.toHaveBeenCalled();
+
+    // Instead we should restore a default local target and proceed.
+    expect(ctxRef.current).toMatchObject({
+      persistedActiveServer: null,
+      restoredActiveServer: { kind: "local" },
+      hadPriorOnboarding: false,
+    });
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "SESSION_RESTORED",
+      target: "embedded-local",
+    });
+  });
+
+  it("keeps the desktop onboarding fallback when no install is detected", async () => {
+    vi.mocked(isElectrobunRuntime).mockReturnValue(true);
+    vi.mocked(loadPersistedActiveServer).mockReturnValue(null);
+    vi.mocked(loadPersistedOnboardingComplete).mockReturnValue(false);
+    vi.mocked(inspectExistingElizaInstall).mockResolvedValue(null);
+    vi.mocked(detectExistingOnboardingConnection).mockResolvedValue(null);
+
+    const dispatch = vi.fn();
+    const ctxRef = { current: null };
+    const deps = {
+      setStartupError: vi.fn(),
+      setAuthRequired: vi.fn(),
+      setConnected: vi.fn(),
+      setOnboardingExistingInstallDetected: vi.fn(),
+      setOnboardingOptions: vi.fn(),
+      setOnboardingComplete: vi.fn(),
+      setOnboardingLoading: vi.fn(),
+      applyDetectedProviders: vi.fn(),
+      forceLocalBootstrapRef: { current: false },
+      onboardingCompletionCommittedRef: { current: false },
+      uiLanguage: "en",
+    };
+
+    await runRestoringSession(deps, dispatch, ctxRef, { current: false });
+
+    expect(deps.setOnboardingOptions).toHaveBeenCalledOnce();
+    expect(deps.setOnboardingComplete).toHaveBeenCalledWith(false);
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "NO_SESSION",
+      hadPriorOnboarding: false,
     });
   });
 });

--- a/packages/app-core/src/state/startup-phase-restore.ts
+++ b/packages/app-core/src/state/startup-phase-restore.ts
@@ -149,7 +149,33 @@ export async function runRestoringSession(
   );
 
   if (!restoredActiveServer) {
-    // No saved backend found — let the user (re-)onboard.
+    // No saved backend. On web/mobile the backend lives at the same origin,
+    // so the probe's 3.5s budget is too tight for CF cold-starts, transient
+    // network hiccups, or Access cookie churn. Fall through to polling-backend
+    // with a default local target — that phase has a 30s budget with retry
+    // and will authoritatively determine whether onboarding is complete.
+    // Desktop keeps the original "no install found → show onboarding" path
+    // because there's no same-origin backend to probe further.
+    if (!isDesktop) {
+      const fallbackLocal = createPersistedActiveServer({ kind: "local" });
+      await applyRestoredConnection({
+        restoredActiveServer: fallbackLocal,
+        clientRef: client,
+      });
+      ctxRef.current = {
+        persistedActiveServer: null,
+        restoredActiveServer: fallbackLocal,
+        shouldPreserveCompletedOnboarding: preserveCompleted,
+        hadPriorOnboarding: hadPrior,
+      };
+      dispatch({
+        type: "SESSION_RESTORED",
+        target: activeServerToTarget(fallbackLocal.kind),
+      });
+      return;
+    }
+
+    // Desktop: let the user (re-)onboard.
     deps.setOnboardingOptions({
       names: [],
       styles: getStylePresets(deps.uiLanguage),


### PR DESCRIPTION
## Summary
- Fresh web browsers visiting `alice.rndrntwrk.com` were landing on the onboarding wizard even though the backend reports `onboardingComplete: true`.
- Root cause: the 3.5s onboarding probe in `runRestoringSession` is too tight for CF Access cold-starts / cookie churn, returns null, and dispatches `NO_SESSION` → `onboarding-required`.
- On web/mobile the backend always lives at the same origin — route inconclusive probe results through `polling-backend` (30s budget, retry) instead of bailing to onboarding. Desktop keeps the current behavior since it has no same-origin fallback.

## Test plan
- [x] Added test: web + no probe result → `SESSION_RESTORED` with `embedded-local`, no `NO_SESSION`, no onboarding option reset.
- [x] Added test: desktop + no probe result + no install → original `NO_SESSION` path preserved.
- [x] `bunx vitest run --config vitest.unit.config.ts packages/app-core/src/state/startup-phase-restore.test.ts` — 7/7 pass.
- [ ] Burn-in: fresh incognito visit to alice.rndrntwrk.com after CF Access SSO should land on companion view with Alice + prior DMs instead of onboarding wizard.