### PR TITLE
fix(go-live-modal): scroll works, scene stops bleeding through

### DIFF
--- a/packages/app-core/src/components/operator/CompanionGoLiveModal.tsx
+++ b/packages/app-core/src/components/operator/CompanionGoLiveModal.tsx
@@ -667,7 +667,7 @@ export function CompanionGoLiveModal({
             </ol>
           </div>
 
-          <div className="go-live-modal__body overflow-y-auto">
+          <div className="go-live-modal__body">
           {step === "setup-required" ? (
             <div className="space-y-5">
               {renderInlineNotice()}

--- a/packages/app-core/src/styles/styles.css
+++ b/packages/app-core/src/styles/styles.css
@@ -168,6 +168,19 @@
   --go-live-text-soft: rgba(255, 255, 255, 0.68);
   --go-live-text-muted: rgba(255, 255, 255, 0.46);
   --go-live-accent-soft: rgba(var(--accent-rgb), 0.14);
+
+  /* shadcn DialogContent is `display: grid` by default. Inside a grid cell,
+     the nested flex-column height chain (shell → body flex:1 → overflow-y
+     scroll) is ambiguous because the grid track auto-sizes to content.
+     Force flex at the DialogContent level so the shell's `height: 100%`
+     resolves against the fixed modal height, body's `min-height: 0` /
+     `flex: 1 1 auto` kicks in, and overflow-y:auto on the body actually
+     has a bounded height to compare against — which is what makes the
+     scroll bar appear when content exceeds the body. Without this the
+     channels step (7 cards in a 2-col grid → 4 rows) rendered off the
+     bottom with no way to reach them. */
+  display: flex !important;
+  flex-direction: column;
 }
 
 .go-live-modal__shell {
@@ -301,6 +314,14 @@
   flex: 1 1 auto;
   min-height: 0;
   padding: 1.5rem;
+  /* Explicit overflow rules so the scroll container is not subject to
+     Tailwind class-purge ordering or specificity surprises. overscroll-
+     behavior: contain prevents the page scroll from taking over once the
+     body bottoms out — on desktop with a trackpad that otherwise bubbles
+     the remaining scroll up to the chat dock behind the modal. */
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
 }
 
 .go-live-modal__mode-grid {

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -20,7 +20,12 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      `fixed inset-0 z-[${Z_DIALOG_OVERLAY}] bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0`,
+      // Backdrop blur is intentional: the operator companion view puts chat
+      // bubbles, the VRM avatar, and live scene overlays *behind* modals, and
+      // bg-black/80 alone let bright scene content (speech bubbles, avatar
+      // colors) read through the dim. The blur turns the leftover 20% of the
+      // scene into unreadable shapes so the modal content wins visually.
+      `fixed inset-0 z-[${Z_DIALOG_OVERLAY}] bg-black/80 backdrop-blur-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0`,
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary

Two live bugs from the Go Live modal screenshot. Design pass for everything else (step indicator, selection state, footer redundancy, wizard overkill, disabled-channel treatment, copy) follows in a separate PR so this ships small.

### 1. Scroll broken
The body had \`overflow-y-auto\` as a Tailwind class and \`flex: 1 1 auto; min-height: 0\` in CSS — the standard pattern. But shadcn's DialogContent is \`display: grid\` by default, and inside a single-track grid the flex-column height chain (shell \`height: 100%\` → body \`flex: 1\` → scroll) is ambiguous — the grid track auto-sizes to content, so the body never has a bounded height to overflow against. Channels step (7 cards in 2-col → 4 rows) rendered past the bottom with no way to reach them.

Fix: force \`display: flex; flex-direction: column\` on \`.go-live-modal\` (!important to beat the Tailwind \`grid\` utility), move overflow rules from Tailwind to CSS for specificity, add \`overscroll-behavior: contain\` so trackpad scroll doesn't bubble up to the chat dock when the body bottoms out.

### 2. Scene reads through the overlay
Shared \`DialogOverlay\` is \`bg-black/80\` with no blur. On the companion view the avatar's bright colors and chat speech bubbles read through the 20% gap — the operator's screenshot showed the avatar head peeking above the modal and a speech bubble legible behind it.

Fix: add \`backdrop-blur-md\` to the overlay. Dim stays at 80% (non-regressive for other dialogs) but leftover scene is now blurred into shapes rather than legible content. Minor improvement across every Dialog in the app.

## Test plan
- [x] \`dialog.test.tsx\` 3/3 pass (typecheck clean).
- [ ] Open Go Live on a small viewport (laptop at 800px height) — Channels step should now scroll when content exceeds body.
- [ ] Chat bubbles + avatar behind the modal should be blurred into shapes, not readable.
- [ ] Every other Dialog in the app (settings, pairing, etc.) should still open correctly — blur is additive, dim/behavior otherwise unchanged.

## Not included in this PR (follow-up)
- Ambiguous stepper (SETUP + CHANNELS both look active)
- Inconsistent Twitch/Kick selection state visuals
- Footer chrome redundancy (\`2 CHANNELS\` pill + \`Channels\` text + CAMERA button)
- Disabled channels taking full card weight
- Wordy copy
- 4-step wizard overkill
- Custom-card orphan in 2-col grid