### PR TITLE
fix(startup): web browsers bypass onboarding short-circuit in legacy initApp

### DIFF
--- a/packages/agent/src/api/static-file-server.test.ts
+++ b/packages/agent/src/api/static-file-server.test.ts
@@ -30,6 +30,36 @@ describe("injectApiBaseIntoHtml", () => {
     expect(injected).toContain("window.__ELIZA_API_TOKEN__");
     expect(withoutToken).not.toContain("window.__ELIZA_API_TOKEN__");
   });
+
+  it("declares same-origin as the API base when no explicit base is provided", () => {
+    // Agent-colocated SPA (e.g. alice-bot): /api/* lives at the same origin
+    // as the served HTML. The injected marker tells shouldUseCloudOnlyBranding
+    // the SPA is not cloud-only, so the startup path calls the same-origin
+    // /api/onboarding/status instead of routing fresh visitors to onboarding.
+    const html = Buffer.from("<html><head></head><body></body></html>");
+    const out = injectApiBaseIntoHtml(html, null).toString("utf8");
+    expect(out).toContain("window.__MILADY_API_BASE__");
+    expect(out).toContain("window.location.origin");
+    // Uses a `||` guard so an already-set value (e.g. from a shell preload)
+    // is not clobbered.
+    expect(out).toContain("window.__MILADY_API_BASE__||window.location.origin");
+  });
+
+  it("pins both namespaces when an explicit base is provided", () => {
+    const html = Buffer.from("<html><head></head><body></body></html>");
+    const out = injectApiBaseIntoHtml(
+      html,
+      "https://proxy.example.com/p/42",
+    ).toString("utf8");
+    expect(out).toContain(
+      'window.__ELIZA_API_BASE__="https://proxy.example.com/p/42"',
+    );
+    expect(out).toContain(
+      'window.__MILADY_API_BASE__="https://proxy.example.com/p/42"',
+    );
+    // Same-origin default does NOT fire when an explicit base is given.
+    expect(out).not.toContain("window.location.origin");
+  });
 });
 
 describe("injectBaseHrefIntoHtml", () => {

--- a/packages/agent/src/api/static-file-server.ts
+++ b/packages/agent/src/api/static-file-server.ts
@@ -142,7 +142,6 @@ export function injectApiBaseIntoHtml(
 ): Buffer {
   const trimmedBase = externalBase?.trim();
   const trimmedToken = opts?.apiToken?.trim();
-  if (!trimmedBase && !trimmedToken) return html;
 
   const headCloseTag = "</head>";
   const headCloseIndex = html.indexOf(headCloseTag);
@@ -150,11 +149,27 @@ export function injectApiBaseIntoHtml(
 
   const parts: string[] = [];
   if (trimmedBase) {
+    // Explicit reverse-proxy base — pin both namespaces to the injected URL.
     parts.push(`window.__ELIZA_API_BASE__=${JSON.stringify(trimmedBase)};`);
+    parts.push(`window.__MILADY_API_BASE__=${JSON.stringify(trimmedBase)};`);
+  } else {
+    // No reverse-proxy base but the SPA is being served by the agent itself,
+    // which means the /api/* endpoints are colocated at the same origin as
+    // this HTML. Set __MILADY_API_BASE__ to window.location.origin so
+    // shouldUseCloudOnlyBranding() (apps/app/src/cloud-only.ts) sees an
+    // injected API base and flips branding.cloudOnly to false. Without this
+    // marker, the SPA defaults to the cloud-only hosted-web posture and
+    // routes fresh visitors into the onboarding wizard instead of hitting
+    // /api/onboarding/status same-origin — the bug that kept showing up on
+    // alice.rndrntwrk.com fresh incognito sessions.
+    parts.push(
+      "window.__MILADY_API_BASE__=window.__MILADY_API_BASE__||window.location.origin;",
+    );
   }
   if (trimmedToken) {
     parts.push(`window.__ELIZA_API_TOKEN__=${JSON.stringify(trimmedToken)};`);
   }
+  if (parts.length === 0) return html;
   const injection = Buffer.from(`<script>${parts.join("")}</script>`);
 
   return Buffer.concat([

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -97,6 +97,7 @@ import {
   invokeDesktopBridgeRequest,
   invokeDesktopBridgeRequestWithTimeout,
   isElectrobunRuntime,
+  isWeb,
   scanProviderCredentials,
 } from "../bridge";
 import {
@@ -7250,10 +7251,21 @@ function AppProviderInner({
       if (cancelled) {
         return;
       }
+      // Web browsers always target the same-origin backend — there is no
+      // filesystem to inspect, no install to detect. If persistence/probe
+      // didn't resolve anything, default to a local target so the backend
+      // poll below gets to call /api/onboarding/status (30s budget, retries)
+      // instead of the legacy short-circuit that bails straight to the
+      // onboarding wizard. Cloud/remote targets are established via the
+      // persisted path, so this only kicks in for fresh browser visits.
+      // Desktop (Electrobun) already flips via shouldPreferLocalBootstrap.
+      // Native (iOS/Android Capacitor) is cloud-only and keeps the original
+      // "show onboarding when no connection" path since there is no
+      // embedded-local runtime to reach.
       const restoredConnection =
         persistedConnection ??
         probedConnection?.connection ??
-        (shouldPreferLocalBootstrap ? { runMode: "local" } : null);
+        (shouldPreferLocalBootstrap || isWeb() ? { runMode: "local" } : null);
       const shouldPreserveCompletedOnboarding =
         persistedOnboardingCompleteAtStartup &&
         !onboardingCompletionCommittedRef.current;

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -97,7 +97,6 @@ import {
   invokeDesktopBridgeRequest,
   invokeDesktopBridgeRequestWithTimeout,
   isElectrobunRuntime,
-  isWeb,
   scanProviderCredentials,
 } from "../bridge";
 import {
@@ -7251,21 +7250,29 @@ function AppProviderInner({
       if (cancelled) {
         return;
       }
-      // Web browsers always target the same-origin backend — there is no
-      // filesystem to inspect, no install to detect. If persistence/probe
-      // didn't resolve anything, default to a local target so the backend
-      // poll below gets to call /api/onboarding/status (30s budget, retries)
+      // When the host has declared a same-origin backend (branding.cloudOnly
+      // === false, which shouldUseCloudOnlyBranding flips when an API base is
+      // injected by the shell), default to a local target so the backend poll
+      // below gets to call /api/onboarding/status (30s budget, retries)
       // instead of the legacy short-circuit that bails straight to the
-      // onboarding wizard. Cloud/remote targets are established via the
-      // persisted path, so this only kicks in for fresh browser visits.
-      // Desktop (Electrobun) already flips via shouldPreferLocalBootstrap.
-      // Native (iOS/Android Capacitor) is cloud-only and keeps the original
-      // "show onboarding when no connection" path since there is no
-      // embedded-local runtime to reach.
+      // onboarding wizard. This handles agent-colocated SPAs like alice-bot
+      // where the /api/* endpoints always exist at the same origin as the
+      // served HTML.
+      //
+      // The cloud-only web bundle (app.milady.ai style hosted distribution)
+      // keeps its original behavior: branding.cloudOnly stays true (no API
+      // base injected), restoredConnection stays null on fresh visits, and
+      // the onboarding/connection flow runs so the user can wire up a cloud
+      // or remote backend. Same for iOS/Android Capacitor (always cloud-only).
+      //
+      // Desktop (Electrobun) is unaffected — shouldPreferLocalBootstrap
+      // already covers it.
       const restoredConnection =
         persistedConnection ??
         probedConnection?.connection ??
-        (shouldPreferLocalBootstrap || isWeb() ? { runMode: "local" } : null);
+        (shouldPreferLocalBootstrap || brandingOverride?.cloudOnly === false
+          ? { runMode: "local" }
+          : null);
       const shouldPreserveCompletedOnboarding =
         persistedOnboardingCompleteAtStartup &&
         !onboardingCompletionCommittedRef.current;


### PR DESCRIPTION
## Summary

PR #89 and #90 didn't actually work — soak testing found the startup coordinator they patched is architecturally dead code at runtime. Walking the call chain in the live SPA bundle:

1. `AppContext.tsx:8185` defines `dispatchStartupCoordinatorEvent` — a shim handling only `RETRY|RESET|SWITCH_AGENT|PAIRING_SUCCESS|ONBOARDING_COMPLETE`. Everything else hits `default: return`. So `SESSION_RESTORED`, `NO_SESSION`, `BACKEND_REACHED` from the new `runRestoringSession` are silently dropped.
2. `AppContext.tsx:8379` recomputes `stableStartupCoordinator.phase` from legacy booleans (`onboardingComplete`, `onboardingLoading`, `startupPhase`) and exports that, overriding whatever the reducer says.
3. The real startup flow is still the legacy `initApp` in `AppContext.tsx` — which has its own copy of the fresh-browser bug.

Fresh browser path in legacy `initApp`:
- `persistedConnection = null` (no localStorage)
- `probedConnection = null` (3.5s probe times out / CF cold-start)
- `shouldPreferLocalBootstrap = false` (not Electrobun, not force-local)
- → `restoredConnection = null` → enters `if (!restoredConnection)` branch → sets `onboardingComplete=false` + `onboardingLoading=false` + returns without hitting `/api/onboarding/status`
- Derived phase: `!onboardingComplete && !onboardingLoading` → `"onboarding-required"` → wizard renders.

## Fix

Same logic as PR #89/#90, but applied to the legacy path that actually runs. On web, default `restoredConnection` to `{runMode: "local"}` when nothing is persisted/probed — `initApp` then falls through to the backend poll (30s budget, retries) which hits `/api/onboarding/status`, gets `{complete:true}` from alice-bot, sets `onboardingComplete=true`, and the derived phase becomes `"ready"`.

Scope limited to web. Desktop (Electrobun) was already handled by `shouldPreferLocalBootstrap`. Native (iOS/Android Capacitor) keeps the original "show onboarding without connection" behavior since `isWeb()` is false there and there is no embedded-local runtime.

## Test plan
- [x] Soak-verified the bug server-side: `/api/onboarding/status` returns `{complete:true}` externally, `main-BQYWH99W.js` has 0 hits for `NO_SESSION|SESSION_RESTORED|BACKEND_REACHED` (coordinator dispatches dead-coded to no-op), yet the phase still derives from legacy booleans.
- [x] Verified the onboarding-complete backend path via live POST to `/api/conversations/:id/messages` and got a round-trip reply from Alice.
- [ ] Burn-in: fresh incognito on alice.rndrntwrk.com should land on companion view directly.

## Follow-up (separate PR)

The coordinator reducer in `packages/app-core/src/state/startup-coordinator.ts` + `startup-phase-*.ts` is dead code. Either wire the dispatch shim to the real reducer, or delete the reducer. Leaving both in place invites future fixes to target the wrong layer again (as I did).