### PR TITLE
Fix false live state for stream555 outputs

### DIFF
--- a/packages/agent/src/api/stream-routes.ts
+++ b/packages/agent/src/api/stream-routes.ts
@@ -458,11 +458,11 @@ function mapStream555StatusToHealth(status?: Stream555StatusLike | null): {
     !Array.isArray(status.platforms)
       ? status.platforms
       : null;
-  const ffmpegAlive = STREAM555_DESTINATION_MAPPINGS.some((mapping) => {
-    const platform = platformEntries?.[mapping.platformId];
-    if (!platform) return false;
-    return isStream555PlatformLiveStatus(platform.status);
-  });
+  const ffmpegAlive = Object.values(platformEntries ?? {}).some(
+    (platform) =>
+      platform?.enabled !== false &&
+      isStream555PlatformLiveStatus(platform?.status),
+  );
   const startTime = status?.startTime;
   const uptime =
     typeof startTime === "number" && Number.isFinite(startTime) && startTime > 0

--- a/packages/agent/src/api/stream-routes.ts
+++ b/packages/agent/src/api/stream-routes.ts
@@ -452,11 +452,17 @@ function mapStream555StatusToHealth(status?: Stream555StatusLike | null): {
   inputMode: "screen";
 } {
   const running = Boolean(status?.active);
-  const jobState = status?.jobStatus?.state?.trim().toLowerCase() ?? "";
-  const ffmpegAlive =
-    running ||
-    (jobState.length > 0 &&
-      !/(stopped|failed|error|terminated|offline)/.test(jobState));
+  const platformEntries =
+    status?.platforms != null &&
+    typeof status.platforms === "object" &&
+    !Array.isArray(status.platforms)
+      ? status.platforms
+      : null;
+  const ffmpegAlive = STREAM555_DESTINATION_MAPPINGS.some((mapping) => {
+    const platform = platformEntries?.[mapping.platformId];
+    if (!platform) return false;
+    return isStream555PlatformLiveStatus(platform.status);
+  });
   const startTime = status?.startTime;
   const uptime =
     typeof startTime === "number" && Number.isFinite(startTime) && startTime > 0

--- a/packages/app-core/src/api/stream-routes.test.ts
+++ b/packages/app-core/src/api/stream-routes.test.ts
@@ -854,6 +854,48 @@ describe("handleStreamRoute", () => {
       );
     });
 
+    it("treats a live non-mapped platform as sufficient stream health", async () => {
+      const { res, getJson } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "GET",
+        url: "/api/stream/status",
+      });
+      const service = mockStream555Service({
+        getBoundSessionId: vi.fn(() => "session-555"),
+        getStreamStatus: vi.fn(async () => ({
+          sessionId: "session-555",
+          active: true,
+          cfSessionId: "cf_123",
+          cloudflare: { isConnected: true, state: "connected" },
+          startTime: Date.now() - 3_000,
+          serverFallbackActive: false,
+          platforms: {
+            zora: { enabled: true, status: "live" },
+          },
+          jobStatus: { state: "running" },
+        })),
+      });
+
+      await handleStreamRoute(
+        req,
+        res,
+        "/api/stream/status",
+        "GET",
+        mockState({ runtime: { getService: vi.fn(() => service) } }),
+      );
+
+      expect(getJson()).toEqual(
+        expect.objectContaining({
+          ok: true,
+          running: true,
+          ffmpegAlive: true,
+          audioSource: "555stream",
+          inputMode: "screen",
+          destination: { id: "555stream", name: "555 Stream" },
+        }),
+      );
+    });
+
     it("maps multiple enabled and connected 555stream platforms in canonical order", async () => {
       const { res, getJson } = createMockHttpResponse();
       const req = createMockIncomingMessage({

--- a/packages/app-core/src/api/stream-routes.test.ts
+++ b/packages/app-core/src/api/stream-routes.test.ts
@@ -811,6 +811,49 @@ describe("handleStreamRoute", () => {
       );
     });
 
+    it("does not report 555stream as live when the session is active but outputs are not live", async () => {
+      const { res, getJson } = createMockHttpResponse();
+      const req = createMockIncomingMessage({
+        method: "GET",
+        url: "/api/stream/status",
+      });
+      const service = mockStream555Service({
+        getBoundSessionId: vi.fn(() => "session-555"),
+        getStreamStatus: vi.fn(async () => ({
+          sessionId: "session-555",
+          active: true,
+          cfSessionId: "cf_123",
+          cloudflare: { isConnected: true, state: "connected" },
+          startTime: Date.now() - 3_000,
+          serverFallbackActive: false,
+          platforms: {
+            twitch: { enabled: true, status: "connected" },
+            kick: { enabled: true, status: "idle" },
+          },
+          jobStatus: { state: "running" },
+        })),
+      });
+
+      await handleStreamRoute(
+        req,
+        res,
+        "/api/stream/status",
+        "GET",
+        mockState({ runtime: { getService: vi.fn(() => service) } }),
+      );
+
+      expect(getJson()).toEqual(
+        expect.objectContaining({
+          ok: true,
+          running: true,
+          ffmpegAlive: false,
+          audioSource: "555stream",
+          inputMode: "screen",
+          destination: { id: "555stream", name: "Twitch, Kick" },
+        }),
+      );
+    });
+
     it("maps multiple enabled and connected 555stream platforms in canonical order", async () => {
       const { res, getJson } = createMockHttpResponse();
       const req = createMockIncomingMessage({

--- a/packages/app-core/src/components/operator/useCompanionStageOperator.test.tsx
+++ b/packages/app-core/src/components/operator/useCompanionStageOperator.test.tsx
@@ -8,10 +8,12 @@ const {
   mockUseApp,
   mockStreamStatus,
   mockGetStreamingDestinations,
+  mockExecuteAliceOperatorPlan,
 } = vi.hoisted(() => ({
   mockUseApp: vi.fn(),
   mockStreamStatus: vi.fn(),
   mockGetStreamingDestinations: vi.fn(),
+  mockExecuteAliceOperatorPlan: vi.fn(),
 }));
 
 vi.mock("@miladyai/app-core/state", () => ({
@@ -27,6 +29,8 @@ vi.mock("@miladyai/app-core/api", () => ({
     streamStatus: (...args: unknown[]) => mockStreamStatus(...args),
     getStreamingDestinations: (...args: unknown[]) =>
       mockGetStreamingDestinations(...args),
+    executeAliceOperatorPlan: (...args: unknown[]) =>
+      mockExecuteAliceOperatorPlan(...args),
     getArcade555GamesCatalog: vi.fn(async () => ({ games: [] })),
     getArcade555GameState: vi.fn(async () => ({
       sessionId: null,
@@ -60,8 +64,15 @@ function createContext(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function Harness() {
+function Harness({
+  onOperator,
+}: {
+  onOperator?: (operator: ReturnType<typeof useCompanionStageOperator>) => void;
+}) {
   const operator = useCompanionStageOperator();
+  React.useEffect(() => {
+    onOperator?.(operator);
+  }, [onOperator, operator]);
   return (
     <div
       data-testid="operator-stream"
@@ -77,6 +88,7 @@ describe("useCompanionStageOperator stream health", () => {
     mockUseApp.mockReset();
     mockStreamStatus.mockReset();
     mockGetStreamingDestinations.mockReset();
+    mockExecuteAliceOperatorPlan.mockReset();
     mockUseApp.mockReturnValue(createContext());
     mockGetStreamingDestinations.mockResolvedValue({
       destinations: [{ id: "twitch", name: "Twitch" }],
@@ -107,5 +119,76 @@ describe("useCompanionStageOperator stream health", () => {
     expect(status?.props["data-available"]).toBe("true");
     expect(status?.props["data-live"]).toBe("false");
     expect(status?.props["data-destination"]).toBe("Twitch");
+  });
+
+  it("returns a partial result when camera launch starts but delivery is not yet live", async () => {
+    const operatorRef: {
+      current: ReturnType<typeof useCompanionStageOperator> | null;
+    } = { current: null };
+    mockUseApp.mockReturnValue(
+      createContext({
+        plugins: [{ id: "@rndrntwrk/plugin-555stream", enabled: true }],
+      }),
+    );
+    mockStreamStatus.mockResolvedValue({
+      ok: true,
+      running: true,
+      ffmpegAlive: false,
+      uptime: 12,
+      frameCount: 48,
+      volume: 80,
+      muted: false,
+      audioSource: "555stream",
+      inputMode: "screen",
+      destination: { id: "twitch", name: "Twitch" },
+    });
+    mockExecuteAliceOperatorPlan.mockResolvedValue({
+      results: [
+        {
+          action: "STREAM555_GO_LIVE",
+          success: true,
+          message: "Launch accepted.",
+        },
+      ],
+    });
+
+    await act(async () => {
+      TestRenderer.create(
+        <Harness
+          onOperator={(operator) => {
+            operatorRef.current = operator;
+          }}
+        />,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    mockStreamStatus.mockClear();
+
+    let result:
+      | Awaited<
+          ReturnType<ReturnType<typeof useCompanionStageOperator>["performGuidedGoLive"]>
+        >
+      | undefined;
+    await act(async () => {
+      result = await operatorRef.current?.performGuidedGoLive({
+        channels: ["twitch"],
+        launchMode: "camera",
+      });
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        state: "partial",
+        tone: "warning",
+        message: "Camera launch started, but delivery is still warming up.",
+        followUp: {
+          label: "Delivery status",
+          detail: "Stream delivery has not reached live state yet.",
+        },
+      }),
+    );
+    expect(mockStreamStatus).toHaveBeenCalledOnce();
   });
 });

--- a/packages/app-core/src/components/operator/useCompanionStageOperator.ts
+++ b/packages/app-core/src/components/operator/useCompanionStageOperator.ts
@@ -77,6 +77,12 @@ function choosePrimaryHyperscapeAgent(
   );
 }
 
+type StreamStatusSnapshot = Awaited<ReturnType<typeof client.streamStatus>>;
+type StreamStatusRefreshResult = {
+  status: StreamStatusSnapshot | null;
+  error: string | null;
+};
+
 function getPhaseLabel(
   phase: string | null | undefined,
   t: (key: string, options?: Record<string, unknown>) => string,
@@ -283,38 +289,49 @@ export function useCompanionStageOperator() {
     [clearPendingEmoteReset],
   );
 
-  const refreshStreamStatus = useCallback(async () => {
-    if (streamLoadingRef.current) return;
-    try {
-      const status = await client.streamStatus();
-      setStreamCapabilityPresent(true);
-      setStreamCapabilityResolved(true);
-      setStreamAvailable(true);
-      setStreamError(null);
-      setStreamLive(Boolean(status.running && status.ffmpegAlive));
-      setUptime(status.uptime ?? 0);
-      setFrameCount(status.frameCount ?? 0);
-      setActiveDestination(status.destination ?? null);
-    } catch (err) {
-      if (isApiError(err) && err.status === 404) {
-        setStreamCapabilityPresent(false);
-        setStreamCapabilityResolved(true);
-        setStreamAvailable(false);
-        setStreamError(null);
-        return;
+  const refreshStreamStatus = useCallback(
+    async ({
+      force = false,
+    }: {
+      force?: boolean;
+    } = {}): Promise<StreamStatusRefreshResult> => {
+      if (streamLoadingRef.current && !force) {
+        return { status: null, error: null };
       }
-      setStreamCapabilityPresent(true);
-      setStreamCapabilityResolved(true);
-      setStreamAvailable(true);
-      setStreamError(
-        err instanceof Error
-          ? err.message
-          : t("aliceoperator.streamStatusFailed", {
-              defaultValue: "Stream status is temporarily unavailable.",
-            }),
-      );
-    }
-  }, [t]);
+      try {
+        const status = await client.streamStatus();
+        setStreamCapabilityPresent(true);
+        setStreamCapabilityResolved(true);
+        setStreamAvailable(true);
+        setStreamError(null);
+        setStreamLive(Boolean(status.running && status.ffmpegAlive));
+        setUptime(status.uptime ?? 0);
+        setFrameCount(status.frameCount ?? 0);
+        setActiveDestination(status.destination ?? null);
+        return { status, error: null };
+      } catch (err) {
+        if (isApiError(err) && err.status === 404) {
+          setStreamCapabilityPresent(false);
+          setStreamCapabilityResolved(true);
+          setStreamAvailable(false);
+          setStreamError(null);
+          return { status: null, error: null };
+        }
+        const errorMessage =
+          err instanceof Error
+            ? err.message
+            : t("aliceoperator.streamStatusFailed", {
+                defaultValue: "Stream status is temporarily unavailable.",
+              });
+        setStreamCapabilityPresent(true);
+        setStreamCapabilityResolved(true);
+        setStreamAvailable(true);
+        setStreamError(errorMessage);
+        return { status: null, error: errorMessage };
+      }
+    },
+    [t],
+  );
 
   useEffect(() => {
     let mounted = true;
@@ -655,7 +672,24 @@ export function useCompanionStageOperator() {
           }
           // STREAM555_GO_LIVE already waits for Cloudflare readiness on the
           // control-plane path; a second local delivery poll only adds lag.
-          await refreshStreamStatus();
+          const refreshed = await refreshStreamStatus({ force: true });
+          if (refreshed.error) {
+            return failed(refreshed.error);
+          }
+          if (!refreshed.status?.running || !refreshed.status.ffmpegAlive) {
+            return partial(
+              t("aliceoperator.cameraLaunchPending", {
+                defaultValue:
+                  "Camera launch started, but delivery is still warming up.",
+              }),
+              t("aliceoperator.deliveryStatus", {
+                defaultValue: "Delivery status",
+              }),
+              t("aliceoperator.deliveryPending", {
+                defaultValue: "Stream delivery has not reached live state yet.",
+              }),
+            );
+          }
           return success(
             t("aliceoperator.cameraLive", {
               defaultValue: "Camera is live and delivering.",


### PR DESCRIPTION
## Summary
- stop treating a bound stream555 session as live unless at least one output platform is actually in a live state
- keep the existing running flag but require real live output status for ffmpeg health
- add a regression test for active sessions whose outputs are only connected or idle

## Verification
- focused Vitest runs are blocked in this worktree by a pre-existing rolldown native binding failure in the shared node_modules checkout
- reviewed the status mapper and regression diff locally