### PR TITLE
Polish Alice canonical go-live UI flow

### DIFF
--- a/packages/app-core/src/api/client-base.ts
+++ b/packages/app-core/src/api/client-base.ts
@@ -356,14 +356,17 @@ export class MiladyClient {
     if (!host) return;
 
     // On Capacitor native (iosScheme/androidScheme = "https"), the origin host
-    // is a dummy bundle host (e.g. "localhost" with no server behind it).
-    // Skip WS if we have no explicit baseUrl and the host doesn't look like a
-    // real backend (no port, not an IP, not a known API domain).
+    // can be a dummy bundle host (e.g. "localhost" with no server behind it).
+    // Keep same-origin WS available for real web hosts.
     if (!this.baseUrl && typeof host === "string") {
-      const hasPort = host.includes(":");
-      const isLoopback =
-        host.startsWith("127.") || host.startsWith("localhost:");
-      if (!hasPort && !isLoopback) return;
+      const normalizedHost = host.trim().toLowerCase();
+      const hasPort = normalizedHost.includes(":");
+      const isNativePlaceholderHost =
+        normalizedHost === "-" ||
+        normalizedHost === "localhost" ||
+        normalizedHost === "127.0.0.1" ||
+        normalizedHost === "[::1]";
+      if (isNativePlaceholderHost && !hasPort) return;
     }
 
     let url = `${wsProtocol}//${host}/ws`;

--- a/packages/app-core/src/api/client.ts
+++ b/packages/app-core/src/api/client.ts
@@ -4811,23 +4811,40 @@ export class MiladyClient {
   // WebSocket
 
   connectWs(): void {
-    if (this.ws?.readyState === WebSocket.OPEN) return;
+    if (
+      this.ws?.readyState === WebSocket.OPEN ||
+      this.ws?.readyState === WebSocket.CONNECTING
+    ) {
+      return;
+    }
 
     let host: string;
+    let wsProtocol: "ws:" | "wss:";
     if (this.baseUrl) {
-      host = new URL(this.baseUrl).host;
+      const parsed = new URL(this.baseUrl);
+      host = parsed.host;
+      wsProtocol = parsed.protocol === "https:" ? "wss:" : "ws:";
     } else {
       // In non-HTTP environments (electrobun://, file://, etc.)
       // window.location.host may be empty or a non-routable placeholder like "-".
       const loc = window.location;
       if (loc.protocol !== "http:" && loc.protocol !== "https:") return;
       host = loc.host;
+      wsProtocol = loc.protocol === "https:" ? "wss:" : "ws:";
     }
 
     if (!host) return;
 
-    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    let url = `${protocol}//${host}/ws`;
+    // On native bundle hosts without an explicit base URL, the location host
+    // can be a non-routable placeholder. Skip WS until a real backend exists.
+    if (!this.baseUrl && typeof host === "string") {
+      const hasPort = host.includes(":");
+      const isLoopback =
+        host.startsWith("127.") || host.startsWith("localhost:");
+      if (!hasPort && !isLoopback) return;
+    }
+
+    let url = `${wsProtocol}//${host}/ws`;
     const params = new URLSearchParams({ clientId: this.clientId });
     url += `?${params.toString()}`;
 

--- a/packages/app-core/src/api/client.ts
+++ b/packages/app-core/src/api/client.ts
@@ -4836,12 +4836,17 @@ export class MiladyClient {
     if (!host) return;
 
     // On native bundle hosts without an explicit base URL, the location host
-    // can be a non-routable placeholder. Skip WS until a real backend exists.
+    // can be a non-routable placeholder such as localhost with no backend
+    // attached. Keep same-origin WS available for real web hosts.
     if (!this.baseUrl && typeof host === "string") {
-      const hasPort = host.includes(":");
-      const isLoopback =
-        host.startsWith("127.") || host.startsWith("localhost:");
-      if (!hasPort && !isLoopback) return;
+      const normalizedHost = host.trim().toLowerCase();
+      const hasPort = normalizedHost.includes(":");
+      const isNativePlaceholderHost =
+        normalizedHost === "-" ||
+        normalizedHost === "localhost" ||
+        normalizedHost === "127.0.0.1" ||
+        normalizedHost === "[::1]";
+      if (isNativePlaceholderHost && !hasPort) return;
     }
 
     let url = `${wsProtocol}//${host}/ws`;

--- a/packages/app-core/src/api/client.websocket-auth.test.ts
+++ b/packages/app-core/src/api/client.websocket-auth.test.ts
@@ -100,6 +100,20 @@ describe("MiladyClient WebSocket auth", () => {
     );
   });
 
+  it("does not open a second socket while the first is still connecting", async () => {
+    const { MiladyClient } = await import("./client");
+
+    const client = new MiladyClient("http://127.0.0.1:31337", null);
+    client.connectWs();
+
+    const firstWs = MockWebSocket.instances[0];
+    firstWs.readyState = MockWebSocket.CONNECTING;
+
+    client.connectWs();
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
   it("keeps retrying on a long interval after max reconnect attempts", async () => {
     const { MiladyClient } = await import("./client");
 

--- a/packages/app-core/src/api/client.websocket-auth.test.ts
+++ b/packages/app-core/src/api/client.websocket-auth.test.ts
@@ -114,6 +114,49 @@ describe("MiladyClient WebSocket auth", () => {
     expect(MockWebSocket.instances).toHaveLength(1);
   });
 
+  it("keeps same-origin websocket fallback on normal web hosts when no base is configured", async () => {
+    const { MiladyClient } = await import("./client");
+
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        ...globalThis.window,
+        location: {
+          protocol: "https:",
+          host: "alice.rndrntwrk.com",
+        },
+      },
+    });
+
+    const client = new MiladyClient(undefined, null);
+    client.connectWs();
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0]?.url).toContain(
+      "wss://alice.rndrntwrk.com/ws?clientId=",
+    );
+  });
+
+  it("skips websocket fallback on native placeholder hosts when no base is configured", async () => {
+    const { MiladyClient } = await import("./client");
+
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        ...globalThis.window,
+        location: {
+          protocol: "https:",
+          host: "localhost",
+        },
+      },
+    });
+
+    const client = new MiladyClient(undefined, null);
+    client.connectWs();
+
+    expect(MockWebSocket.instances).toHaveLength(0);
+  });
+
   it("keeps retrying on a long interval after max reconnect attempts", async () => {
     const { MiladyClient } = await import("./client");
 

--- a/packages/app-core/src/components/avatar/VrmEngine.ts
+++ b/packages/app-core/src/components/avatar/VrmEngine.ts
@@ -580,7 +580,7 @@ export class VrmEngine {
   private overlayManager: SceneOverlayManager | null = null;
   private avatarRoot: THREE.Group | null = null;
   private camera: THREE.PerspectiveCamera | null = null;
-  private clock = new THREE.Clock();
+  private clock = new THREE.Timer();
   private vrm: VRM | null = null;
   private mixer: THREE.AnimationMixer | null = null;
   private idleAction: THREE.AnimationAction | null = null;
@@ -985,7 +985,7 @@ export class VrmEngine {
       }
       this.animationFrameId = null;
     }
-    this.clock.stop();
+    this.clock.reset();
   }
 
   /**
@@ -1027,7 +1027,7 @@ export class VrmEngine {
 
   private resumeLoop(): void {
     if (!this.initialized || this.paused) return;
-    this.clock.start();
+    this.clock.reset();
     this.scheduleNextFrame();
   }
 
@@ -1443,7 +1443,7 @@ export class VrmEngine {
         if (backend === "webgl") {
           const webglRenderer = renderer as THREE.WebGLRenderer;
           webglRenderer.shadowMap.enabled = true;
-          webglRenderer.shadowMap.type = THREE.PCFSoftShadowMap;
+          webglRenderer.shadowMap.type = THREE.PCFShadowMap;
           webglRenderer.toneMapping = THREE.NoToneMapping;
           webglRenderer.toneMappingExposure = 1.0;
           webglRenderer.outputColorSpace = THREE.SRGBColorSpace;
@@ -2684,6 +2684,7 @@ ${isOutgoing ? "if (teleportNoise >= teleportRatio) discard;" : "if (teleportNoi
     if (this.baseCameraPosition.lengthSq() > 1e-6) {
       camera.position.copy(this.baseCameraPosition);
     }
+    this.clock.update();
     const rawDelta = this.clock.getDelta();
     const stableDelta = Math.min(rawDelta, 1 / 30);
     this.elapsedTime += rawDelta;

--- a/packages/app-core/src/components/operator/CompanionGoLiveModal.tsx
+++ b/packages/app-core/src/components/operator/CompanionGoLiveModal.tsx
@@ -5,6 +5,7 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogDescription,
   DialogTitle,
 } from "@miladyai/ui";
 import {
@@ -608,12 +609,12 @@ export function CompanionGoLiveModal({
                     defaultValue: "Go Live",
                   })}
                 </DialogTitle>
-                <p className="go-live-modal__description">
+                <DialogDescription className="go-live-modal__description">
                   {t("aliceoperator.goLiveDescription", {
                     defaultValue:
                       "Authenticate, choose channels, pick the launch format, and send Alice live without leaving the stage.",
                   })}
-                </p>
+                </DialogDescription>
               </div>
               <DialogClose asChild>
                 <Button
@@ -1084,7 +1085,11 @@ export function CompanionGoLiveModal({
               </OperatorPill>
               {activeStepIndex >= 0 ? (
                 <span className="text-sm text-white/70">
-                  {STEP_ORDER[activeStepIndex]?.label}
+                  {launching
+                    ? t("aliceoperator.launchProgressHint", {
+                        defaultValue: "Waiting for delivery lock",
+                      })
+                    : STEP_ORDER[activeStepIndex]?.label}
                 </span>
               ) : null}
             </div>

--- a/packages/app-core/src/components/operator/useCompanionStageOperator.test.tsx
+++ b/packages/app-core/src/components/operator/useCompanionStageOperator.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockUseApp,
+  mockStreamStatus,
+  mockGetStreamingDestinations,
+} = vi.hoisted(() => ({
+  mockUseApp: vi.fn(),
+  mockStreamStatus: vi.fn(),
+  mockGetStreamingDestinations: vi.fn(),
+}));
+
+vi.mock("@miladyai/app-core/state", () => ({
+  useApp: () => mockUseApp(),
+}));
+
+vi.mock("@miladyai/app-core/hooks", () => ({
+  useDocumentVisibility: () => true,
+}));
+
+vi.mock("@miladyai/app-core/api", () => ({
+  client: {
+    streamStatus: (...args: unknown[]) => mockStreamStatus(...args),
+    getStreamingDestinations: (...args: unknown[]) =>
+      mockGetStreamingDestinations(...args),
+    getArcade555GamesCatalog: vi.fn(async () => ({ games: [] })),
+    getArcade555GameState: vi.fn(async () => ({
+      sessionId: null,
+      activeGameId: null,
+      activeGameLabel: null,
+      mode: null,
+      phase: null,
+      live: false,
+      destination: null,
+    })),
+  },
+  isApiError: (err: unknown) =>
+    Boolean(err && typeof err === "object" && "status" in (err as object)),
+}));
+
+import { useCompanionStageOperator } from "./useCompanionStageOperator";
+
+function createContext(overrides: Record<string, unknown> = {}) {
+  return {
+    plugins: [],
+    selectedVrmIndex: 9,
+    logConversationOperatorAction: vi.fn(async () => true),
+    setActionNotice: vi.fn(),
+    setTab: vi.fn(),
+    switchShellView: vi.fn(),
+    t: (key: string, options?: Record<string, unknown>) =>
+      (typeof options?.defaultValue === "string"
+        ? options.defaultValue
+        : key),
+    ...overrides,
+  };
+}
+
+function Harness() {
+  const operator = useCompanionStageOperator();
+  return (
+    <div
+      data-testid="operator-stream"
+      data-live={String(operator.stream.live)}
+      data-available={String(operator.stream.available)}
+      data-destination={operator.stream.activeDestination?.name ?? ""}
+    />
+  );
+}
+
+describe("useCompanionStageOperator stream health", () => {
+  beforeEach(() => {
+    mockUseApp.mockReset();
+    mockStreamStatus.mockReset();
+    mockGetStreamingDestinations.mockReset();
+    mockUseApp.mockReturnValue(createContext());
+    mockGetStreamingDestinations.mockResolvedValue({
+      destinations: [{ id: "twitch", name: "Twitch" }],
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not mark the stream live until the stream health is actually ready", async () => {
+    mockStreamStatus.mockResolvedValue({
+      running: true,
+      ffmpegAlive: false,
+      uptime: 12,
+      frameCount: 48,
+      destination: { id: "twitch", name: "Twitch" },
+    });
+
+    let tree: TestRenderer.ReactTestRenderer | undefined;
+    await act(async () => {
+      tree = TestRenderer.create(<Harness />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const status = tree?.root.findByProps({ "data-testid": "operator-stream" });
+    expect(status?.props["data-available"]).toBe("true");
+    expect(status?.props["data-live"]).toBe("false");
+    expect(status?.props["data-destination"]).toBe("Twitch");
+  });
+});

--- a/packages/app-core/src/components/operator/useCompanionStageOperator.ts
+++ b/packages/app-core/src/components/operator/useCompanionStageOperator.ts
@@ -291,7 +291,7 @@ export function useCompanionStageOperator() {
       setStreamCapabilityResolved(true);
       setStreamAvailable(true);
       setStreamError(null);
-      setStreamLive(Boolean(status.running));
+      setStreamLive(Boolean(status.running && status.ffmpegAlive));
       setUptime(status.uptime ?? 0);
       setFrameCount(status.frameCount ?? 0);
       setActiveDestination(status.destination ?? null);

--- a/packages/app-core/src/components/operator/useCompanionStageOperator.ts
+++ b/packages/app-core/src/components/operator/useCompanionStageOperator.ts
@@ -24,6 +24,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const ALICE_ARCADE_PLUGIN_IDS = new Set(["five55-games"]);
+const HYPERSCAPE_PLUGIN_IDS = new Set(["hyperscape"]);
 
 export type AliceGoLiveLaunchResult = {
   state: "success" | "partial" | "blocked" | "failed";
@@ -218,6 +219,18 @@ export function useCompanionStageOperator() {
     [plugins],
   );
 
+  const hyperscapeRuntimeAvailable = useMemo(
+    () =>
+      plugins.some((plugin) => {
+        const normalized = normalizePluginId(plugin.id);
+        return (
+          HYPERSCAPE_PLUGIN_IDS.has(normalized) &&
+          (plugin.isActive ?? plugin.enabled)
+        );
+      }),
+    [plugins],
+  );
+
   const streamPluginPresent = useMemo(
     () =>
       plugins.some(
@@ -278,7 +291,7 @@ export function useCompanionStageOperator() {
       setStreamCapabilityResolved(true);
       setStreamAvailable(true);
       setStreamError(null);
-      setStreamLive(Boolean(status.running && status.ffmpegAlive));
+      setStreamLive(Boolean(status.running));
       setUptime(status.uptime ?? 0);
       setFrameCount(status.frameCount ?? 0);
       setActiveDestination(status.destination ?? null);
@@ -432,7 +445,15 @@ export function useCompanionStageOperator() {
   }, [arcadeRuntimeAvailable, isAliceActive, loadCatalog, loadGameState]);
 
   const refreshHyperscape = useCallback(async () => {
-    if (!isAliceActive) return;
+    if (!isAliceActive || !hyperscapeRuntimeAvailable) {
+      setHyperscapeAvailable(false);
+      setHyperscapeAgent(null);
+      setHyperscapeQuickCommands([]);
+      setHyperscapeGoal(null);
+      setHyperscapeError(null);
+      setHyperscapeLoading(false);
+      return;
+    }
     setHyperscapeLoading(true);
     setHyperscapeError(null);
     try {
@@ -454,17 +475,18 @@ export function useCompanionStageOperator() {
     } catch (err) {
       if (isApiError(err) && err.status === 404) {
         setHyperscapeAvailable(false);
+        setHyperscapeError(null);
       } else {
         setHyperscapeAvailable(true);
+        setHyperscapeError(err instanceof Error ? err.message : null);
       }
       setHyperscapeAgent(null);
       setHyperscapeQuickCommands([]);
       setHyperscapeGoal(null);
-      setHyperscapeError(err instanceof Error ? err.message : null);
     } finally {
       setHyperscapeLoading(false);
     }
-  }, [isAliceActive]);
+  }, [hyperscapeRuntimeAvailable, isAliceActive]);
 
   useEffect(() => {
     if (!isAliceActive) return;
@@ -536,34 +558,6 @@ export function useCompanionStageOperator() {
     },
     [executePlan],
   );
-
-  const pollDelivery = useCallback(async () => {
-    const deadlineAt = Date.now() + 30_000;
-    let lastMessage = "";
-    while (Date.now() < deadlineAt) {
-      try {
-        const status = await client.streamStatus();
-        if (status.running && status.ffmpegAlive) {
-          await refreshStreamStatus();
-          return { ok: true };
-        }
-        lastMessage = t("aliceoperator.deliveryPending", {
-          defaultValue: "Stream delivery did not reach live state yet.",
-        });
-      } catch (err) {
-        lastMessage = err instanceof Error ? err.message : lastMessage;
-      }
-      await new Promise((resolve) => window.setTimeout(resolve, 2_500));
-    }
-    return {
-      ok: false,
-      message:
-        lastMessage ||
-        t("aliceoperator.deliveryTimeout", {
-          defaultValue: "Stream delivery did not reach live state in time.",
-        }),
-    };
-  }, [refreshStreamStatus, t]);
 
   const performGuidedGoLive = useCallback(
     async (config: {
@@ -659,15 +653,9 @@ export function useCompanionStageOperator() {
               ),
             );
           }
-          const delivery = await pollDelivery();
-          if (!delivery.ok) {
-            return failed(
-              delivery.message ??
-                t("aliceoperator.deliveryTimeout", {
-                  defaultValue: "Stream delivery did not reach live state in time.",
-                }),
-            );
-          }
+          // STREAM555_GO_LIVE already waits for Cloudflare readiness on the
+          // control-plane path; a second local delivery poll only adds lag.
+          await refreshStreamStatus();
           return success(
             t("aliceoperator.cameraLive", {
               defaultValue: "Camera is live and delivering.",
@@ -918,7 +906,6 @@ export function useCompanionStageOperator() {
       executePlan,
       gameState?.activeGameId,
       loadGameState,
-      pollDelivery,
       recordOperatorAction,
       refreshStreamStatus,
       selectedGameId,

--- a/packages/app-core/src/components/pages/CompanionView.tsx
+++ b/packages/app-core/src/components/pages/CompanionView.tsx
@@ -38,15 +38,15 @@ const COMPANION_DOCK_HEIGHT = "min(42vh, 24rem)";
 const SHELL_MODE_MOBILE_MEDIA_QUERY = "(max-width: 639px)";
 const ALICE_STAGE_BUBBLE_HIDE_MEDIA_QUERY = "(max-width: 767px)";
 const ALICE_GO_LIVE_STRIP_CLASSNAME =
-  "pointer-events-auto inline-flex h-11 min-h-[44px] max-w-full items-center !rounded-xl border border-white/10 bg-black/52 p-1 shadow-[0_10px_30px_rgba(0,0,0,0.24)] ring-1 ring-inset ring-white/6 backdrop-blur-2xl";
+  "pointer-events-auto inline-flex max-w-full items-center gap-1 rounded-lg border border-white/12 bg-black/48 px-1.5 py-1 shadow-[0_12px_32px_rgba(0,0,0,0.22)] backdrop-blur-xl";
 const ALICE_GO_LIVE_BUTTON_CLASSNAME =
-  "h-9 min-h-9 !rounded-[10px] px-3.5 text-sm font-medium shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]";
+  "h-8 min-h-8 gap-2 rounded-lg border border-transparent px-3 text-[12px] font-semibold shadow-none transition-colors";
 const ALICE_GO_LIVE_IDLE_CLASSNAME =
-  "border-accent/40 bg-[linear-gradient(180deg,rgba(var(--accent-rgb),0.22),rgba(var(--accent-rgb),0.12))] text-txt-strong hover:border-accent/65 hover:bg-[linear-gradient(180deg,rgba(var(--accent-rgb),0.28),rgba(var(--accent-rgb),0.16))]";
+  "bg-white/[0.08] text-white/88 hover:bg-white/[0.12]";
 const ALICE_GO_LIVE_LIVE_CLASSNAME =
-  "border-danger/45 bg-[linear-gradient(180deg,rgba(239,68,68,0.92),rgba(220,38,38,0.86))] text-white hover:border-danger/70 hover:bg-[linear-gradient(180deg,rgba(239,68,68,0.98),rgba(220,38,38,0.92))]";
+  "bg-[linear-gradient(180deg,#ef5a50,#d83d35)] text-white hover:bg-[linear-gradient(180deg,#f36960,#df463e)]";
 const ALICE_GO_LIVE_DESTINATION_PILL_CLASSNAME =
-  "pointer-events-none max-w-[10rem] shrink truncate normal-case tracking-[0.08em]";
+  "pointer-events-none max-w-[11rem] shrink-0 truncate rounded-lg border border-white/10 bg-white/[0.04] px-3 py-0 text-[12px] font-medium normal-case tracking-[0.01em] text-white/76 shadow-none";
 
 function AliceConnectionIcon(props: SVGProps<SVGSVGElement>) {
   return (
@@ -77,6 +77,13 @@ const AliceGoLiveHeaderControl = memo(function AliceGoLiveHeaderControl({
   const [preferredMode, setPreferredMode] = useState<"camera" | "screen-share" | "play-games" | "reaction" | "radio">("camera");
   const isMobileViewport = useMediaQuery(SHELL_MODE_MOBILE_MEDIA_QUERY);
   const liveDestinationName = operator.stream.activeDestination?.name?.trim() || null;
+  const liveDestinationLabel = liveDestinationName
+    ? liveDestinationName
+        .split(",")
+        .map((segment) => segment.trim())
+        .filter(Boolean)
+        .join(" · ")
+    : null;
   const liveStateLabel = t("statusbar.LiveShort", { defaultValue: "LIVE" });
   const goLiveLabel = t("statusbar.GoLive");
   const endLiveLabel = t("aliceoperator.action.endLive", {
@@ -100,7 +107,7 @@ const AliceGoLiveHeaderControl = memo(function AliceGoLiveHeaderControl({
     operator.stream.live
       ? ALICE_GO_LIVE_LIVE_CLASSNAME
       : ALICE_GO_LIVE_IDLE_CLASSNAME
-  } ${isMobileViewport ? "!w-9 min-w-9 px-0" : ""}`;
+  } ${isMobileViewport ? "!w-8 min-w-8 px-0" : ""}`;
 
   const handleClick = () => {
     if (operator.stream.live) {
@@ -120,7 +127,7 @@ const AliceGoLiveHeaderControl = memo(function AliceGoLiveHeaderControl({
         <Button
           type="button"
           size="sm"
-          variant={operator.stream.live ? "destructive" : "secondary"}
+          variant="ghost"
           aria-label={actionAriaLabel}
           title={buttonTitle}
           className={buttonClassName}
@@ -140,14 +147,14 @@ const AliceGoLiveHeaderControl = memo(function AliceGoLiveHeaderControl({
             <span className="pointer-events-none">{liveActionLabel}</span>
           )}
         </Button>
-        {operator.stream.live && liveDestinationName && !isMobileViewport ? (
+        {operator.stream.live && liveDestinationLabel && !isMobileViewport ? (
           <OperatorPill
-            tone="accent"
+            tone="neutral"
             className={ALICE_GO_LIVE_DESTINATION_PILL_CLASSNAME}
             title={liveDestinationName}
             data-testid="companion-header-live-destination"
           >
-            {liveDestinationName}
+            {liveDestinationLabel}
           </OperatorPill>
         ) : null}
       </div>


### PR DESCRIPTION
## Summary
- remove the extra client-side post-launch delivery wait from Alice go-live
- fix websocket and live-state regressions on the canonical Alice header path
- clean up Alice go-live UI polish, dialog a11y, Hyperscape 404 noise, and easy Three warnings

## Testing
- /Users/mac/.bun/bin/bunx vitest run packages/app-core/src/api/client.websocket-auth.test.ts
- /Users/mac/.bun/bin/bunx vitest run packages/app-core/src/components/operator/useCompanionStageOperator.test.tsx

Supersedes the stale draft work from #101 on a clean branch.