### PR TITLE
Fix stream555 live session recovery after restart

### DIFF
--- a/packages/agent/src/api/stream-routes.ts
+++ b/packages/agent/src/api/stream-routes.ts
@@ -128,6 +128,14 @@ interface Stream555SessionLike {
   sessionId: string;
 }
 
+interface Stream555PlatformOverviewLike {
+  platforms?: Array<{
+    platformId?: string;
+    enabled?: boolean;
+    status?: string | null;
+  }>;
+}
+
 interface Stream555ConfigLike {
   defaultSessionId?: string;
 }
@@ -135,6 +143,7 @@ interface Stream555ConfigLike {
 interface Stream555ServiceLike {
   getBoundSessionId(): string | null;
   getConfig(): Stream555ConfigLike | null;
+  getPlatformStatusOverview?(): Promise<Stream555PlatformOverviewLike>;
   createOrResumeSession(sessionId?: string): Promise<Stream555SessionLike>;
   bindWebSocket(sessionId: string): Promise<void>;
   getStreamStatus(sessionId?: string): Promise<Stream555StatusLike>;
@@ -267,6 +276,73 @@ function getConfiguredStream555SessionId(
   if (bound) return bound;
   const configured = service.getConfig()?.defaultSessionId?.trim();
   return configured || undefined;
+}
+
+function stream555OverviewShowsLiveOutputs(
+  overview?: Stream555PlatformOverviewLike | null,
+): boolean {
+  if (!overview || !Array.isArray(overview.platforms)) {
+    return false;
+  }
+
+  return overview.platforms.some((platform) => {
+    const platformId =
+      typeof platform?.platformId === "string"
+        ? platform.platformId.trim().toLowerCase()
+        : "";
+    if (
+      !platformId ||
+      !STREAM555_DESTINATION_MAPPINGS.some(
+        (mapping) => mapping.platformId === platformId,
+      )
+    ) {
+      return false;
+    }
+    return isStream555PlatformDisplayableStatus(platform.status ?? undefined);
+  });
+}
+
+async function recoverActiveStream555SessionId(
+  service: Stream555ServiceLike,
+): Promise<string | undefined> {
+  const existing = getConfiguredStream555SessionId(service);
+  if (existing) {
+    return existing;
+  }
+
+  if (typeof service.getPlatformStatusOverview !== "function") {
+    return undefined;
+  }
+
+  let overview: Stream555PlatformOverviewLike | undefined;
+  try {
+    overview = await service.getPlatformStatusOverview();
+  } catch (err) {
+    logger.warn(
+      `[stream] 555stream platform overview unavailable during recovery: ${formatErrorMessage(
+        err,
+      )}`,
+    );
+    return undefined;
+  }
+
+  if (!stream555OverviewShowsLiveOutputs(overview)) {
+    return undefined;
+  }
+
+  const recovered = await service.createOrResumeSession();
+  const sessionId = recovered.sessionId?.trim();
+  if (!sessionId) {
+    throw new Error("555stream did not return a session id during recovery");
+  }
+
+  try {
+    await service.bindWebSocket(sessionId);
+  } catch {
+    // HTTP status/stop calls still work with explicit session ids.
+  }
+
+  return sessionId;
 }
 
 async function ensureStream555SessionId(
@@ -1018,7 +1094,9 @@ export async function handleStreamRoute(
     const stream555 = getStream555Service(state);
     if (stream555) {
       try {
-        const sessionId = getConfiguredStream555SessionId(stream555);
+        const sessionId =
+          getConfiguredStream555SessionId(stream555) ??
+          (await recoverActiveStream555SessionId(stream555));
         if (!sessionId) {
           json(res, { ok: true, live: false });
           return true;
@@ -1142,7 +1220,9 @@ export async function handleStreamRoute(
   if (method === "GET" && pathname === "/api/stream/status") {
     const stream555 = getStream555Service(state);
     if (stream555) {
-      const sessionId = getConfiguredStream555SessionId(stream555);
+      const sessionId =
+        getConfiguredStream555SessionId(stream555) ??
+        (await recoverActiveStream555SessionId(stream555));
       if (!sessionId) {
         json(res, {
           ok: true,

--- a/packages/app-core/src/api/stream-routes.test.ts
+++ b/packages/app-core/src/api/stream-routes.test.ts
@@ -118,6 +118,13 @@ function mockStream555Service(
   overrides: Partial<{
     getBoundSessionId: () => string | null;
     getConfig: () => { defaultSessionId?: string } | null;
+    getPlatformStatusOverview: () => Promise<{
+      platforms?: Array<{
+        platformId?: string;
+        enabled?: boolean;
+        status?: string | null;
+      }>;
+    }>;
     createOrResumeSession: () => Promise<{ sessionId: string }>;
     bindWebSocket: (sessionId: string) => Promise<void>;
     getStreamStatus: (sessionId?: string) => Promise<{
@@ -152,6 +159,7 @@ function mockStream555Service(
   return {
     getBoundSessionId: vi.fn(() => null),
     getConfig: vi.fn(() => null),
+    getPlatformStatusOverview: vi.fn(async () => ({ platforms: [] })),
     createOrResumeSession: vi.fn(async () => ({ sessionId: "session-555" })),
     bindWebSocket: vi.fn(async () => {}),
     getStreamStatus: vi.fn(async (sessionId = "session-555") => ({
@@ -535,7 +543,7 @@ describe("handleStreamRoute", () => {
       Object.assign(process.env, savedEnv);
     });
 
-    it("returns an inactive 555stream payload when the service is loaded but no session is bound", async () => {
+    it("returns an inactive 555stream payload without creating a session when no outputs are live", async () => {
       const { res, getStatus, getJson } = createMockHttpResponse();
       const req = createMockIncomingMessage({
         method: "GET",
@@ -554,6 +562,8 @@ describe("handleStreamRoute", () => {
 
       expect(handled).toBe(true);
       expect(getStatus()).toBe(200);
+      expect(service.getPlatformStatusOverview).toHaveBeenCalledOnce();
+      expect(service.createOrResumeSession).not.toHaveBeenCalled();
       expect(service.getStreamStatus).not.toHaveBeenCalled();
       expect(getJson()).toEqual(
         expect.objectContaining({
@@ -563,6 +573,59 @@ describe("handleStreamRoute", () => {
           audioSource: "555stream",
           inputMode: "screen",
           destination: { id: "555stream", name: "555 Stream" },
+        }),
+      );
+    });
+
+    it("reclaims an already-live 555stream session after restart when outputs are still live", async () => {
+      const { res, getJson } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "GET",
+        url: "/api/stream/status",
+      });
+      const service = mockStream555Service({
+        getPlatformStatusOverview: vi.fn(async () => ({
+          platforms: [
+            { platformId: "kick", enabled: true, status: "live" },
+            { platformId: "twitch", enabled: true, status: "connected" },
+          ],
+        })),
+        createOrResumeSession: vi.fn(async () => ({ sessionId: "session-recovered" })),
+        getStreamStatus: vi.fn(async () => ({
+          sessionId: "session-recovered",
+          active: true,
+          cfSessionId: "cf_recovered",
+          cloudflare: { isConnected: true, state: "connected" },
+          startTime: Date.now() - 5_000,
+          serverFallbackActive: false,
+          platforms: {
+            twitch: { enabled: true, status: "live" },
+            kick: { enabled: true, status: "live" },
+          },
+          jobStatus: { state: "live" },
+        })),
+      });
+
+      await handleStreamRoute(
+        req,
+        res,
+        "/api/stream/status",
+        "GET",
+        mockState({ runtime: { getService: vi.fn(() => service) } }),
+      );
+
+      expect(service.getPlatformStatusOverview).toHaveBeenCalledOnce();
+      expect(service.createOrResumeSession).toHaveBeenCalledOnce();
+      expect(service.bindWebSocket).toHaveBeenCalledWith("session-recovered");
+      expect(service.getStreamStatus).toHaveBeenCalledWith("session-recovered");
+      expect(getJson()).toEqual(
+        expect.objectContaining({
+          ok: true,
+          running: true,
+          ffmpegAlive: true,
+          audioSource: "555stream",
+          inputMode: "screen",
+          destination: { id: "555stream", name: "Twitch, Kick" },
         }),
       );
     });
@@ -1236,6 +1299,39 @@ describe("handleStreamRoute", () => {
 
       expect(handled).toBe(true);
       expect(state.streamManager.stop).toHaveBeenCalledOnce();
+      expect(getJson()).toEqual(
+        expect.objectContaining({ ok: true, live: false }),
+      );
+    });
+
+    it("reclaims an already-live 555stream session before stopping it", async () => {
+      const { res, getJson } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "POST",
+        url: "/api/stream/offline",
+      });
+      const service = mockStream555Service({
+        getPlatformStatusOverview: vi.fn(async () => ({
+          platforms: [{ platformId: "twitch", enabled: true, status: "live" }],
+        })),
+        createOrResumeSession: vi.fn(async () => ({
+          sessionId: "session-recovered",
+        })),
+      });
+
+      const handled = await handleStreamRoute(
+        req,
+        res,
+        "/api/stream/offline",
+        "POST",
+        mockState({ runtime: { getService: vi.fn(() => service) } }),
+      );
+
+      expect(handled).toBe(true);
+      expect(service.getPlatformStatusOverview).toHaveBeenCalledOnce();
+      expect(service.createOrResumeSession).toHaveBeenCalledOnce();
+      expect(service.bindWebSocket).toHaveBeenCalledWith("session-recovered");
+      expect(service.stopStream).toHaveBeenCalledWith("session-recovered");
       expect(getJson()).toEqual(
         expect.objectContaining({ ok: true, live: false }),
       );

--- a/packages/plugin-555stream/src/services/StreamControlService.ts
+++ b/packages/plugin-555stream/src/services/StreamControlService.ts
@@ -95,6 +95,22 @@ const STREAM555_CHANNEL_RUNTIME_SPECS = [
   },
 ] as const;
 
+interface PlatformStatusOverviewPlatform {
+  platformId: string;
+  enabled: boolean;
+  status?: string | null;
+  configured?: boolean;
+  rtmpUrl?: string;
+  error?: string | null;
+  connectedAt?: number | null;
+}
+
+interface PlatformStatusOverview {
+  userId?: string;
+  platforms: PlatformStatusOverviewPlatform[];
+  requestId?: string;
+}
+
 function parseBooleanEnv(value: string | undefined): boolean {
   if (!value) return false;
   switch (value.trim().toLowerCase()) {
@@ -439,6 +455,26 @@ export class StreamControlService implements Service {
    */
   getConfig(): Stream555Config | null {
     return this.config;
+  }
+
+  /**
+   * Get the caller's configured platform statuses without binding a session.
+   * This is the only side-effect-free way to see whether outputs are already live.
+   */
+  async getPlatformStatusOverview(): Promise<PlatformStatusOverview> {
+    if (!this.httpClient) {
+      throw new Error('[555stream] Service not initialized');
+    }
+
+    const response = await this.httpClient.get<PlatformStatusOverview>(
+      '/api/agent/v1/sessions'
+    );
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error || 'Failed to get platform status overview');
+    }
+
+    return response.data;
   }
 
   /**


### PR DESCRIPTION
## Summary
- recover a stream555 session after restart when outputs are still live
- use side-effect-free platform overview probing before attempting recovery
- reuse the recovered session for both /api/stream/status and /api/stream/offline

## Testing
- bunx vitest run --config vitest.current-agent.config.ts packages/app-core/src/api/stream-routes.test.ts packages/app-core/src/state/startup-phase-restore.test.ts
- bun test packages/plugin-555stream/src/services/StreamControlService.test.ts