### PR TITLE
fix(dialog): suppress companion chat + stage rail while a Dialog is open

### DIFF
--- a/packages/app-core/src/components/operator/CompanionStageOperatorOverlay.tsx
+++ b/packages/app-core/src/components/operator/CompanionStageOperatorOverlay.tsx
@@ -312,7 +312,12 @@ export function CompanionStageOperatorOverlay({
   return (
     <>
       <aside
-        className="pointer-events-none absolute left-4 top-1/2 z-20 hidden -translate-y-1/2 md:block xl:left-6"
+        // `companion-stage-overlay` is a stable hook the shared DialogContent
+        // effect uses to hide the stage rail (Action Log launcher + any
+        // bubble/tooltip children) while a Dialog is open. Without this, the
+        // rail sits in its own stacking context above the Dialog overlay on
+        // the companion view.
+        className="companion-stage-overlay pointer-events-none absolute left-4 top-1/2 z-20 hidden -translate-y-1/2 md:block xl:left-6"
         data-no-camera-drag="true"
         data-no-camera-zoom="true"
       >

--- a/packages/app-core/src/components/pages/CompanionView.tsx
+++ b/packages/app-core/src/components/pages/CompanionView.tsx
@@ -326,7 +326,12 @@ const CompanionViewOverlay = memo(function CompanionViewOverlay() {
 
       {avatarReady && companionView === "companion" && (
         <div
-          className="pointer-events-auto absolute inset-x-0 bottom-0 z-20 flex justify-center px-1.5 sm:px-4"
+          // `companion-chat-dock` class is a stable hook used by the
+          // shared DialogContent effect (packages/ui/.../dialog.tsx) to
+          // hide the chat dock while any Dialog is open — the dock's
+          // stacking context otherwise renders chat bubbles and the
+          // compose bar above the Dialog overlay on the companion view.
+          className="companion-chat-dock pointer-events-auto absolute inset-x-0 bottom-0 z-20 flex justify-center px-1.5 sm:px-4"
           style={{
             paddingBottom: "calc(var(--safe-area-bottom, 0px) + 0.75rem)",
           }}

--- a/packages/app-core/src/styles/styles.css
+++ b/packages/app-core/src/styles/styles.css
@@ -162,6 +162,31 @@
   overflow-y: auto;
 }
 
+/* ── Scene chrome suppression while a Dialog is open ───────────────────
+ * The companion view mounts the chat dock and stage rail as direct children
+ * of the VRM scene. Both create their own stacking contexts above the
+ * DialogOverlay (via `position: absolute` on a z-10 ancestor in the
+ * companion stacking context), so without this rule chat bubbles and the
+ * compose bar remain legible in front of the modal.
+ *
+ * The body attribute is set by a ref-counted effect inside our shared
+ * DialogContent (see packages/ui/.../dialog.tsx) so nested Dialogs keep
+ * the flag on until the last one closes. We deliberately do NOT key off
+ * Radix's generic `data-scroll-locked` — other primitives set it too and
+ * would cause unrelated hides.
+ *
+ * Scoped to the two known leaking surfaces only — we rely on the overlay
+ * dim + blur (set on DialogOverlay) to cover the VRM avatar and
+ * background so the companion scene as a whole does not need to be
+ * hidden. That keeps the overlay blur read-through subtle (you can
+ * tell a scene is there) without letting readable UI chrome compete with
+ * the dialog content.
+ */
+body[data-milady-dialog-open="true"] .companion-chat-dock,
+body[data-milady-dialog-open="true"] .companion-stage-overlay {
+  display: none !important;
+}
+
 .go-live-modal {
   --go-live-border: rgba(255, 255, 255, 0.1);
   --go-live-border-strong: rgba(255, 255, 255, 0.16);

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -33,6 +33,42 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+// ── Open-dialog tracking for app-wide scene suppression ───────────────
+// Ref-counted on `window.__MILADY_OPEN_DIALOG_COUNT__` so nested dialogs
+// (e.g. a Dialog inside a Drawer) don't clear the marker early on unmount
+// while a sibling is still open. We expose a simple body dataset attribute
+// — `body[data-milady-dialog-open="true"]` — that app CSS can hang hide
+// rules off for scene chrome that otherwise leaks above the Dialog overlay
+// on the companion view (chat dock, stage rail, etc.).
+//
+// We intentionally avoid keying off `document.body[data-scroll-locked]`
+// which Radix sets from other primitives (Popover, Drawer) and would
+// trigger unrelated hide bugs.
+type MiladyDialogTrackingWindow = typeof window & {
+  __MILADY_OPEN_DIALOG_COUNT__?: number;
+};
+
+function useDialogOpenBodyAttr(): void {
+  React.useEffect(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+    const w = window as MiladyDialogTrackingWindow;
+    const prev = w.__MILADY_OPEN_DIALOG_COUNT__ ?? 0;
+    const next = prev + 1;
+    w.__MILADY_OPEN_DIALOG_COUNT__ = next;
+    document.body.dataset.miladyDialogOpen = "true";
+    return () => {
+      const current = w.__MILADY_OPEN_DIALOG_COUNT__ ?? 0;
+      const remaining = Math.max(0, current - 1);
+      w.__MILADY_OPEN_DIALOG_COUNT__ = remaining;
+      if (remaining === 0) {
+        delete document.body.dataset.miladyDialogOpen;
+      }
+    };
+  }, []);
+}
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
@@ -41,28 +77,35 @@ const DialogContent = React.forwardRef<
     /** Hide the default top-right close button when the consumer renders its own close affordance. */
     showCloseButton?: boolean;
   }
->(({ className, children, container, showCloseButton = true, ...props }, ref) => (
-  <DialogPortal container={container}>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        `fixed left-[50%] top-[50%] z-[${Z_DIALOG}] grid w-[min(calc(100vw-1.5rem),42rem)] max-h-[min(calc(100dvh-1.5rem-var(--safe-area-top,0px)-var(--safe-area-bottom,0px)),44rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden rounded-[1.125rem] border border-border/70 bg-bg p-5 shadow-[0_24px_70px_rgba(2,8,23,0.24)] duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:p-6`,
-        "max-sm:left-1/2 max-sm:top-auto max-sm:bottom-[max(0.75rem,var(--safe-area-bottom,0px))] max-sm:max-h-[min(calc(100dvh-1rem-var(--safe-area-top,0px)-var(--safe-area-bottom,0px)),42rem)] max-sm:w-[min(calc(100vw-1rem),42rem)] max-sm:translate-y-0 max-sm:rounded-[1.25rem] max-sm:data-[state=closed]:slide-out-to-bottom-6 max-sm:data-[state=open]:slide-in-from-bottom-6",
-        className,
-      )}
-      {...props}
-    >
-      {children}
-      {showCloseButton ? (
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-bg transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-accent-fg">
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
-      ) : null}
-    </DialogPrimitive.Content>
-  </DialogPortal>
-));
+>(({ className, children, container, showCloseButton = true, ...props }, ref) => {
+  // Effect runs for the lifetime of this DialogContent — which maps to the
+  // Dialog being open (DialogContent is only mounted when Radix's Portal is
+  // open, so we don't need to thread open-state through props).
+  useDialogOpenBodyAttr();
+
+  return (
+    <DialogPortal container={container}>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          `fixed left-[50%] top-[50%] z-[${Z_DIALOG}] grid w-[min(calc(100vw-1.5rem),42rem)] max-h-[min(calc(100dvh-1.5rem-var(--safe-area-top,0px)-var(--safe-area-bottom,0px)),44rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden rounded-[1.125rem] border border-border/70 bg-bg p-5 shadow-[0_24px_70px_rgba(2,8,23,0.24)] duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:p-6`,
+          "max-sm:left-1/2 max-sm:top-auto max-sm:bottom-[max(0.75rem,var(--safe-area-bottom,0px))] max-sm:max-h-[min(calc(100dvh-1rem-var(--safe-area-top,0px)-var(--safe-area-bottom,0px)),42rem)] max-sm:w-[min(calc(100vw-1rem),42rem)] max-sm:translate-y-0 max-sm:rounded-[1.25rem] max-sm:data-[state=closed]:slide-out-to-bottom-6 max-sm:data-[state=open]:slide-in-from-bottom-6",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton ? (
+          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-bg transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-accent-fg">
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        ) : null}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+});
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({


### PR DESCRIPTION
## Summary

PR #92 added overlay blur and fixed the VRM avatar leaking through the modal. But the chat dock (compose bar + most recent message) and the Action Log launcher were still visible above the modal — they escape the DialogOverlay's stacking because the companion view creates its own stacking context (z-10 absolute) at the body level.

Declaring the invariant in one place instead of chasing stacking contexts:

- Shared \`DialogContent\` effect refcounts open dialogs on \`window.__MILADY_OPEN_DIALOG_COUNT__\` and sets \`document.body.dataset.miladyDialogOpen = \"true\"\`. Ref-count so nested dialogs don't clear early.
- Deliberately **not** keying off Radix's \`data-scroll-locked\` — other primitives (Popover, Drawer) set it and would trigger unrelated hide bugs.
- Stable classes \`.companion-chat-dock\` (on \`CompanionView\`'s dock wrapper) and \`.companion-stage-overlay\` (on \`CompanionStageOperatorOverlay\`'s rail aside) tag the two leaking surfaces.
- CSS \`body[data-milady-dialog-open=\"true\"] .companion-chat-dock, .companion-stage-overlay { display: none !important; }\` — scoped narrowly. The overlay dim + blur (PR #92) still handles VRM avatar + background; the whole scene is not blanket-hidden.

Other \`DialogContent\` consumers (settings, pairing, mobile menu) get the body attribute for free but their CSS doesn't match, so no visual change there.

## Test plan
- [x] Typecheck clean on touched files.
- [ ] Open Go Live modal — chat compose bar and recent bubble disappear. Modal content wins.
- [ ] Close Go Live — chat and rail return.
- [ ] Open Settings / pairing / mobile-menu Dialogs — no regression.
- [ ] Verify scroll after suppression lands — if still broken, \`document.querySelector('.go-live-modal__body').scrollHeight vs clientHeight\` tells us whether it's a sizing or event-capture bug.