### PR TITLE
fix(go-live): extend operator execute timeout

### DIFF
--- a/packages/app-core/src/api/client-operator.test.ts
+++ b/packages/app-core/src/api/client-operator.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MiladyClient } from "./client";
+
+describe("MiladyClient Alice operator plan execution", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses an extended timeout for operator plan execution", async () => {
+    const fetchSpy = vi
+      .spyOn(MiladyClient.prototype, "fetch")
+      .mockResolvedValue({ results: [] } as never);
+    const client = new MiladyClient("http://127.0.0.1:31337");
+
+    await client.executeAliceOperatorPlan({
+      steps: [{ action: "STREAM555_GO_LIVE", params: { inputType: "avatar" } }],
+      stopOnFailure: true,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/alice/operator/execute",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          steps: [{ action: "STREAM555_GO_LIVE", params: { inputType: "avatar" } }],
+          stopOnFailure: true,
+        }),
+      },
+      { timeoutMs: 45_000 },
+    );
+  });
+});

--- a/packages/app-core/src/api/client.ts
+++ b/packages/app-core/src/api/client.ts
@@ -2247,6 +2247,7 @@ const GENERIC_NO_RESPONSE_TEXT =
   "Sorry, I couldn't generate a response right now. Please try again.";
 const AGENT_TRANSFER_MIN_PASSWORD_LENGTH = 4;
 const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
+const ALICE_OPERATOR_EXECUTE_TIMEOUT_MS = 45_000;
 const SESSION_STORAGE_API_BASE_KEY = "milady_api_base";
 
 function miladyClientSettingsDebug(): boolean {
@@ -2410,7 +2411,7 @@ export class MiladyClient {
   private async rawRequest(
     path: string,
     init?: RequestInit,
-    options?: { allowNonOk?: boolean },
+    options?: { allowNonOk?: boolean; timeoutMs?: number },
   ): Promise<Response> {
     if (!this.apiAvailable) {
       throw new ApiError({
@@ -2420,6 +2421,7 @@ export class MiladyClient {
       });
     }
     const makeRequest = async (token: string | null): Promise<Response> => {
+      const timeoutMs = options?.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
       let abortListener: (() => void) | undefined;
       const requestInit: RequestInit = {
@@ -2444,10 +2446,10 @@ export class MiladyClient {
               new ApiError({
                 kind: "timeout",
                 path,
-                message: `Request timed out after ${DEFAULT_FETCH_TIMEOUT_MS}ms`,
+                message: `Request timed out after ${timeoutMs}ms`,
               }),
             );
-          }, DEFAULT_FETCH_TIMEOUT_MS);
+          }, timeoutMs);
         }),
       );
 
@@ -2528,14 +2530,18 @@ export class MiladyClient {
     return res;
   }
 
-  private async fetch<T>(path: string, init?: RequestInit): Promise<T> {
+  private async fetch<T>(
+    path: string,
+    init?: RequestInit,
+    options?: { allowNonOk?: boolean; timeoutMs?: number },
+  ): Promise<T> {
     const res = await this.rawRequest(path, {
       ...init,
       headers: {
         "Content-Type": "application/json",
         ...init?.headers,
       },
-    });
+    }, options);
     return res.json() as Promise<T>;
   }
 
@@ -4297,15 +4303,19 @@ export class MiladyClient {
     steps: AliceOperatorActionStep[];
     stopOnFailure?: boolean;
   }): Promise<AliceOperatorPlanResponse> {
-    return this.fetch("/api/alice/operator/execute", {
-      method: "POST",
-      body: JSON.stringify({
-        steps: input.steps,
-        ...(input.stopOnFailure !== undefined
-          ? { stopOnFailure: input.stopOnFailure }
-          : {}),
-      }),
-    });
+    return this.fetch(
+      "/api/alice/operator/execute",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          steps: input.steps,
+          ...(input.stopOnFailure !== undefined
+            ? { stopOnFailure: input.stopOnFailure }
+            : {}),
+        }),
+      },
+      { timeoutMs: ALICE_OPERATOR_EXECUTE_TIMEOUT_MS },
+    );
   }
   async listRegistryPlugins(): Promise<RegistryPluginItem[]> {
     return this.fetch("/api/apps/plugins");


### PR DESCRIPTION
What this fixes:
The Go Live review step now gets past the earlier title helper crash, but the actual launch RPC still fails after exactly 10000ms.

Root cause:
The client sends POST /api/alice/operator/execute through the generic REST wrapper, which enforces the global 10s timeout. The operator execute route is synchronous and can legitimately take longer while it drives stream startup.

Change:
- add per-request timeout support to the client fetch/rawRequest wrapper
- keep the global default at 10000ms
- give executeAliceOperatorPlan a dedicated 45000ms timeout budget
- add a focused client test that asserts the timeout override

Verification:
- bunx vitest run --config vitest.config.ts packages/app-core/src/api/client-operator.test.ts