### PR TITLE
fix(startup): tighten PR #89 gate — native cloud-only keeps onboarding

### DIFF
--- a/packages/app-core/src/state/startup-phase-restore.test.ts
+++ b/packages/app-core/src/state/startup-phase-restore.test.ts
@@ -15,6 +15,7 @@ vi.mock("../bridge", () => ({
   inspectExistingElizaInstall: vi.fn(async () => null),
   invokeDesktopBridgeRequest: vi.fn(async () => {}),
   isElectrobunRuntime: vi.fn(() => false),
+  isWeb: vi.fn(() => true),
   scanProviderCredentials: vi.fn(async () => []),
 }));
 
@@ -38,6 +39,7 @@ import {
   inspectExistingElizaInstall,
   invokeDesktopBridgeRequest,
   isElectrobunRuntime,
+  isWeb,
 } from "../bridge";
 import { detectExistingOnboardingConnection } from "./onboarding-bootstrap";
 import {
@@ -193,6 +195,7 @@ describe("runRestoringSession", () => {
     // no prior onboarding evidence, and the onboarding probe fails/returns
     // null (e.g. CF cold-start timed out the 3.5s budget).
     vi.mocked(isElectrobunRuntime).mockReturnValue(false);
+    vi.mocked(isWeb).mockReturnValue(true);
     vi.mocked(loadPersistedActiveServer).mockReturnValue(null);
     vi.mocked(loadPersistedOnboardingComplete).mockReturnValue(false);
     vi.mocked(inspectExistingElizaInstall).mockResolvedValue(null);
@@ -238,6 +241,7 @@ describe("runRestoringSession", () => {
 
   it("keeps the desktop onboarding fallback when no install is detected", async () => {
     vi.mocked(isElectrobunRuntime).mockReturnValue(true);
+    vi.mocked(isWeb).mockReturnValue(false);
     vi.mocked(loadPersistedActiveServer).mockReturnValue(null);
     vi.mocked(loadPersistedOnboardingComplete).mockReturnValue(false);
     vi.mocked(inspectExistingElizaInstall).mockResolvedValue(null);
@@ -261,6 +265,48 @@ describe("runRestoringSession", () => {
 
     await runRestoringSession(deps, dispatch, ctxRef, { current: false });
 
+    expect(deps.setOnboardingOptions).toHaveBeenCalledOnce();
+    expect(deps.setOnboardingComplete).toHaveBeenCalledWith(false);
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "NO_SESSION",
+      hadPriorOnboarding: false,
+    });
+  });
+
+  it("keeps the onboarding fallback on native cloud-only runtimes (iOS/Android)", async () => {
+    // Native Capacitor apps report platform !== "web" and are not Electrobun.
+    // They are cloud-only — there is no embedded-local runtime to fall back
+    // to. The web short-circuit must not fire here; the original NO_SESSION
+    // path should take over so the onboarding/connection wizard renders.
+    vi.mocked(isElectrobunRuntime).mockReturnValue(false);
+    vi.mocked(isWeb).mockReturnValue(false);
+    vi.mocked(loadPersistedActiveServer).mockReturnValue(null);
+    vi.mocked(loadPersistedOnboardingComplete).mockReturnValue(false);
+    vi.mocked(inspectExistingElizaInstall).mockResolvedValue(null);
+    vi.mocked(detectExistingOnboardingConnection).mockResolvedValue(null);
+
+    const dispatch = vi.fn();
+    const ctxRef = { current: null };
+    const deps = {
+      setStartupError: vi.fn(),
+      setAuthRequired: vi.fn(),
+      setConnected: vi.fn(),
+      setOnboardingExistingInstallDetected: vi.fn(),
+      setOnboardingOptions: vi.fn(),
+      setOnboardingComplete: vi.fn(),
+      setOnboardingLoading: vi.fn(),
+      applyDetectedProviders: vi.fn(),
+      forceLocalBootstrapRef: { current: false },
+      onboardingCompletionCommittedRef: { current: false },
+      uiLanguage: "en",
+    };
+
+    await runRestoringSession(deps, dispatch, ctxRef, { current: false });
+
+    // Must not synthesize a local target the native runtime cannot satisfy.
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "SESSION_RESTORED" }),
+    );
     expect(deps.setOnboardingOptions).toHaveBeenCalledOnce();
     expect(deps.setOnboardingComplete).toHaveBeenCalledWith(false);
     expect(dispatch).toHaveBeenCalledWith({

--- a/packages/app-core/src/state/startup-phase-restore.ts
+++ b/packages/app-core/src/state/startup-phase-restore.ts
@@ -12,6 +12,7 @@ import {
   inspectExistingElizaInstall,
   invokeDesktopBridgeRequest,
   isElectrobunRuntime,
+  isWeb,
   scanProviderCredentials,
 } from "../bridge";
 import { ONBOARDING_PROVIDER_CATALOG } from "@miladyai/shared/contracts/onboarding";
@@ -149,14 +150,19 @@ export async function runRestoringSession(
   );
 
   if (!restoredActiveServer) {
-    // No saved backend. On web/mobile the backend lives at the same origin,
-    // so the probe's 3.5s budget is too tight for CF cold-starts, transient
-    // network hiccups, or Access cookie churn. Fall through to polling-backend
-    // with a default local target — that phase has a 30s budget with retry
-    // and will authoritatively determine whether onboarding is complete.
-    // Desktop keeps the original "no install found → show onboarding" path
-    // because there's no same-origin backend to probe further.
-    if (!isDesktop) {
+    // Web only: the backend always lives at the same origin, so the probe's
+    // 3.5s budget is too tight for CF cold-starts, transient network hiccups,
+    // or Access cookie churn. Fall through to polling-backend with a default
+    // local target — that phase has a 30s budget with retry and will
+    // authoritatively determine whether onboarding is complete.
+    //
+    // Native (iOS/Android Capacitor) is explicitly cloud-only: there is no
+    // same-origin embedded runtime to reach, so defaulting to "local" here
+    // would park the UI on a 30s poll against a backend that will never
+    // exist. Desktop (Electrobun) has an embedded runtime but no same-origin
+    // guarantee without an install on disk. Both keep the original
+    // "no session → show onboarding" path.
+    if (isWeb()) {
       const fallbackLocal = createPersistedActiveServer({ kind: "local" });
       await applyRestoredConnection({
         restoredActiveServer: fallbackLocal,
@@ -175,7 +181,7 @@ export async function runRestoringSession(
       return;
     }
 
-    // Desktop: let the user (re-)onboard.
+    // Desktop / native: let the user (re-)onboard.
     deps.setOnboardingOptions({
       names: [],
       styles: getStylePresets(deps.uiLanguage),


### PR DESCRIPTION
## Summary
- Follow-up to #89. The web short-circuit was guarded by \`!isDesktop\`, which also matched iOS/Android Capacitor.
- Native is explicitly cloud-only — there's no local backend to fall back to, so defaulting to \`embedded-local\` would park the UI on a 30s poll against a runtime that never exists.
- Replace the gate with the existing \`isWeb()\` helper from the platform bridge so only real browser contexts take the new fallback; desktop and native keep the original \"no session → show onboarding\" path.

## Test plan
- [x] Added test: native (iOS/Android) runtime — \`isElectrobunRuntime=false\`, \`isWeb=false\` — dispatches \`NO_SESSION\`, not \`SESSION_RESTORED\`, and renders the onboarding options.
- [x] Updated existing web-fallback test to set \`isWeb(true)\` explicitly.
- [x] Updated existing desktop test to set \`isWeb(false)\` explicitly.
- [x] \`bunx vitest run --config vitest.unit.config.ts packages/app-core/src/state/startup-phase-restore.test.ts\` — 8/8 pass.
- [ ] Burn-in: alice.rndrntwrk.com fresh browser still lands on companion view; iOS/Android devtools (future) still see the onboarding/connection step.