### PR TITLE
fix(go-live): share launch mode title helper

### DIFF
--- a/packages/app-core/src/components/operator/CompanionGoLiveModal.tsx
+++ b/packages/app-core/src/components/operator/CompanionGoLiveModal.tsx
@@ -33,8 +33,8 @@ import {
   buildStream555SetupSummary,
   filterStream555SetupParams,
   findStream555Plugin,
-  labelForStream555LaunchMode,
   serializeStream555ConfigValue,
+  titleForStream555LaunchMode,
   type Stream555LaunchMode,
 } from "./stream555-setup";
 import type { useCompanionStageOperator } from "./useCompanionStageOperator";
@@ -83,15 +83,6 @@ function labelForDestinationReadiness(
         defaultValue: "Disabled",
       });
   }
-}
-
-function titleForMode(
-  mode: Stream555LaunchMode,
-  t: (key: string, options?: Record<string, unknown>) => string,
-) {
-  return t(`aliceoperator.mode.${mode}.title`, {
-    defaultValue: labelForStream555LaunchMode(mode),
-  });
 }
 
 function descriptionForMode(
@@ -531,7 +522,7 @@ export function CompanionGoLiveModal({
       (["camera", "radio", "screen-share", "play-games", "reaction"] as const).map(
         (mode) => ({
           value: mode,
-          title: titleForMode(mode, t),
+          title: titleForStream555LaunchMode(mode, t),
           description: descriptionForMode(mode, t),
           availability: availabilityLabelForMode(mode, t),
           support: supportLabelForMode(mode, operator, t),
@@ -547,7 +538,7 @@ export function CompanionGoLiveModal({
         label: t("aliceoperator.review.launchMode", {
           defaultValue: "Launch mode",
         }),
-        value: titleForMode(launchMode, t),
+        value: titleForStream555LaunchMode(launchMode, t),
       },
       {
         label: t("aliceoperator.review.channels", {
@@ -1080,7 +1071,7 @@ export function CompanionGoLiveModal({
           <div className="go-live-modal__footer">
             <div className="go-live-modal__footer-status">
               <OperatorPill tone="accent">
-                {titleForMode(launchMode, t)}
+                {titleForStream555LaunchMode(launchMode, t)}
               </OperatorPill>
               <OperatorPill>
                 {selectedChannels.length > 0

--- a/packages/app-core/src/components/operator/stream555-setup.ts
+++ b/packages/app-core/src/components/operator/stream555-setup.ts
@@ -238,6 +238,15 @@ export function labelForStream555LaunchMode(
   }
 }
 
+export function titleForStream555LaunchMode(
+  mode: Stream555LaunchMode,
+  t: (key: string, options?: Record<string, unknown>) => string,
+): string {
+  return t(`aliceoperator.mode.${mode}.title`, {
+    defaultValue: labelForStream555LaunchMode(mode),
+  });
+}
+
 export function serializeStream555ConfigValue(
   value: unknown,
 ): string | null {

--- a/packages/app-core/src/components/operator/useCompanionStageOperator.ts
+++ b/packages/app-core/src/components/operator/useCompanionStageOperator.ts
@@ -16,7 +16,11 @@ import {
   getPinnedStageEmotes,
   groupStageEmotes,
 } from "./alice-operator-catalog";
-import { isStream555PrimaryPlugin, type Stream555LaunchMode } from "./stream555-setup";
+import {
+  isStream555PrimaryPlugin,
+  titleForStream555LaunchMode,
+  type Stream555LaunchMode,
+} from "./stream555-setup";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const ALICE_ARCADE_PLUGIN_IDS = new Set(["five55-games"]);
@@ -618,13 +622,13 @@ export function useCompanionStageOperator() {
 
       try {
         await recordOperatorAction({
-          label: titleForMode(config.launchMode, t),
+          label: titleForStream555LaunchMode(config.launchMode, t),
           kind: "launch",
           detail:
             config.launchMode === "play-games" && selectedGameLabel
               ? `${selectedGameLabel} · ${selectedChannels.join(", ")}`
               : selectedChannels.join(", "),
-          fallbackText: titleForMode(config.launchMode, t),
+          fallbackText: titleForStream555LaunchMode(config.launchMode, t),
         });
 
         if (config.launchMode === "camera") {


### PR DESCRIPTION
## What this fixes
The Go Live review step crashes with "titleForMode is not defined" when guided launch runs through useCompanionStageOperator.

## Root cause
 only existed as a local helper inside , but  also calls it when recording the launch operator action. That hook had no local definition or import, so the review flow blew up at runtime.

## Change
- move the title helper into shared 
- import the shared helper from both  and 

## Verification
Attempted package typecheck, but this worktree is currently broken by unrelated dependency resolution failures (, , ) before reaching these files.