### PR TITLE
Persist live state in companion header

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -7375,6 +7375,7 @@ export async function startApiServer(opts?: {
           port,
           screenCapture,
           captureUrl: undefined as string | undefined,
+          runtime: state.runtime,
           destinations,
           activeDestinationId,
           activeStreamSource: { type: "stream-tab" as const },

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -7375,7 +7375,6 @@ export async function startApiServer(opts?: {
           port,
           screenCapture,
           captureUrl: undefined as string | undefined,
-          runtime: state.runtime,
           destinations,
           activeDestinationId,
           activeStreamSource: { type: "stream-tab" as const },
@@ -7420,6 +7419,9 @@ export async function startApiServer(opts?: {
                 }`,
               );
             }
+          },
+          get runtime() {
+            return state.runtime;
           },
           get config() {
             const cfg = state.config as Record<string, unknown> | undefined;

--- a/packages/agent/src/api/stream-routes.ts
+++ b/packages/agent/src/api/stream-routes.ts
@@ -159,6 +159,7 @@ interface Stream555ServiceLike {
 
 interface Stream555DestinationMapping {
   platformId: string;
+  displayName: string;
   rtmpUrlEnv: string;
   streamKeyEnv: string;
   enabledEnv: string;
@@ -172,42 +173,49 @@ const STREAM555_DESTINATION = {
 const STREAM555_DESTINATION_MAPPINGS: Stream555DestinationMapping[] = [
   {
     platformId: "pumpfun",
+    displayName: "Pump.fun",
     rtmpUrlEnv: "STREAM555_DEST_PUMPFUN_RTMP_URL",
     streamKeyEnv: "STREAM555_DEST_PUMPFUN_STREAM_KEY",
     enabledEnv: "STREAM555_DEST_PUMPFUN_ENABLED",
   },
   {
     platformId: "x",
+    displayName: "X",
     rtmpUrlEnv: "STREAM555_DEST_X_RTMP_URL",
     streamKeyEnv: "STREAM555_DEST_X_STREAM_KEY",
     enabledEnv: "STREAM555_DEST_X_ENABLED",
   },
   {
     platformId: "twitch",
+    displayName: "Twitch",
     rtmpUrlEnv: "STREAM555_DEST_TWITCH_RTMP_URL",
     streamKeyEnv: "STREAM555_DEST_TWITCH_STREAM_KEY",
     enabledEnv: "STREAM555_DEST_TWITCH_ENABLED",
   },
   {
     platformId: "kick",
+    displayName: "Kick",
     rtmpUrlEnv: "STREAM555_DEST_KICK_RTMP_URL",
     streamKeyEnv: "STREAM555_DEST_KICK_STREAM_KEY",
     enabledEnv: "STREAM555_DEST_KICK_ENABLED",
   },
   {
     platformId: "youtube",
+    displayName: "YouTube",
     rtmpUrlEnv: "STREAM555_DEST_YOUTUBE_RTMP_URL",
     streamKeyEnv: "STREAM555_DEST_YOUTUBE_STREAM_KEY",
     enabledEnv: "STREAM555_DEST_YOUTUBE_ENABLED",
   },
   {
     platformId: "facebook",
+    displayName: "Facebook",
     rtmpUrlEnv: "STREAM555_DEST_FACEBOOK_RTMP_URL",
     streamKeyEnv: "STREAM555_DEST_FACEBOOK_STREAM_KEY",
     enabledEnv: "STREAM555_DEST_FACEBOOK_ENABLED",
   },
   {
     platformId: "custom",
+    displayName: "Custom",
     rtmpUrlEnv: "STREAM555_DEST_CUSTOM_RTMP_URL",
     streamKeyEnv: "STREAM555_DEST_CUSTOM_STREAM_KEY",
     enabledEnv: "STREAM555_DEST_CUSTOM_ENABLED",
@@ -395,6 +403,53 @@ function isStream555Ready(status: Stream555StatusLike): boolean {
   return Boolean(
     status.active && status.cfSessionId && status.cloudflare?.isConnected,
   );
+}
+
+function isStream555PlatformDisplayableStatus(
+  status: string | undefined,
+): boolean {
+  const normalized = status?.trim().toLowerCase() ?? "";
+  return (
+    normalized.startsWith("live") ||
+    normalized.startsWith("connected") ||
+    normalized.startsWith("active")
+  );
+}
+
+function deriveStream555Destination(
+  status?: Stream555StatusLike | null,
+): { id: string; name: string } {
+  const platformEntries =
+    status?.platforms != null &&
+    typeof status.platforms === "object" &&
+    !Array.isArray(status.platforms)
+      ? status.platforms
+      : null;
+
+  if (!platformEntries) {
+    return STREAM555_DESTINATION;
+  }
+
+  const names = STREAM555_DESTINATION_MAPPINGS.flatMap((mapping) => {
+    const platform = platformEntries[mapping.platformId];
+    if (!platform) return [];
+    if (
+      platform.enabled === true ||
+      isStream555PlatformDisplayableStatus(platform.status)
+    ) {
+      return [mapping.displayName];
+    }
+    return [];
+  });
+
+  if (names.length === 0) {
+    return STREAM555_DESTINATION;
+  }
+
+  return {
+    id: STREAM555_DESTINATION.id,
+    name: names.join(", "),
+  };
 }
 
 async function waitForStream555Readiness(
@@ -1092,7 +1147,7 @@ export async function handleStreamRoute(
         json(res, {
           ok: true,
           ...mapStream555StatusToHealth(null),
-          destination: STREAM555_DESTINATION,
+          destination: deriveStream555Destination(null),
         });
         return true;
       }
@@ -1101,7 +1156,7 @@ export async function handleStreamRoute(
         json(res, {
           ok: true,
           ...mapStream555StatusToHealth(status),
-          destination: STREAM555_DESTINATION,
+          destination: deriveStream555Destination(status),
         });
       } catch (err) {
         logger.warn(
@@ -1112,7 +1167,7 @@ export async function handleStreamRoute(
         json(res, {
           ok: true,
           ...mapStream555StatusToHealth(null),
-          destination: STREAM555_DESTINATION,
+          destination: deriveStream555Destination(null),
         });
       }
       return true;

--- a/packages/app-core/src/api/client-operator.test.ts
+++ b/packages/app-core/src/api/client-operator.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MiladyClient } from "./client";
+
+describe("MiladyClient Alice operator plan execution", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses an extended timeout for operator plan execution", async () => {
+    const fetchSpy = vi
+      .spyOn(MiladyClient.prototype, "fetch")
+      .mockResolvedValue({ results: [] } as never);
+    const client = new MiladyClient("http://127.0.0.1:31337");
+
+    await client.executeAliceOperatorPlan({
+      steps: [{ action: "STREAM555_GO_LIVE", params: { inputType: "avatar" } }],
+      stopOnFailure: true,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/alice/operator/execute",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          steps: [{ action: "STREAM555_GO_LIVE", params: { inputType: "avatar" } }],
+          stopOnFailure: true,
+        }),
+      },
+      { timeoutMs: 45_000 },
+    );
+  });
+});

--- a/packages/app-core/src/api/client.ts
+++ b/packages/app-core/src/api/client.ts
@@ -2247,6 +2247,7 @@ const GENERIC_NO_RESPONSE_TEXT =
   "Sorry, I couldn't generate a response right now. Please try again.";
 const AGENT_TRANSFER_MIN_PASSWORD_LENGTH = 4;
 const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
+const ALICE_OPERATOR_EXECUTE_TIMEOUT_MS = 45_000;
 const SESSION_STORAGE_API_BASE_KEY = "milady_api_base";
 
 function miladyClientSettingsDebug(): boolean {
@@ -2410,7 +2411,7 @@ export class MiladyClient {
   private async rawRequest(
     path: string,
     init?: RequestInit,
-    options?: { allowNonOk?: boolean },
+    options?: { allowNonOk?: boolean; timeoutMs?: number },
   ): Promise<Response> {
     if (!this.apiAvailable) {
       throw new ApiError({
@@ -2420,6 +2421,7 @@ export class MiladyClient {
       });
     }
     const makeRequest = async (token: string | null): Promise<Response> => {
+      const timeoutMs = options?.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
       let abortListener: (() => void) | undefined;
       const requestInit: RequestInit = {
@@ -2444,10 +2446,10 @@ export class MiladyClient {
               new ApiError({
                 kind: "timeout",
                 path,
-                message: `Request timed out after ${DEFAULT_FETCH_TIMEOUT_MS}ms`,
+                message: `Request timed out after ${timeoutMs}ms`,
               }),
             );
-          }, DEFAULT_FETCH_TIMEOUT_MS);
+          }, timeoutMs);
         }),
       );
 
@@ -2528,14 +2530,18 @@ export class MiladyClient {
     return res;
   }
 
-  private async fetch<T>(path: string, init?: RequestInit): Promise<T> {
+  private async fetch<T>(
+    path: string,
+    init?: RequestInit,
+    options?: { allowNonOk?: boolean; timeoutMs?: number },
+  ): Promise<T> {
     const res = await this.rawRequest(path, {
       ...init,
       headers: {
         "Content-Type": "application/json",
         ...init?.headers,
       },
-    });
+    }, options);
     return res.json() as Promise<T>;
   }
 
@@ -4297,15 +4303,19 @@ export class MiladyClient {
     steps: AliceOperatorActionStep[];
     stopOnFailure?: boolean;
   }): Promise<AliceOperatorPlanResponse> {
-    return this.fetch("/api/alice/operator/execute", {
-      method: "POST",
-      body: JSON.stringify({
-        steps: input.steps,
-        ...(input.stopOnFailure !== undefined
-          ? { stopOnFailure: input.stopOnFailure }
-          : {}),
-      }),
-    });
+    return this.fetch(
+      "/api/alice/operator/execute",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          steps: input.steps,
+          ...(input.stopOnFailure !== undefined
+            ? { stopOnFailure: input.stopOnFailure }
+            : {}),
+        }),
+      },
+      { timeoutMs: ALICE_OPERATOR_EXECUTE_TIMEOUT_MS },
+    );
   }
   async listRegistryPlugins(): Promise<RegistryPluginItem[]> {
     return this.fetch("/api/apps/plugins");

--- a/packages/app-core/src/api/stream-routes.test.ts
+++ b/packages/app-core/src/api/stream-routes.test.ts
@@ -567,7 +567,7 @@ describe("handleStreamRoute", () => {
       );
     });
 
-    it("maps active 555stream status through the generic status route", async () => {
+    it("maps a single active 555stream platform through the generic status route", async () => {
       const { res, getJson } = createMockHttpResponse();
       const req = createMockIncomingMessage({
         method: "GET",
@@ -602,6 +602,79 @@ describe("handleStreamRoute", () => {
           ok: true,
           running: true,
           ffmpegAlive: true,
+          audioSource: "555stream",
+          inputMode: "screen",
+          destination: { id: "555stream", name: "Twitch" },
+        }),
+      );
+    });
+
+    it("maps multiple enabled and connected 555stream platforms in canonical order", async () => {
+      const { res, getJson } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "GET",
+        url: "/api/stream/status",
+      });
+      const service = mockStream555Service({
+        getBoundSessionId: vi.fn(() => "session-555"),
+        getStreamStatus: vi.fn(async () => ({
+          sessionId: "session-555",
+          active: false,
+          serverFallbackActive: false,
+          platforms: {
+            kick: { enabled: false, status: "connected_cached" },
+            twitch: { enabled: true, status: "idle" },
+          },
+          jobStatus: { state: "idle" },
+        })),
+      });
+
+      await handleStreamRoute(
+        req,
+        res,
+        "/api/stream/status",
+        "GET",
+        mockState({ runtime: { getService: vi.fn(() => service) } }),
+      );
+
+      expect(getJson()).toEqual(
+        expect.objectContaining({
+          ok: true,
+          audioSource: "555stream",
+          inputMode: "screen",
+          destination: { id: "555stream", name: "Twitch, Kick" },
+        }),
+      );
+    });
+
+    it("falls back to the generic 555stream destination when status fetch fails", async () => {
+      const { res, getStatus, getJson } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "GET",
+        url: "/api/stream/status",
+      });
+      const service = mockStream555Service({
+        getBoundSessionId: vi.fn(() => "session-555"),
+        getStreamStatus: vi.fn(async () => {
+          throw new Error("status unavailable");
+        }),
+      });
+
+      const handled = await handleStreamRoute(
+        req,
+        res,
+        "/api/stream/status",
+        "GET",
+        mockState({ runtime: { getService: vi.fn(() => service) } }),
+      );
+
+      expect(handled).toBe(true);
+      expect(getStatus()).toBe(200);
+      expect(getJson()).toEqual(
+        expect.objectContaining({
+          ok: true,
+          running: false,
+          ffmpegAlive: false,
           audioSource: "555stream",
           inputMode: "screen",
           destination: { id: "555stream", name: "555 Stream" },

--- a/packages/app-core/src/components/pages/CompanionView.tsx
+++ b/packages/app-core/src/components/pages/CompanionView.tsx
@@ -23,6 +23,7 @@ import { InferenceCloudAlertButton } from "../companion/InferenceCloudAlertButto
 import { resolveCompanionInferenceNotice } from "../companion/resolve-companion-inference-notice";
 import { PtyConsoleSidePanel } from "../coding/PtyConsoleSidePanel";
 import { CompanionGoLiveModal } from "../operator/CompanionGoLiveModal";
+import { OperatorPill } from "../operator/OperatorPrimitives";
 import { CompanionStageOperatorOverlay } from "../operator/CompanionStageOperatorOverlay";
 import { useCompanionStageOperator } from "../operator/useCompanionStageOperator";
 
@@ -44,6 +45,8 @@ const ALICE_GO_LIVE_IDLE_CLASSNAME =
   "border-accent/40 bg-[linear-gradient(180deg,rgba(var(--accent-rgb),0.22),rgba(var(--accent-rgb),0.12))] text-txt-strong hover:border-accent/65 hover:bg-[linear-gradient(180deg,rgba(var(--accent-rgb),0.28),rgba(var(--accent-rgb),0.16))]";
 const ALICE_GO_LIVE_LIVE_CLASSNAME =
   "border-danger/45 bg-[linear-gradient(180deg,rgba(239,68,68,0.92),rgba(220,38,38,0.86))] text-white hover:border-danger/70 hover:bg-[linear-gradient(180deg,rgba(239,68,68,0.98),rgba(220,38,38,0.92))]";
+const ALICE_GO_LIVE_DESTINATION_PILL_CLASSNAME =
+  "pointer-events-none max-w-[10rem] shrink truncate normal-case tracking-[0.08em]";
 
 function AliceConnectionIcon(props: SVGProps<SVGSVGElement>) {
   return (
@@ -64,23 +67,6 @@ function AliceConnectionIcon(props: SVGProps<SVGSVGElement>) {
   );
 }
 
-function AliceStopIcon(props: SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-      {...props}
-    >
-      <rect x="7" y="7" width="10" height="10" rx="2" />
-    </svg>
-  );
-}
-
 const AliceGoLiveHeaderControl = memo(function AliceGoLiveHeaderControl({
   operator,
 }: {
@@ -90,11 +76,23 @@ const AliceGoLiveHeaderControl = memo(function AliceGoLiveHeaderControl({
   const [open, setOpen] = useState(false);
   const [preferredMode, setPreferredMode] = useState<"camera" | "screen-share" | "play-games" | "reaction" | "radio">("camera");
   const isMobileViewport = useMediaQuery(SHELL_MODE_MOBILE_MEDIA_QUERY);
-  const liveActionLabel = operator.stream.live
-    ? t("aliceoperator.action.endLive", { defaultValue: "End Live" })
-    : t("statusbar.GoLive");
+  const liveDestinationName = operator.stream.activeDestination?.name?.trim() || null;
+  const liveStateLabel = t("statusbar.LiveShort", { defaultValue: "LIVE" });
+  const goLiveLabel = t("statusbar.GoLive");
+  const endLiveLabel = t("aliceoperator.action.endLive", {
+    defaultValue: "End Live",
+  });
+  const liveActionLabel = operator.stream.live ? liveStateLabel : goLiveLabel;
+  const actionAriaLabel = operator.stream.live ? endLiveLabel : goLiveLabel;
   const buttonTitle = operator.stream.live
-    ? liveActionLabel
+    ? liveDestinationName
+      ? t("aliceoperator.headerLiveDestinationTitle", {
+          destination: liveDestinationName,
+          defaultValue: `Live on ${liveDestinationName}. Click to end live.`,
+        })
+      : t("aliceoperator.headerLiveTitle", {
+          defaultValue: "Alice is live. Click to end live.",
+        })
     : operator.stream.available
       ? liveActionLabel
       : t("statusbar.InstallStreamingPlugin");
@@ -123,7 +121,7 @@ const AliceGoLiveHeaderControl = memo(function AliceGoLiveHeaderControl({
           type="button"
           size="sm"
           variant={operator.stream.live ? "destructive" : "secondary"}
-          aria-label={liveActionLabel}
+          aria-label={actionAriaLabel}
           title={buttonTitle}
           className={buttonClassName}
           onClick={handleClick}
@@ -134,7 +132,7 @@ const AliceGoLiveHeaderControl = memo(function AliceGoLiveHeaderControl({
           data-testid="companion-header-go-live"
         >
           {operator.stream.live ? (
-            <AliceStopIcon className="pointer-events-none h-3.5 w-3.5 shrink-0" />
+            <span className="pointer-events-none inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-white shadow-[0_0_0_4px_rgba(255,255,255,0.14)]" />
           ) : (
             <AliceConnectionIcon className="pointer-events-none h-3.5 w-3.5 shrink-0" />
           )}
@@ -142,6 +140,16 @@ const AliceGoLiveHeaderControl = memo(function AliceGoLiveHeaderControl({
             <span className="pointer-events-none">{liveActionLabel}</span>
           )}
         </Button>
+        {operator.stream.live && liveDestinationName && !isMobileViewport ? (
+          <OperatorPill
+            tone="accent"
+            className={ALICE_GO_LIVE_DESTINATION_PILL_CLASSNAME}
+            title={liveDestinationName}
+            data-testid="companion-header-live-destination"
+          >
+            {liveDestinationName}
+          </OperatorPill>
+        ) : null}
       </div>
       <CompanionGoLiveModal
         open={open}

--- a/packages/app-core/test/app/companion-view.test.tsx
+++ b/packages/app-core/test/app/companion-view.test.tsx
@@ -823,6 +823,80 @@ describe("CompanionView", () => {
     ).toHaveLength(1);
   });
 
+  it("surfaces live destination state in the header control and ends live on click", async () => {
+    mockClientFns.streamStatus.mockResolvedValue({
+      running: true,
+      ffmpegAlive: true,
+      uptime: 12,
+      frameCount: 48,
+      destination: { id: "twitch", name: "Twitch" },
+    });
+    mockClientFns.executeAliceOperatorPlan.mockResolvedValue({
+      ok: true,
+      allSucceeded: true,
+      results: [
+        {
+          action: "STREAM555_END_LIVE",
+          success: true,
+          message: "ended",
+          data: null,
+        },
+      ],
+    });
+    mockUseApp.mockReturnValue(
+      createContext({
+        onboardingHandoffPhase: "bootstrapping",
+        selectedVrmIndex: 9,
+        t: (key: string, options?: Record<string, unknown>) => {
+          if (typeof options?.defaultValue === "string") {
+            return options.defaultValue.replace(
+              "{{destination}}",
+              String(options.destination ?? ""),
+            );
+          }
+          return key;
+        },
+      }),
+    );
+
+    let tree: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      tree = TestRenderer.create(React.createElement(CompanionView));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const liveButton = tree?.root.findByProps({
+      "data-testid": "companion-header-go-live",
+    });
+
+    expect(text(liveButton)).toContain("LIVE");
+    expect(liveButton?.props.title).toBe("Live on Twitch. Click to end live.");
+    expect(liveButton?.props["aria-label"]).toBe("End Live");
+    expect(
+      text(
+        tree?.root.findByProps({
+          "data-testid": "companion-header-live-destination",
+        }),
+      ),
+    ).toContain("Twitch");
+
+    await act(async () => {
+      await liveButton?.props.onClick();
+      await Promise.resolve();
+    });
+
+    expect(mockClientFns.executeAliceOperatorPlan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        steps: [
+          expect.objectContaining({
+            action: "STREAM555_END_LIVE",
+          }),
+        ],
+      }),
+    );
+  });
+
   it("plays the greeting emote only after teleport completion", async () => {
     vi.useFakeTimers();
     window.setTimeout = globalThis.setTimeout.bind(globalThis);


### PR DESCRIPTION
## Summary
- show a durable LIVE state in the companion header once Alice is broadcasting
- expose the active destination beside the header control and in the hover title
- keep the same control wired to end live, with a regression test for the live-state path

## Verification
- attempted app-layer vitest run from apps/app for packages/app-core/test/app/companion-view.test.tsx
- blocked by pre-existing vite alias resolution failure for @miladyai/shared in this worktree
