### PR TITLE
Alice cross-channel corpus and deploy guardrails

### DIFF
--- a/packages/agent/src/api/__tests__/cross-channel-ingest-server-wiring.test.ts
+++ b/packages/agent/src/api/__tests__/cross-channel-ingest-server-wiring.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const serverSource = readFileSync(
+  path.resolve(import.meta.dirname, "..", "server.ts"),
+  "utf-8",
+);
+
+describe("cross-channel ingest server wiring", () => {
+  it("registers Alice corpus and coding policy routes", () => {
+    expect(serverSource).toContain("handleAliceCorpusRoutes");
+    expect(serverSource).toContain("handleAliceCodingPolicyRoutes");
+    expect(serverSource.indexOf("handleAliceCorpusRoutes")).toBeLessThan(
+      serverSource.indexOf("handleMiscRoutes"),
+    );
+    expect(serverSource.indexOf("handleAliceCodingPolicyRoutes")).toBeLessThan(
+      serverSource.indexOf("handleMiscRoutes"),
+    );
+  });
+
+  it("registers dedicated comment ingest routes before misc ingest routes", () => {
+    expect(serverSource).toContain("handleCrossChannelIngestRoutes");
+    expect(serverSource.indexOf("handleCrossChannelIngestRoutes")).toBeLessThan(
+      serverSource.indexOf("handleMiscRoutes"),
+    );
+  });
+});

--- a/packages/agent/src/api/alice-coding-policy-routes.test.ts
+++ b/packages/agent/src/api/alice-coding-policy-routes.test.ts
@@ -45,9 +45,9 @@ describe("handleAliceCodingPolicyRoutes", () => {
       ok: true,
       policy: {
         allowedRepos: [
-          "Render-Network-OS/milaidy",
+          "rndrntwrk/milaidy",
           "Render-Network-OS/555-bot",
-          "Render-Network-OS/555stream",
+          "Render-Network-OS/stream",
         ],
         deployRail: "webhook",
         productionDeploys: "approval",
@@ -61,7 +61,7 @@ describe("handleAliceCodingPolicyRoutes", () => {
       pathname: "/api/alice/coding/decision",
       body: {
         action: "deploy",
-        repo: "Render-Network-OS/milaidy",
+        repo: "rndrntwrk/milaidy",
         environment: "production",
         deployRail: "webhook",
       },
@@ -84,7 +84,7 @@ describe("handleAliceCodingPolicyRoutes", () => {
       pathname: "/api/alice/coding/decision",
       body: {
         action: "deploy",
-        repo: "Render-Network-OS/milaidy",
+        repo: "rndrntwrk/milaidy",
         environment: "staging",
         deployRail: "local-shell",
       },
@@ -100,5 +100,40 @@ describe("handleAliceCodingPolicyRoutes", () => {
         reason: "Deploys must use the webhook rail so they are visible in Ops.",
       },
     });
+  });
+
+  it("rejects unknown coding actions before policy evaluation", async () => {
+    const { ctx, errorCalls } = makeContext({
+      method: "POST",
+      pathname: "/api/alice/coding/decision",
+      body: {
+        action: "rm_everything",
+        repo: "rndrntwrk/milaidy",
+      },
+    });
+
+    await handleAliceCodingPolicyRoutes(ctx);
+
+    expect(errorCalls).toEqual([
+      { message: "Invalid Alice coding action request", status: 400 },
+    ]);
+  });
+
+  it("rejects deploy decisions without a valid environment", async () => {
+    const { ctx, errorCalls } = makeContext({
+      method: "POST",
+      pathname: "/api/alice/coding/decision",
+      body: {
+        action: "deploy",
+        repo: "rndrntwrk/milaidy",
+        deployRail: "webhook",
+      },
+    });
+
+    await handleAliceCodingPolicyRoutes(ctx);
+
+    expect(errorCalls).toEqual([
+      { message: "Invalid Alice coding action request", status: 400 },
+    ]);
   });
 });

--- a/packages/agent/src/api/alice-coding-policy-routes.test.ts
+++ b/packages/agent/src/api/alice-coding-policy-routes.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { handleAliceCodingPolicyRoutes } from "./alice-coding-policy-routes";
+
+function makeContext({
+  method,
+  pathname,
+  body,
+}: {
+  method: string;
+  pathname: string;
+  body?: Record<string, unknown>;
+}) {
+  const jsonCalls: Array<{ data: unknown; status?: number }> = [];
+  const errorCalls: Array<{ message: string; status?: number }> = [];
+  return {
+    ctx: {
+      req: {} as never,
+      res: {} as never,
+      method,
+      pathname,
+      config: {},
+      readJsonBody: async () => body ?? {},
+      json: (_res: unknown, data: unknown, status?: number) => {
+        jsonCalls.push({ data, status });
+      },
+      error: (_res: unknown, message: string, status?: number) => {
+        errorCalls.push({ message, status });
+      },
+    },
+    jsonCalls,
+    errorCalls,
+  };
+}
+
+describe("handleAliceCodingPolicyRoutes", () => {
+  it("exposes Alice's allowed repo and deploy rail policy", async () => {
+    const { ctx, jsonCalls } = makeContext({
+      method: "GET",
+      pathname: "/api/alice/coding/policy",
+    });
+
+    await expect(handleAliceCodingPolicyRoutes(ctx)).resolves.toBe(true);
+
+    expect(jsonCalls[0]?.data).toMatchObject({
+      ok: true,
+      policy: {
+        allowedRepos: [
+          "Render-Network-OS/milaidy",
+          "Render-Network-OS/555-bot",
+          "Render-Network-OS/555stream",
+        ],
+        deployRail: "webhook",
+        productionDeploys: "approval",
+      },
+    });
+  });
+
+  it("rejects production deploy decisions unless human approval is attached", async () => {
+    const { ctx, jsonCalls } = makeContext({
+      method: "POST",
+      pathname: "/api/alice/coding/decision",
+      body: {
+        action: "deploy",
+        repo: "Render-Network-OS/milaidy",
+        environment: "production",
+        deployRail: "webhook",
+      },
+    });
+
+    await expect(handleAliceCodingPolicyRoutes(ctx)).resolves.toBe(true);
+
+    expect(jsonCalls[0]?.data).toMatchObject({
+      ok: true,
+      decision: {
+        allowed: false,
+        requiresApproval: true,
+      },
+    });
+  });
+
+  it("blocks deploys that bypass the Ops-visible webhook rail", async () => {
+    const { ctx, jsonCalls } = makeContext({
+      method: "POST",
+      pathname: "/api/alice/coding/decision",
+      body: {
+        action: "deploy",
+        repo: "Render-Network-OS/milaidy",
+        environment: "staging",
+        deployRail: "local-shell",
+      },
+    });
+
+    await handleAliceCodingPolicyRoutes(ctx);
+
+    expect(jsonCalls[0]?.data).toMatchObject({
+      ok: true,
+      decision: {
+        allowed: false,
+        requiresApproval: false,
+        reason: "Deploys must use the webhook rail so they are visible in Ops.",
+      },
+    });
+  });
+});

--- a/packages/agent/src/api/alice-coding-policy-routes.ts
+++ b/packages/agent/src/api/alice-coding-policy-routes.ts
@@ -2,7 +2,9 @@ import type http from "node:http";
 import type { ElizaConfig } from "../config/types.eliza.js";
 import type { ReadJsonBodyOptions } from "./http-helpers.js";
 import {
+  type AliceCodingAction,
   type AliceCodingActionRequest,
+  type AliceDeployEnvironment,
   resolveAliceCodingActionDecision,
   resolveAliceOperationalDefaults,
 } from "./alice-coding-policy.js";
@@ -22,10 +24,38 @@ export interface AliceCodingPolicyRouteContext {
   ) => Promise<T | null>;
 }
 
+const CODING_ACTIONS = new Set<AliceCodingAction>([
+  "inspect_repo",
+  "run_tests",
+  "build",
+  "open_pr",
+  "deploy",
+]);
+const DEPLOY_ENVIRONMENTS = new Set<AliceDeployEnvironment>([
+  "staging",
+  "production",
+]);
+
+function isCodingAction(value: unknown): value is AliceCodingAction {
+  return typeof value === "string" && CODING_ACTIONS.has(value as AliceCodingAction);
+}
+
+function isDeployEnvironment(value: unknown): value is AliceDeployEnvironment {
+  return (
+    typeof value === "string" &&
+    DEPLOY_ENVIRONMENTS.has(value as AliceDeployEnvironment)
+  );
+}
+
 function isActionRequest(value: unknown): value is AliceCodingActionRequest {
   if (!value || typeof value !== "object") return false;
   const record = value as Record<string, unknown>;
-  return typeof record.action === "string";
+  if (!isCodingAction(record.action)) return false;
+  if (record.repo !== undefined && typeof record.repo !== "string") return false;
+  if (record.action === "deploy" && !isDeployEnvironment(record.environment)) {
+    return false;
+  }
+  return true;
 }
 
 export async function handleAliceCodingPolicyRoutes(

--- a/packages/agent/src/api/alice-coding-policy-routes.ts
+++ b/packages/agent/src/api/alice-coding-policy-routes.ts
@@ -1,0 +1,69 @@
+import type http from "node:http";
+import type { ElizaConfig } from "../config/types.eliza.js";
+import type { ReadJsonBodyOptions } from "./http-helpers.js";
+import {
+  type AliceCodingActionRequest,
+  resolveAliceCodingActionDecision,
+  resolveAliceOperationalDefaults,
+} from "./alice-coding-policy.js";
+
+export interface AliceCodingPolicyRouteContext {
+  req: http.IncomingMessage;
+  res: http.ServerResponse;
+  method: string;
+  pathname: string;
+  config: Pick<ElizaConfig, "alice">;
+  json: (res: http.ServerResponse, data: unknown, status?: number) => void;
+  error: (res: http.ServerResponse, message: string, status?: number) => void;
+  readJsonBody: <T extends object>(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    options?: ReadJsonBodyOptions,
+  ) => Promise<T | null>;
+}
+
+function isActionRequest(value: unknown): value is AliceCodingActionRequest {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.action === "string";
+}
+
+export async function handleAliceCodingPolicyRoutes(
+  ctx: AliceCodingPolicyRouteContext,
+): Promise<boolean> {
+  const { req, res, method, pathname, config, json, error, readJsonBody } = ctx;
+
+  if (
+    pathname !== "/api/alice/coding/policy" &&
+    pathname !== "/api/alice/coding/decision"
+  ) {
+    return false;
+  }
+
+  const policy = resolveAliceOperationalDefaults(config);
+
+  if (method === "GET" && pathname === "/api/alice/coding/policy") {
+    json(res, { ok: true, policy });
+    return true;
+  }
+
+  if (method === "POST" && pathname === "/api/alice/coding/decision") {
+    const body = await readJsonBody<Record<string, unknown>>(req, res, {
+      maxBytes: 64 * 1024,
+    });
+    if (!body) return true;
+    if (!isActionRequest(body)) {
+      error(res, "Invalid Alice coding action request", 400);
+      return true;
+    }
+    json(res, {
+      ok: true,
+      policy,
+      decision: resolveAliceCodingActionDecision(policy, body),
+    });
+    return true;
+  }
+
+  error(res, "Method not allowed", 405);
+  return true;
+}

--- a/packages/agent/src/api/alice-coding-policy.test.ts
+++ b/packages/agent/src/api/alice-coding-policy.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveAliceCodingActionDecision,
+  resolveAliceOperationalDefaults,
+} from "./alice-coding-policy";
+
+describe("Alice coding and deploy policy", () => {
+  it("allows code/build/pr work and staging deploys by default", () => {
+    const defaults = resolveAliceOperationalDefaults({});
+
+    expect(
+      resolveAliceCodingActionDecision(defaults, {
+        action: "run_tests",
+        repo: "Render-Network-OS/milaidy",
+      }),
+    ).toMatchObject({ allowed: true, requiresApproval: false });
+
+    expect(
+      resolveAliceCodingActionDecision(defaults, {
+        action: "deploy",
+        environment: "staging",
+        deployRail: "webhook",
+        repo: "Render-Network-OS/555-bot",
+      }),
+    ).toMatchObject({ allowed: true, requiresApproval: false });
+  });
+
+  it("requires explicit human approval for production deploys", () => {
+    const defaults = resolveAliceOperationalDefaults({});
+
+    expect(
+      resolveAliceCodingActionDecision(defaults, {
+        action: "deploy",
+        environment: "production",
+        deployRail: "webhook",
+        repo: "Render-Network-OS/555-bot",
+      }),
+    ).toEqual({
+      allowed: false,
+      requiresApproval: true,
+      reason: "Production deploy requires explicit human approval.",
+    });
+
+    expect(
+      resolveAliceCodingActionDecision(defaults, {
+        action: "deploy",
+        environment: "production",
+        deployRail: "webhook",
+        repo: "Render-Network-OS/555-bot",
+        approval: {
+          approvedBy: "gl4sspr1sm@gmail.com",
+          approvalId: "ops-approval-1",
+        },
+      }),
+    ).toMatchObject({ allowed: true, requiresApproval: false });
+  });
+
+  it("blocks ad-hoc deploy rails so Ops remains the deployment source of truth", () => {
+    const defaults = resolveAliceOperationalDefaults({});
+
+    expect(
+      resolveAliceCodingActionDecision(defaults, {
+        action: "deploy",
+        environment: "production",
+        deployRail: "local-shell",
+        repo: "Render-Network-OS/555-bot",
+        approval: {
+          approvedBy: "gl4sspr1sm@gmail.com",
+          approvalId: "ops-approval-1",
+        },
+      }),
+    ).toEqual({
+      allowed: false,
+      requiresApproval: false,
+      reason: "Deploys must use the webhook rail so they are visible in Ops.",
+    });
+  });
+
+  it("can narrow allowed repositories from config", () => {
+    const config = resolveAliceOperationalDefaults({
+      alice: {
+        coding: {
+          allowedRepos: ["Render-Network-OS/milaidy"],
+        },
+      },
+    });
+
+    expect(
+      resolveAliceCodingActionDecision(config, {
+        action: "open_pr",
+        repo: "Render-Network-OS/555stream",
+      }),
+    ).toEqual({
+      allowed: false,
+      requiresApproval: false,
+      reason: "Repository is not in Alice's allowed repo list.",
+    });
+  });
+});

--- a/packages/agent/src/api/alice-coding-policy.test.ts
+++ b/packages/agent/src/api/alice-coding-policy.test.ts
@@ -11,7 +11,7 @@ describe("Alice coding and deploy policy", () => {
     expect(
       resolveAliceCodingActionDecision(defaults, {
         action: "run_tests",
-        repo: "Render-Network-OS/milaidy",
+        repo: "rndrntwrk/milaidy",
       }),
     ).toMatchObject({ allowed: true, requiresApproval: false });
 
@@ -23,6 +23,22 @@ describe("Alice coding and deploy policy", () => {
         repo: "Render-Network-OS/555-bot",
       }),
     ).toMatchObject({ allowed: true, requiresApproval: false });
+  });
+
+  it("denies deploy decisions without a valid environment", () => {
+    const defaults = resolveAliceOperationalDefaults({});
+
+    expect(
+      resolveAliceCodingActionDecision(defaults, {
+        action: "deploy",
+        deployRail: "webhook",
+        repo: "Render-Network-OS/555-bot",
+      }),
+    ).toEqual({
+      allowed: false,
+      requiresApproval: false,
+      reason: "Deploy environment must be staging or production.",
+    });
   });
 
   it("requires explicit human approval for production deploys", () => {
@@ -88,7 +104,7 @@ describe("Alice coding and deploy policy", () => {
     expect(
       resolveAliceCodingActionDecision(config, {
         action: "open_pr",
-        repo: "Render-Network-OS/555stream",
+        repo: "Render-Network-OS/stream",
       }),
     ).toEqual({
       allowed: false,

--- a/packages/agent/src/api/alice-coding-policy.ts
+++ b/packages/agent/src/api/alice-coding-policy.ts
@@ -36,9 +36,9 @@ export interface AliceCodingActionDecision {
 }
 
 const DEFAULT_ALLOWED_REPOS = [
-  "Render-Network-OS/milaidy",
+  "rndrntwrk/milaidy",
   "Render-Network-OS/555-bot",
-  "Render-Network-OS/555stream",
+  "Render-Network-OS/stream",
 ];
 
 function asStringArray(value: unknown): string[] | undefined {
@@ -81,6 +81,14 @@ export function resolveAliceCodingActionDecision(
 
   if (request.action !== "deploy") {
     return { allowed: true, requiresApproval: false };
+  }
+
+  if (request.environment !== "staging" && request.environment !== "production") {
+    return {
+      allowed: false,
+      requiresApproval: false,
+      reason: "Deploy environment must be staging or production.",
+    };
   }
 
   if (request.deployRail !== policy.deployRail) {

--- a/packages/agent/src/api/alice-coding-policy.ts
+++ b/packages/agent/src/api/alice-coding-policy.ts
@@ -1,0 +1,123 @@
+import type { ElizaConfig } from "../config/types.eliza.js";
+
+export type AliceCodingAction =
+  | "inspect_repo"
+  | "run_tests"
+  | "build"
+  | "open_pr"
+  | "deploy";
+
+export type AliceDeployEnvironment = "staging" | "production";
+
+export type AliceDeployRail = "webhook" | "local-shell" | "github-actions";
+
+export interface AliceOperationalPolicy {
+  allowedRepos: string[];
+  stagingDeploys: "allow" | "approval";
+  productionDeploys: "approval" | "deny";
+  deployRail: "webhook";
+}
+
+export interface AliceCodingActionRequest {
+  action: AliceCodingAction;
+  repo?: string;
+  environment?: AliceDeployEnvironment;
+  deployRail?: AliceDeployRail;
+  approval?: {
+    approvedBy?: string;
+    approvalId?: string;
+  };
+}
+
+export interface AliceCodingActionDecision {
+  allowed: boolean;
+  requiresApproval: boolean;
+  reason?: string;
+}
+
+const DEFAULT_ALLOWED_REPOS = [
+  "Render-Network-OS/milaidy",
+  "Render-Network-OS/555-bot",
+  "Render-Network-OS/555stream",
+];
+
+function asStringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : undefined;
+}
+
+export function resolveAliceOperationalDefaults(
+  config: Pick<ElizaConfig, "alice">,
+): AliceOperationalPolicy {
+  const aliceConfig = config.alice;
+  const coding =
+    aliceConfig && typeof aliceConfig === "object" ? aliceConfig.coding : undefined;
+  const allowedRepos = asStringArray(coding?.allowedRepos);
+  return {
+    allowedRepos:
+      allowedRepos && allowedRepos.length > 0
+        ? allowedRepos
+        : DEFAULT_ALLOWED_REPOS,
+    stagingDeploys:
+      coding?.stagingDeploys === "approval" ? "approval" : "allow",
+    productionDeploys:
+      coding?.productionDeploys === "deny" ? "deny" : "approval",
+    deployRail: "webhook",
+  };
+}
+
+export function resolveAliceCodingActionDecision(
+  policy: AliceOperationalPolicy,
+  request: AliceCodingActionRequest,
+): AliceCodingActionDecision {
+  if (request.repo && !policy.allowedRepos.includes(request.repo)) {
+    return {
+      allowed: false,
+      requiresApproval: false,
+      reason: "Repository is not in Alice's allowed repo list.",
+    };
+  }
+
+  if (request.action !== "deploy") {
+    return { allowed: true, requiresApproval: false };
+  }
+
+  if (request.deployRail !== policy.deployRail) {
+    return {
+      allowed: false,
+      requiresApproval: false,
+      reason: "Deploys must use the webhook rail so they are visible in Ops.",
+    };
+  }
+
+  if (request.environment === "production") {
+    if (policy.productionDeploys === "deny") {
+      return {
+        allowed: false,
+        requiresApproval: false,
+        reason: "Production deploys are disabled for Alice.",
+      };
+    }
+    if (!request.approval?.approvedBy || !request.approval.approvalId) {
+      return {
+        allowed: false,
+        requiresApproval: true,
+        reason: "Production deploy requires explicit human approval.",
+      };
+    }
+    return { allowed: true, requiresApproval: false };
+  }
+
+  if (request.environment === "staging" && policy.stagingDeploys === "approval") {
+    if (!request.approval?.approvedBy || !request.approval.approvalId) {
+      return {
+        allowed: false,
+        requiresApproval: true,
+        reason: "Staging deploy requires explicit human approval by policy.",
+      };
+    }
+  }
+
+  return { allowed: true, requiresApproval: false };
+}

--- a/packages/agent/src/api/alice-corpus-manifest-routes.test.ts
+++ b/packages/agent/src/api/alice-corpus-manifest-routes.test.ts
@@ -1,0 +1,121 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { handleAliceCorpusRoutes } from "./alice-corpus-routes";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "alice-corpus-routes-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeFile(root: string, relativePath: string, content: string): void {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf-8");
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeContext({
+  method,
+  pathname,
+  repoRoot,
+  stateDir,
+}: {
+  method: string;
+  pathname: string;
+  repoRoot: string;
+  stateDir: string;
+}) {
+  const jsonCalls: Array<{ data: unknown; status?: number }> = [];
+  const errorCalls: Array<{ message: string; status?: number }> = [];
+  return {
+    ctx: {
+      req: {} as never,
+      res: {} as never,
+      method,
+      pathname,
+      url: new URL(`http://localhost${pathname}`),
+      stateDir,
+      config: {
+        alice: {
+          corpus: {
+            roots: [{ id: "milaidy", path: repoRoot }],
+          },
+        },
+      },
+      json: (_res: unknown, data: unknown, status?: number) => {
+        jsonCalls.push({ data, status });
+      },
+      error: (_res: unknown, message: string, status?: number) => {
+        errorCalls.push({ message, status });
+      },
+    },
+    jsonCalls,
+    errorCalls,
+  };
+}
+
+describe("handleAliceCorpusRoutes", () => {
+  it("builds a configured corpus manifest without secrets or backups", async () => {
+    const repoRoot = makeTempDir();
+    const stateDir = makeTempDir();
+    writeFile(repoRoot, "packages/agent/src/api/server.ts", "export const api = true;\n");
+    writeFile(repoRoot, ".env.production", "OPENAI_API_KEY=sk-secret\n");
+    writeFile(repoRoot, "backup/old-config.json", "{\"token\":\"ghp_secret\"}");
+
+    const { ctx, jsonCalls } = makeContext({
+      method: "GET",
+      pathname: "/api/alice/corpus/manifest",
+      repoRoot,
+      stateDir,
+    });
+
+    await expect(handleAliceCorpusRoutes(ctx)).resolves.toBe(true);
+
+    expect(jsonCalls[0]?.data).toMatchObject({
+      ok: true,
+      manifest: {
+        roots: [{ id: "milaidy", path: repoRoot }],
+        items: [{ relativePath: "packages/agent/src/api/server.ts" }],
+        excludedCount: 2,
+      },
+    });
+  });
+
+  it("persists corpus snapshots in the Alice state directory", async () => {
+    const repoRoot = makeTempDir();
+    const stateDir = makeTempDir();
+    writeFile(repoRoot, "README.md", "# Alice\n");
+
+    const { ctx, jsonCalls } = makeContext({
+      method: "POST",
+      pathname: "/api/alice/corpus/snapshot",
+      repoRoot,
+      stateDir,
+    });
+
+    await handleAliceCorpusRoutes(ctx);
+
+    const snapshotPath = path.join(stateDir, "alice", "corpus-manifest.json");
+    expect(jsonCalls[0]?.data).toMatchObject({
+      ok: true,
+      snapshotPath,
+      manifest: {
+        items: [{ relativePath: "README.md" }],
+      },
+    });
+    expect(JSON.parse(fs.readFileSync(snapshotPath, "utf-8"))).toMatchObject({
+      version: 1,
+      items: [{ relativePath: "README.md" }],
+    });
+  });
+});

--- a/packages/agent/src/api/alice-corpus-manifest.test.ts
+++ b/packages/agent/src/api/alice-corpus-manifest.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildAliceCorpusManifest } from "./alice-corpus-manifest";
+
+const tempDirs: string[] = [];
+
+function makeRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "alice-corpus-"));
+  tempDirs.push(root);
+  return root;
+}
+
+function writeFile(root: string, relativePath: string, content: string): void {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf-8");
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("buildAliceCorpusManifest", () => {
+  it("indexes current code and docs with stable hashes", () => {
+    const root = makeRoot();
+    writeFile(root, "packages/agent/src/api/server.ts", "export const api = true;\n");
+    writeFile(root, "docs/runbook.md", "# Runbook\n");
+    writeFile(root, "README.md", "# Repo\n");
+
+    const manifest = buildAliceCorpusManifest({
+      roots: [{ id: "milaidy", path: root }],
+      generatedAt: "2026-05-01T12:00:00.000Z",
+    });
+
+    expect(manifest).toMatchObject({
+      version: 1,
+      generatedAt: "2026-05-01T12:00:00.000Z",
+      roots: [{ id: "milaidy", path: root }],
+    });
+    expect(manifest.items.map((item) => item.relativePath)).toEqual([
+      "README.md",
+      "docs/runbook.md",
+      "packages/agent/src/api/server.ts",
+    ]);
+    expect(manifest.items[0]).toMatchObject({
+      rootId: "milaidy",
+      contentType: "markdown",
+      byteSize: 7,
+    });
+    expect(manifest.items[0]?.sha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("excludes secrets, generated artifacts, binaries, and old backup payloads", () => {
+    const root = makeRoot();
+    writeFile(root, "src/index.ts", "export const safe = true;\n");
+    writeFile(root, ".env", "OPENAI_API_KEY=sk-secret\n");
+    writeFile(root, "secrets/prod.json", "{\"token\":\"ghp_secret\"}");
+    writeFile(root, "dist/bundle.js", "compiled");
+    writeFile(root, "node_modules/pkg/index.js", "dependency");
+    writeFile(root, "backup/alice.env", "legacy secret");
+    writeFile(root, "avatars/alice.vrm", "binary-ish");
+
+    const manifest = buildAliceCorpusManifest({
+      roots: [{ id: "milaidy", path: root }],
+      generatedAt: "2026-05-01T12:00:00.000Z",
+    });
+
+    expect(manifest.items.map((item) => item.relativePath)).toEqual([
+      "src/index.ts",
+    ]);
+    expect(manifest.excludedCount).toBe(6);
+  });
+});

--- a/packages/agent/src/api/alice-corpus-manifest.ts
+++ b/packages/agent/src/api/alice-corpus-manifest.ts
@@ -1,0 +1,229 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+export interface AliceCorpusRoot {
+  id: string;
+  path: string;
+}
+
+export interface AliceCorpusManifestItem {
+  rootId: string;
+  relativePath: string;
+  absolutePath: string;
+  contentType: "code" | "config" | "markdown" | "text";
+  sha256: string;
+  byteSize: number;
+}
+
+export interface AliceCorpusManifest {
+  version: 1;
+  generatedAt: string;
+  roots: AliceCorpusRoot[];
+  items: AliceCorpusManifestItem[];
+  excludedCount: number;
+}
+
+export interface BuildAliceCorpusManifestOptions {
+  roots: AliceCorpusRoot[];
+  generatedAt?: string;
+}
+
+const EXCLUDED_DIR_NAMES = new Set([
+  ".cache",
+  ".git",
+  ".next",
+  ".turbo",
+  "backup",
+  "backups",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "output",
+  "secrets",
+  "tmp",
+  "temp",
+]);
+
+const EXCLUDED_EXACT_FILENAMES = new Set([
+  ".env",
+  ".env.local",
+  ".env.production",
+  ".env.staging",
+  "bun.lockb",
+  "package-lock.json",
+  "pnpm-lock.yaml",
+  "yarn.lock",
+]);
+
+const EXCLUDED_EXTENSIONS = new Set([
+  ".aac",
+  ".avi",
+  ".bin",
+  ".dylib",
+  ".gif",
+  ".gz",
+  ".ico",
+  ".jpeg",
+  ".jpg",
+  ".key",
+  ".mov",
+  ".mp3",
+  ".mp4",
+  ".p12",
+  ".pem",
+  ".png",
+  ".so",
+  ".tar",
+  ".vrm",
+  ".wav",
+  ".webm",
+  ".webp",
+  ".zip",
+]);
+
+const INCLUDED_EXTENSIONS = new Set([
+  ".cjs",
+  ".css",
+  ".csv",
+  ".html",
+  ".js",
+  ".json",
+  ".jsx",
+  ".md",
+  ".mdx",
+  ".mjs",
+  ".sh",
+  ".sql",
+  ".tf",
+  ".toml",
+  ".ts",
+  ".tsx",
+  ".txt",
+  ".xml",
+  ".yaml",
+  ".yml",
+]);
+
+const INCLUDED_FILENAMES = new Set([
+  "Dockerfile",
+  "Makefile",
+  "README",
+  "AGENTS",
+  "BOOTSTRAP",
+  "HEARTBEAT",
+  "IDENTITY",
+  "TOOLS",
+  "USER",
+]);
+
+function sha256(buffer: Buffer): string {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+function normalizeRelativePath(filePath: string): string {
+  return filePath.split(path.sep).join("/");
+}
+
+function shouldExclude(relativePath: string): boolean {
+  const normalized = normalizeRelativePath(relativePath);
+  const segments = normalized.split("/");
+  if (segments.some((segment) => EXCLUDED_DIR_NAMES.has(segment))) {
+    return true;
+  }
+  const base = segments.at(-1) ?? "";
+  if (EXCLUDED_EXACT_FILENAMES.has(base)) return true;
+  if (base.startsWith(".env.")) return true;
+  if (/secret|credential|token|private-key/i.test(normalized)) return true;
+  const ext = path.extname(base);
+  return EXCLUDED_EXTENSIONS.has(ext);
+}
+
+function shouldInclude(relativePath: string): boolean {
+  const base = path.basename(relativePath);
+  if (INCLUDED_FILENAMES.has(base)) return true;
+  return INCLUDED_EXTENSIONS.has(path.extname(base));
+}
+
+function contentTypeFor(relativePath: string): AliceCorpusManifestItem["contentType"] {
+  const ext = path.extname(relativePath);
+  if (ext === ".md" || ext === ".mdx") return "markdown";
+  if (ext === ".json" || ext === ".yaml" || ext === ".yml" || ext === ".toml") {
+    return "config";
+  }
+  if (
+    [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".sh", ".tf", ".sql", ".css", ".html"].includes(
+      ext,
+    )
+  ) {
+    return "code";
+  }
+  return "text";
+}
+
+function walkFiles(root: string): string[] {
+  const output: string[] = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) continue;
+    const entries = fs.readdirSync(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+      } else if (entry.isFile()) {
+        output.push(fullPath);
+      }
+    }
+  }
+  return output;
+}
+
+export function buildAliceCorpusManifest(
+  options: BuildAliceCorpusManifestOptions,
+): AliceCorpusManifest {
+  const items: AliceCorpusManifestItem[] = [];
+  let excludedCount = 0;
+
+  for (const root of options.roots) {
+    const rootPath = path.resolve(root.path);
+    if (!fs.existsSync(rootPath)) continue;
+    for (const filePath of walkFiles(rootPath)) {
+      const relativePath = normalizeRelativePath(path.relative(rootPath, filePath));
+      if (shouldExclude(relativePath) || !shouldInclude(relativePath)) {
+        excludedCount += 1;
+        continue;
+      }
+      const bytes = fs.readFileSync(filePath);
+      items.push({
+        rootId: root.id,
+        relativePath,
+        absolutePath: filePath,
+        contentType: contentTypeFor(relativePath),
+        sha256: sha256(bytes),
+        byteSize: bytes.byteLength,
+      });
+    }
+  }
+
+  items.sort((a, b) => {
+    const left = `${a.rootId}/${a.relativePath}`;
+    const right = `${b.rootId}/${b.relativePath}`;
+    if (left < right) return -1;
+    if (left > right) return 1;
+    return 0;
+  });
+
+  return {
+    version: 1,
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    roots: options.roots.map((root) => ({
+      id: root.id,
+      path: path.resolve(root.path),
+    })),
+    items,
+    excludedCount,
+  };
+}

--- a/packages/agent/src/api/alice-corpus-routes.ts
+++ b/packages/agent/src/api/alice-corpus-routes.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs";
+import type http from "node:http";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import type { ElizaConfig } from "../config/types.eliza.js";
+import {
+  type AliceCorpusRoot,
+  buildAliceCorpusManifest,
+} from "./alice-corpus-manifest.js";
+
+export interface AliceCorpusRouteContext {
+  req: http.IncomingMessage;
+  res: http.ServerResponse;
+  method: string;
+  pathname: string;
+  url: URL;
+  config: Pick<ElizaConfig, "alice">;
+  stateDir?: string;
+  cwd?: string;
+  json: (res: http.ServerResponse, data: unknown, status?: number) => void;
+  error: (res: http.ServerResponse, message: string, status?: number) => void;
+}
+
+function resolveCorpusRoots(
+  config: Pick<ElizaConfig, "alice">,
+  cwd: string,
+): AliceCorpusRoot[] {
+  const configuredRoots = config.alice?.corpus?.roots;
+  if (Array.isArray(configuredRoots) && configuredRoots.length > 0) {
+    return configuredRoots
+      .filter(
+        (root): root is { id: string; path: string } =>
+          typeof root.id === "string" && typeof root.path === "string",
+      )
+      .map((root) => ({
+        id: root.id,
+        path: path.resolve(cwd, root.path),
+      }));
+  }
+
+  return [{ id: "runtime", path: cwd }];
+}
+
+function resolveSnapshotPath(stateDir?: string): string {
+  return path.join(stateDir ?? resolveStateDir(), "alice", "corpus-manifest.json");
+}
+
+export async function handleAliceCorpusRoutes(
+  ctx: AliceCorpusRouteContext,
+): Promise<boolean> {
+  const { res, method, pathname, config, stateDir, cwd = process.cwd(), json, error } = ctx;
+
+  if (
+    pathname !== "/api/alice/corpus/manifest" &&
+    pathname !== "/api/alice/corpus/snapshot"
+  ) {
+    return false;
+  }
+
+  const manifest = buildAliceCorpusManifest({
+    roots: resolveCorpusRoots(config, cwd),
+  });
+
+  if (method === "GET" && pathname === "/api/alice/corpus/manifest") {
+    json(res, { ok: true, manifest });
+    return true;
+  }
+
+  if (method === "POST" && pathname === "/api/alice/corpus/snapshot") {
+    const snapshotPath = resolveSnapshotPath(stateDir);
+    fs.mkdirSync(path.dirname(snapshotPath), { recursive: true });
+    fs.writeFileSync(snapshotPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
+    json(res, { ok: true, snapshotPath, manifest });
+    return true;
+  }
+
+  error(res, "Method not allowed", 405);
+  return true;
+}

--- a/packages/agent/src/api/auth-routes.test.ts
+++ b/packages/agent/src/api/auth-routes.test.ts
@@ -14,11 +14,11 @@ describe("agent auth routes source regression guard", () => {
     expect(source).toContain(
       'import { getConfiguredApiToken, isApiAuthDisabled } from "./server-auth.js";',
     );
-    expect(source).toContain(
-      "if (isApiAuthDisabled() || isCloudProvisionedContainer())",
-    );
+    expect(source).toContain("isCloudProvisionedContainer() ||");
     expect(source).toContain(
       "const enabled = !isApiAuthDisabled() && pairingEnabled();",
     );
+    expect(source).toContain('from "./cloudflare-access-auth.js";');
+    expect(source).toContain("isCloudflareAccessAuthenticated(req)");
   });
 });

--- a/packages/agent/src/api/auth-routes.ts
+++ b/packages/agent/src/api/auth-routes.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { isCloudProvisionedContainer } from "./cloud-provisioning.js";
+import { isCloudflareAccessAuthenticated } from "./cloudflare-access-auth.js";
 import { getConfiguredApiToken, isApiAuthDisabled } from "./server-auth.js";
 import type { RouteRequestContext } from "./route-helpers.js";
 
@@ -34,7 +35,11 @@ export async function handleAuthRoutes(
   if (!pathname.startsWith("/api/auth/")) return false;
 
   if (method === "GET" && pathname === "/api/auth/status") {
-    if (isApiAuthDisabled() || isCloudProvisionedContainer()) {
+    if (
+      isApiAuthDisabled() ||
+      isCloudProvisionedContainer() ||
+      isCloudflareAccessAuthenticated(req)
+    ) {
       // Steward-managed cloud containers enforce API auth upstream, but the
       // local pairing flow is intentionally unavailable there. Reporting
       // required=true would strand app-core clients in PairingView.
@@ -60,7 +65,11 @@ export async function handleAuthRoutes(
     const body = await readJsonBody<{ code?: string }>(req, res);
     if (!body) return true;
 
-    if (isApiAuthDisabled() || isCloudProvisionedContainer()) {
+    if (
+      isApiAuthDisabled() ||
+      isCloudProvisionedContainer() ||
+      isCloudflareAccessAuthenticated(req)
+    ) {
       error(res, "Pairing disabled", 403);
       return true;
     }

--- a/packages/agent/src/api/cloudflare-access-auth.test.ts
+++ b/packages/agent/src/api/cloudflare-access-auth.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasCloudflareAccessIdentity,
+  isCloudflareAccessAuthenticated,
+  isCloudflareAccessTrustEnabled,
+} from "./cloudflare-access-auth";
+
+describe("Cloudflare Access auth trust gate", () => {
+  it("requires explicit trust before accepting Cloudflare Access identity headers", () => {
+    const req = {
+      headers: {
+        "cf-access-authenticated-user-email": "gl4sspr1sm@gmail.com",
+      },
+    };
+
+    expect(hasCloudflareAccessIdentity(req)).toBe(true);
+    expect(isCloudflareAccessTrustEnabled({})).toBe(false);
+    expect(isCloudflareAccessAuthenticated(req, {})).toBe(false);
+    expect(
+      isCloudflareAccessAuthenticated(req, {
+        MILADY_TRUST_CLOUDFLARE_ACCESS: "1",
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts JWT assertion headers when email forwarding is unavailable", () => {
+    expect(
+      isCloudflareAccessAuthenticated(
+        {
+          headers: {
+            "cf-access-jwt-assertion": "signed.jwt.value",
+          },
+        },
+        { ELIZA_TRUST_CLOUDFLARE_ACCESS: "true" },
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/agent/src/api/cloudflare-access-auth.test.ts
+++ b/packages/agent/src/api/cloudflare-access-auth.test.ts
@@ -20,7 +20,38 @@ describe("Cloudflare Access auth trust gate", () => {
       isCloudflareAccessAuthenticated(req, {
         MILADY_TRUST_CLOUDFLARE_ACCESS: "1",
       }),
+    ).toBe(false);
+    expect(
+      isCloudflareAccessAuthenticated(
+        {
+          headers: {
+            ...req.headers,
+            "x-milady-cloudflare-access-secret": "origin-proof",
+          },
+        },
+        {
+          MILADY_TRUST_CLOUDFLARE_ACCESS: "1",
+          MILADY_CLOUDFLARE_ACCESS_PROXY_SECRET: "origin-proof",
+        },
+      ),
     ).toBe(true);
+  });
+
+  it("rejects Cloudflare Access identity headers with the wrong origin proof", () => {
+    expect(
+      isCloudflareAccessAuthenticated(
+        {
+          headers: {
+            "cf-access-authenticated-user-email": "gl4sspr1sm@gmail.com",
+            "x-milady-cloudflare-access-secret": "wrong-proof",
+          },
+        },
+        {
+          MILADY_TRUST_CLOUDFLARE_ACCESS: "1",
+          MILADY_CLOUDFLARE_ACCESS_PROXY_SECRET: "origin-proof",
+        },
+      ),
+    ).toBe(false);
   });
 
   it("accepts JWT assertion headers when email forwarding is unavailable", () => {
@@ -29,9 +60,13 @@ describe("Cloudflare Access auth trust gate", () => {
         {
           headers: {
             "cf-access-jwt-assertion": "signed.jwt.value",
+            "x-milady-cloudflare-access-secret": "origin-proof",
           },
         },
-        { ELIZA_TRUST_CLOUDFLARE_ACCESS: "true" },
+        {
+          ELIZA_TRUST_CLOUDFLARE_ACCESS: "true",
+          CLOUDFLARE_ACCESS_PROXY_SECRET: "origin-proof",
+        },
       ),
     ).toBe(true);
   });

--- a/packages/agent/src/api/cloudflare-access-auth.ts
+++ b/packages/agent/src/api/cloudflare-access-auth.ts
@@ -1,4 +1,5 @@
 import type http from "node:http";
+import crypto from "node:crypto";
 
 const ENABLED_VALUES = new Set(["1", "true", "yes", "on"]);
 
@@ -28,6 +29,22 @@ export function isCloudflareAccessTrustEnabled(
   );
 }
 
+function readTrustedProxySecret(env: NodeJS.ProcessEnv): string | undefined {
+  return (
+    env.MILADY_CLOUDFLARE_ACCESS_PROXY_SECRET ??
+    env.MILAIDY_CLOUDFLARE_ACCESS_PROXY_SECRET ??
+    env.ELIZA_CLOUDFLARE_ACCESS_PROXY_SECRET ??
+    env.CLOUDFLARE_ACCESS_PROXY_SECRET
+  )?.trim();
+}
+
+function tokenMatches(expected: string, provided: string): boolean {
+  const expectedBuffer = Buffer.from(expected, "utf8");
+  const providedBuffer = Buffer.from(provided, "utf8");
+  if (expectedBuffer.length !== providedBuffer.length) return false;
+  return crypto.timingSafeEqual(expectedBuffer, providedBuffer);
+}
+
 export function hasCloudflareAccessIdentity(
   req: Pick<http.IncomingMessage, "headers">,
 ): boolean {
@@ -37,9 +54,28 @@ export function hasCloudflareAccessIdentity(
   );
 }
 
+export function hasCloudflareAccessTrustedProxyProof(
+  req: Pick<http.IncomingMessage, "headers">,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const expectedSecret = readTrustedProxySecret(env);
+  if (!expectedSecret) return false;
+  const providedSecret =
+    readHeader(req, "x-milady-cloudflare-access-secret") ??
+    readHeader(req, "x-eliza-cloudflare-access-secret") ??
+    readHeader(req, "x-cloudflare-access-proxy-secret");
+  return providedSecret
+    ? tokenMatches(expectedSecret, providedSecret)
+    : false;
+}
+
 export function isCloudflareAccessAuthenticated(
   req: Pick<http.IncomingMessage, "headers">,
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  return isCloudflareAccessTrustEnabled(env) && hasCloudflareAccessIdentity(req);
+  return (
+    isCloudflareAccessTrustEnabled(env) &&
+    hasCloudflareAccessIdentity(req) &&
+    hasCloudflareAccessTrustedProxyProof(req, env)
+  );
 }

--- a/packages/agent/src/api/cloudflare-access-auth.ts
+++ b/packages/agent/src/api/cloudflare-access-auth.ts
@@ -1,0 +1,45 @@
+import type http from "node:http";
+
+const ENABLED_VALUES = new Set(["1", "true", "yes", "on"]);
+
+function envFlagEnabled(value: string | undefined): boolean {
+  return value ? ENABLED_VALUES.has(value.trim().toLowerCase()) : false;
+}
+
+function readHeader(
+  req: Pick<http.IncomingMessage, "headers">,
+  name: string,
+): string | undefined {
+  const value = req.headers[name.toLowerCase()];
+  if (Array.isArray(value)) return value.find((item) => item.trim().length > 0);
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+export function isCloudflareAccessTrustEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    envFlagEnabled(env.MILADY_TRUST_CLOUDFLARE_ACCESS) ||
+    envFlagEnabled(env.MILAIDY_TRUST_CLOUDFLARE_ACCESS) ||
+    envFlagEnabled(env.ELIZA_TRUST_CLOUDFLARE_ACCESS) ||
+    envFlagEnabled(env.CLOUDFLARE_ACCESS_TRUSTED)
+  );
+}
+
+export function hasCloudflareAccessIdentity(
+  req: Pick<http.IncomingMessage, "headers">,
+): boolean {
+  return Boolean(
+    readHeader(req, "cf-access-authenticated-user-email") ||
+      readHeader(req, "cf-access-jwt-assertion"),
+  );
+}
+
+export function isCloudflareAccessAuthenticated(
+  req: Pick<http.IncomingMessage, "headers">,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return isCloudflareAccessTrustEnabled(env) && hasCloudflareAccessIdentity(req);
+}

--- a/packages/agent/src/api/cross-channel-ingest-routes.test.ts
+++ b/packages/agent/src/api/cross-channel-ingest-routes.test.ts
@@ -1,0 +1,212 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { handleCrossChannelIngestRoutes } from "./cross-channel-ingest-routes";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "alice-ingest-routes-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeContext({
+  method,
+  pathname,
+  body,
+  rootDir,
+  config,
+  url = `http://localhost${pathname}`,
+}: {
+  method: string;
+  pathname: string;
+  body?: Record<string, unknown>;
+  rootDir: string;
+  config?: Record<string, unknown>;
+  url?: string;
+}) {
+  const jsonCalls: Array<{ data: unknown; status?: number }> = [];
+  const errorCalls: Array<{ message: string; status?: number }> = [];
+  return {
+    ctx: {
+      req: {} as never,
+      res: {} as never,
+      method,
+      pathname,
+      url: new URL(url),
+      stateDir: rootDir,
+      config,
+      readJsonBody: async () => body ?? {},
+      json: (_res: unknown, data: unknown, status?: number) => {
+        jsonCalls.push({ data, status });
+      },
+      error: (_res: unknown, message: string, status?: number) => {
+        errorCalls.push({ message, status });
+      },
+    },
+    jsonCalls,
+    errorCalls,
+  };
+}
+
+describe("handleCrossChannelIngestRoutes", () => {
+  it("ingests normalized comments through the HTTP handler", async () => {
+    const rootDir = makeTempDir();
+    const { ctx, jsonCalls } = makeContext({
+      method: "POST",
+      pathname: "/api/ingest/comments",
+      rootDir,
+      body: {
+        source: "github",
+        externalId: "gh1",
+        threadId: "pr1",
+        body: "Review this before production",
+      },
+    });
+
+    await expect(handleCrossChannelIngestRoutes(ctx)).resolves.toBe(true);
+
+    expect(jsonCalls).toHaveLength(1);
+    expect(jsonCalls[0]?.data).toMatchObject({
+      ok: true,
+      created: true,
+      comment: {
+        source: "github",
+        externalId: "gh1",
+        actionability: "needs_review",
+      },
+    });
+  });
+
+  it("ingests source payloads and exposes status/list endpoints", async () => {
+    const rootDir = makeTempDir();
+    await handleCrossChannelIngestRoutes(
+      makeContext({
+        method: "POST",
+        pathname: "/api/ingest/comments",
+        rootDir,
+        body: {
+          source: "slack",
+          payload: {
+            team: "T1",
+            channel: "C1",
+            ts: "1777639200.000100",
+            text: "Corpus update needed",
+            user: "U1",
+          },
+        },
+      }).ctx,
+    );
+
+    const status = makeContext({
+      method: "GET",
+      pathname: "/api/ingest/comments/status",
+      rootDir,
+    });
+    await handleCrossChannelIngestRoutes(status.ctx);
+
+    expect(status.jsonCalls[0]?.data).toMatchObject({
+      ok: true,
+      status: {
+        total: 1,
+        bySource: { slack: 1 },
+      },
+    });
+
+    const list = makeContext({
+      method: "GET",
+      pathname: "/api/ingest/comments",
+      rootDir,
+      url: "http://localhost/api/ingest/comments?source=slack&limit=10",
+    });
+    await handleCrossChannelIngestRoutes(list.ctx);
+
+    expect(list.jsonCalls[0]?.data).toMatchObject({
+      ok: true,
+      total: 1,
+      items: [{ source: "slack", channelId: "C1" }],
+    });
+  });
+
+  it("rejects unsupported ingest sources", async () => {
+    const { ctx, errorCalls } = makeContext({
+      method: "POST",
+      pathname: "/api/ingest/comments",
+      rootDir: makeTempDir(),
+      body: {
+        source: "x-twitter",
+        payload: {},
+      },
+    });
+
+    await expect(handleCrossChannelIngestRoutes(ctx)).resolves.toBe(true);
+    expect(errorCalls).toEqual([
+      { message: "Unsupported cross-channel source", status: 400 },
+    ]);
+  });
+
+  it("honors the configured Alice ingest store directory", async () => {
+    const rootDir = makeTempDir();
+    const customStoreDir = path.join(makeTempDir(), "custom-ingest");
+    const { ctx } = makeContext({
+      method: "POST",
+      pathname: "/api/ingest/comments",
+      rootDir,
+      config: {
+        alice: {
+          ingest: {
+            storeDir: customStoreDir,
+          },
+        },
+      },
+      body: {
+        source: "ops",
+        externalId: "run-1",
+        threadId: "alice-prod",
+        body: "prod deploy requires approval",
+      },
+    });
+
+    await handleCrossChannelIngestRoutes(ctx);
+
+    expect(fs.existsSync(path.join(customStoreDir, "comments.json"))).toBe(true);
+    expect(fs.existsSync(path.join(rootDir, "ingest", "comments", "comments.json"))).toBe(
+      false,
+    );
+  });
+
+  it("rejects sources disabled by Alice ingest config", async () => {
+    const { ctx, errorCalls } = makeContext({
+      method: "POST",
+      pathname: "/api/ingest/comments",
+      rootDir: makeTempDir(),
+      config: {
+        alice: {
+          ingest: {
+            sources: ["github"],
+          },
+        },
+      },
+      body: {
+        source: "slack",
+        externalId: "slack-1",
+        threadId: "thread-1",
+        body: "should not ingest",
+      },
+    });
+
+    await handleCrossChannelIngestRoutes(ctx);
+
+    expect(errorCalls).toEqual([
+      { message: "Cross-channel source is disabled", status: 403 },
+    ]);
+  });
+});

--- a/packages/agent/src/api/cross-channel-ingest-routes.ts
+++ b/packages/agent/src/api/cross-channel-ingest-routes.ts
@@ -1,0 +1,158 @@
+import path from "node:path";
+import type http from "node:http";
+import { resolveStateDir } from "../config/paths.js";
+import type { ElizaConfig } from "../config/types.eliza.js";
+import type { ReadJsonBodyOptions } from "./http-helpers.js";
+import {
+  type CrossChannelCommentInput,
+  type CrossChannelCommentSource,
+  createCrossChannelIngestStore,
+  type SourcePayloadInput,
+} from "./cross-channel-ingest.js";
+
+const SUPPORTED_SOURCES = new Set<CrossChannelCommentSource>([
+  "github",
+  "discord",
+  "telegram",
+  "slack",
+  "gmail",
+  "ops",
+  "stream555",
+]);
+
+export interface CrossChannelIngestRouteContext {
+  req: http.IncomingMessage;
+  res: http.ServerResponse;
+  method: string;
+  pathname: string;
+  url: URL;
+  stateDir?: string;
+  config?: Pick<ElizaConfig, "alice">;
+  json: (res: http.ServerResponse, data: unknown, status?: number) => void;
+  error: (res: http.ServerResponse, message: string, status?: number) => void;
+  readJsonBody: <T extends object>(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    options?: ReadJsonBodyOptions,
+  ) => Promise<T | null>;
+}
+
+type RawIngestBody = Partial<CrossChannelCommentInput & SourcePayloadInput>;
+
+function resolveIngestRoot(
+  stateDir?: string,
+  config?: Pick<ElizaConfig, "alice">,
+): string {
+  const configuredStoreDir = config?.alice?.ingest?.storeDir;
+  const baseStateDir = stateDir ?? resolveStateDir();
+  if (configuredStoreDir) {
+    return path.isAbsolute(configuredStoreDir)
+      ? configuredStoreDir
+      : path.join(baseStateDir, configuredStoreDir);
+  }
+  return path.join(baseStateDir, "ingest", "comments");
+}
+
+function parseSource(value: unknown): CrossChannelCommentSource | null {
+  return typeof value === "string" && SUPPORTED_SOURCES.has(value as CrossChannelCommentSource)
+    ? (value as CrossChannelCommentSource)
+    : null;
+}
+
+function isSourceEnabled(
+  source: CrossChannelCommentSource,
+  config?: Pick<ElizaConfig, "alice">,
+): boolean {
+  const ingestConfig = config?.alice?.ingest;
+  if (ingestConfig?.enabled === false) return false;
+  const configuredSources = ingestConfig?.sources;
+  if (!Array.isArray(configuredSources) || configuredSources.length === 0) {
+    return true;
+  }
+  return configuredSources.includes(source);
+}
+
+function parseLimit(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return undefined;
+  return parsed;
+}
+
+export async function handleCrossChannelIngestRoutes(
+  ctx: CrossChannelIngestRouteContext,
+): Promise<boolean> {
+  const { req, res, method, pathname, url, json, error, readJsonBody } = ctx;
+
+  if (
+    pathname !== "/api/ingest/comments" &&
+    pathname !== "/api/ingest/comments/status" &&
+    pathname !== "/api/ingest/comments/replay"
+  ) {
+    return false;
+  }
+
+  const store = createCrossChannelIngestStore({
+    rootDir: resolveIngestRoot(ctx.stateDir, ctx.config),
+  });
+
+  if (method === "GET" && pathname === "/api/ingest/comments/status") {
+    json(res, { ok: true, status: store.status() });
+    return true;
+  }
+
+  if (method === "GET" && pathname === "/api/ingest/comments") {
+    const sourceParam = url.searchParams.get("source");
+    const source = sourceParam ? parseSource(sourceParam) : undefined;
+    if (sourceParam && !source) {
+      error(res, "Unsupported cross-channel source", 400);
+      return true;
+    }
+    const result = store.list({
+      source,
+      limit: parseLimit(url.searchParams.get("limit")),
+      since: url.searchParams.get("since") ?? undefined,
+    });
+    json(res, { ok: true, ...result });
+    return true;
+  }
+
+  if (method === "POST" && pathname === "/api/ingest/comments") {
+    const body = await readJsonBody<RawIngestBody>(req, res, {
+      maxBytes: 4 * 1024 * 1024,
+    });
+    if (!body) return true;
+
+    const source = parseSource(body.source);
+    if (!source) {
+      error(res, "Unsupported cross-channel source", 400);
+      return true;
+    }
+    if (!isSourceEnabled(source, ctx.config)) {
+      error(res, "Cross-channel source is disabled", 403);
+      return true;
+    }
+
+    const result =
+      body.payload && typeof body.payload === "object"
+        ? store.ingest({
+            source,
+            payload: body.payload as Record<string, unknown>,
+          })
+        : store.ingest({ ...(body as CrossChannelCommentInput), source });
+    json(res, { ok: true, ...result });
+    return true;
+  }
+
+  if (method === "POST" && pathname === "/api/ingest/comments/replay") {
+    const result = store.list({
+      limit: parseLimit(url.searchParams.get("limit")) ?? 100,
+      since: url.searchParams.get("since") ?? undefined,
+    });
+    json(res, { ok: true, replayed: result.items.length, items: result.items });
+    return true;
+  }
+
+  error(res, "Method not allowed", 405);
+  return true;
+}

--- a/packages/agent/src/api/cross-channel-ingest.test.ts
+++ b/packages/agent/src/api/cross-channel-ingest.test.ts
@@ -1,0 +1,232 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createCrossChannelIngestStore,
+  normalizeCrossChannelCommentEvent,
+  normalizeCrossChannelSourcePayload,
+  redactCrossChannelSecrets,
+} from "./cross-channel-ingest";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "alice-ingest-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("cross-channel comment ingest", () => {
+  it("normalizes GitHub issue comments into the canonical comment contract", () => {
+    const comment = normalizeCrossChannelSourcePayload({
+      source: "github",
+      payload: {
+        action: "created",
+        repository: {
+          full_name: "Render-Network-OS/milaidy",
+        },
+        issue: {
+          number: 105,
+          pull_request: { url: "https://api.github.com/repos/x/y/pulls/105" },
+          html_url: "https://github.com/Render-Network-OS/milaidy/pull/105",
+          title: "Alice production branch update",
+        },
+        comment: {
+          id: 987,
+          html_url:
+            "https://github.com/Render-Network-OS/milaidy/pull/105#issuecomment-987",
+          body: "Please keep staging green before prod.",
+          created_at: "2026-05-01T10:00:00Z",
+          updated_at: "2026-05-01T10:01:00Z",
+          user: {
+            login: "ops-reviewer",
+            html_url: "https://github.com/ops-reviewer",
+          },
+        },
+      },
+    });
+
+    expect(comment).toMatchObject({
+      source: "github",
+      externalId: "github:Render-Network-OS/milaidy:issue-comment:987",
+      threadId: "github:Render-Network-OS/milaidy:pull:105",
+      channelId: "Render-Network-OS/milaidy",
+      body: "Please keep staging green before prod.",
+      permalink:
+        "https://github.com/Render-Network-OS/milaidy/pull/105#issuecomment-987",
+      visibility: "internal",
+      actionability: "needs_review",
+    });
+    expect(comment.author).toEqual({
+      id: "ops-reviewer",
+      name: "ops-reviewer",
+      url: "https://github.com/ops-reviewer",
+    });
+    expect(comment.provenance).toMatchObject({
+      adapter: "github.issue_comment",
+      repository: "Render-Network-OS/milaidy",
+      pullRequest: 105,
+    });
+  });
+
+  it("normalizes all core first-release channel payloads", () => {
+    const samples = [
+      {
+        source: "discord",
+        payload: {
+          id: "d1",
+          channel_id: "chan",
+          guild_id: "guild",
+          content: "ship staging first",
+          timestamp: "2026-05-01T10:00:00Z",
+          author: { id: "u1", username: "discord-user" },
+        },
+      },
+      {
+        source: "telegram",
+        payload: {
+          message_id: 42,
+          date: 1777639200,
+          text: "prod needs approval",
+          chat: { id: -1001, title: "ops" },
+          from: { id: 777, username: "telegram_user" },
+        },
+      },
+      {
+        source: "slack",
+        payload: {
+          team: "T1",
+          channel: "C1",
+          ts: "1777639200.000100",
+          thread_ts: "1777639100.000100",
+          text: "please update the corpus",
+          user: "U1",
+        },
+      },
+      {
+        source: "gmail",
+        payload: {
+          id: "m1",
+          threadId: "t1",
+          from: "Alice Tester <alice@example.com>",
+          subject: "Alice setup",
+          snippet: "Connect GitHub and Slack",
+          internalDate: "1777639200000",
+        },
+      },
+      {
+        source: "ops",
+        payload: {
+          id: "run-prod-1",
+          environment: "production",
+          service: "alice-bot",
+          status: "requires_approval",
+          message: "Prepared prod deploy for Alice",
+          createdAt: "2026-05-01T10:00:00Z",
+        },
+      },
+      {
+        source: "stream555",
+        payload: {
+          id: "comment-1",
+          channel: "alice-cam",
+          user: "viewer",
+          text: "audio sounds good",
+          createdAt: "2026-05-01T10:00:00Z",
+        },
+      },
+    ] as const;
+
+    const comments = samples.map(normalizeCrossChannelSourcePayload);
+
+    expect(comments.map((comment) => comment.source)).toEqual([
+      "discord",
+      "telegram",
+      "slack",
+      "gmail",
+      "ops",
+      "stream555",
+    ]);
+    expect(comments.every((comment) => comment.dedupeKey.length > 10)).toBe(
+      true,
+    );
+    expect(comments.every((comment) => comment.receivedAt)).toBe(true);
+  });
+
+  it("redacts tokens before comments are stored or projected to knowledge", () => {
+    const text =
+      "github ghp_1234567890abcdef1234567890abcdef1234 openai sk-proj-abcDEF1234567890 twitch live_123456789_secret";
+
+    expect(redactCrossChannelSecrets(text)).toBe(
+      "github [REDACTED:github-token] openai [REDACTED:openai-token] twitch [REDACTED:stream-key]",
+    );
+  });
+
+  it("persists raw envelopes and idempotently upserts normalized comments", () => {
+    const store = createCrossChannelIngestStore({
+      rootDir: makeTempDir(),
+      now: () => 1777639200000,
+    });
+
+    const first = store.ingest({
+      source: "github",
+      externalId: "gh-comment-1",
+      threadId: "gh-pr-1",
+      author: { id: "alice", name: "alice" },
+      body: "first body",
+      createdAt: "2026-05-01T10:00:00Z",
+    });
+    const second = store.ingest({
+      source: "github",
+      externalId: "gh-comment-1",
+      threadId: "gh-pr-1",
+      author: { id: "alice", name: "alice" },
+      body: "edited body",
+      createdAt: "2026-05-01T10:00:00Z",
+      updatedAt: "2026-05-01T10:10:00Z",
+    });
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(store.list().items).toHaveLength(1);
+    expect(store.list().items[0]).toMatchObject({
+      body: "edited body",
+      updatedAt: "2026-05-01T10:10:00.000Z",
+    });
+    expect(fs.readFileSync(store.paths.rawAuditLog, "utf-8").trim().split("\n"))
+      .toHaveLength(2);
+  });
+
+  it("builds safe knowledge fragments with provenance and no raw payload secrets", () => {
+    const normalized = normalizeCrossChannelCommentEvent({
+      source: "slack",
+      externalId: "slack-message-1",
+      threadId: "slack-thread-1",
+      channelId: "ops",
+      author: { id: "U1", name: "ops-user" },
+      body: "rotate this sk-abcdef1234567890 immediately",
+      createdAt: "2026-05-01T10:00:00Z",
+      permalink: "https://slack.example/archives/C1/p1",
+    });
+
+    expect(normalized.knowledgeFragment).toEqual({
+      title: "slack comment from ops-user",
+      text:
+        "Source: slack\nThread: slack-thread-1\nAuthor: ops-user\nLink: https://slack.example/archives/C1/p1\n\nrotate this [REDACTED:openai-token] immediately",
+      metadata: {
+        source: "slack",
+        externalId: "slack-message-1",
+        threadId: "slack-thread-1",
+        channelId: "ops",
+        permalink: "https://slack.example/archives/C1/p1",
+      },
+    });
+  });
+});

--- a/packages/agent/src/api/cross-channel-ingest.test.ts
+++ b/packages/agent/src/api/cross-channel-ingest.test.ts
@@ -160,6 +160,59 @@ describe("cross-channel comment ingest", () => {
     expect(comments.every((comment) => comment.receivedAt)).toBe(true);
   });
 
+  it("normalizes live Slack Events API envelopes", () => {
+    const comment = normalizeCrossChannelSourcePayload({
+      source: "slack",
+      payload: {
+        team_id: "T1",
+        event: {
+          type: "message",
+          channel: "C-live",
+          user: "U-live",
+          text: "please ingest the real Slack envelope",
+          ts: "1777639200.000100",
+          thread_ts: "1777639100.000100",
+        },
+      },
+    });
+
+    expect(comment).toMatchObject({
+      source: "slack",
+      externalId: "slack:T1:C-live:1777639200.000100",
+      threadId: "slack:T1:C-live:1777639100.000100",
+      channelId: "C-live",
+      body: "please ingest the real Slack envelope",
+      author: { id: "U-live", name: "U-live" },
+    });
+  });
+
+  it("normalizes live Telegram webhook envelopes", () => {
+    const comment = normalizeCrossChannelSourcePayload({
+      source: "telegram",
+      payload: {
+        update_id: 123,
+        message: {
+          message_id: 42,
+          message_thread_id: 7,
+          date: 1777639200,
+          text: "real Telegram update envelope",
+          chat: { id: -1001, type: "supergroup", title: "ops" },
+          from: { id: 777, username: "telegram_user" },
+        },
+      },
+    });
+
+    expect(comment).toMatchObject({
+      source: "telegram",
+      externalId: "telegram:-1001:42",
+      threadId: "telegram:-1001:7",
+      channelId: "-1001",
+      body: "real Telegram update envelope",
+      visibility: "internal",
+      author: { id: "777", name: "telegram_user" },
+    });
+  });
+
   it("redacts tokens before comments are stored or projected to knowledge", () => {
     const text =
       "github ghp_1234567890abcdef1234567890abcdef1234 openai sk-proj-abcDEF1234567890 twitch live_123456789_secret";

--- a/packages/agent/src/api/cross-channel-ingest.ts
+++ b/packages/agent/src/api/cross-channel-ingest.ts
@@ -380,31 +380,69 @@ function normalizeDiscordPayload(payload: Record<string, unknown>): NormalizedCr
 }
 
 function normalizeTelegramPayload(payload: Record<string, unknown>): NormalizedCrossChannelComment {
-  const chat = asRecord(payload.chat);
-  const from = asRecord(payload.from);
+  const message =
+    Object.keys(asRecord(payload.message)).length > 0
+      ? asRecord(payload.message)
+      : Object.keys(asRecord(payload.edited_message)).length > 0
+        ? asRecord(payload.edited_message)
+        : Object.keys(asRecord(payload.channel_post)).length > 0
+          ? asRecord(payload.channel_post)
+          : Object.keys(asRecord(payload.edited_channel_post)).length > 0
+            ? asRecord(payload.edited_channel_post)
+            : payload;
+  const chat = asRecord(message.chat);
+  const from = asRecord(message.from);
   const chatId = String(asString(chat.id) ?? asNumber(chat.id) ?? "unknown-chat");
-  const messageId = String(asNumber(payload.message_id) ?? asString(payload.message_id) ?? hashStable(JSON.stringify(payload)));
+  const messageId = String(asNumber(message.message_id) ?? asString(message.message_id) ?? hashStable(JSON.stringify(payload)));
+  const messageThreadId =
+    asString(message.message_thread_id) ??
+    (asNumber(message.message_thread_id) != null
+      ? String(asNumber(message.message_thread_id))
+      : undefined);
   return normalizeCrossChannelCommentEvent({
     source: "telegram",
     externalId: `telegram:${chatId}:${messageId}`,
-    threadId: `telegram:${chatId}:${asString(payload.message_thread_id) ?? "main"}`,
+    threadId: `telegram:${chatId}:${messageThreadId ?? "main"}`,
     channelId: chatId,
     author: compactObject({
       id: String(asString(from.id) ?? asNumber(from.id) ?? ""),
       name: asString(from.username) ?? asString(from.first_name),
     }),
-    body: asString(payload.text) ?? asString(payload.caption) ?? "Telegram message",
-    createdAt: asNumber(payload.date),
+    body: asString(message.text) ?? asString(message.caption) ?? "Telegram message",
+    createdAt: asNumber(message.date),
     visibility: asString(chat.type) === "private" ? "private" : "internal",
     raw: payload,
   });
 }
 
 function normalizeSlackPayload(payload: Record<string, unknown>): NormalizedCrossChannelComment {
-  const team = asString(payload.team) ?? asString(payload.team_id);
-  const channelId = asString(payload.channel) ?? "unknown-channel";
-  const ts = asString(payload.ts) ?? hashStable(JSON.stringify(payload));
-  const threadTs = asString(payload.thread_ts) ?? ts;
+  const event = asRecord(payload.event);
+  const eventMessage = asRecord(event.message);
+  const message =
+    Object.keys(eventMessage).length > 0
+      ? eventMessage
+      : Object.keys(event).length > 0
+        ? event
+        : payload;
+  const team =
+    asString(payload.team) ??
+    asString(payload.team_id) ??
+    asString(event.team) ??
+    asString(message.team);
+  const channelId =
+    asString(message.channel) ??
+    asString(message.channel_id) ??
+    asString(payload.channel) ??
+    "unknown-channel";
+  const ts =
+    asString(message.ts) ??
+    asString(message.event_ts) ??
+    asString(payload.ts) ??
+    hashStable(JSON.stringify(payload));
+  const threadTs = asString(message.thread_ts) ?? asString(payload.thread_ts) ?? ts;
+  const author = asString(message.user) ?? asString(payload.user) ?? asString(message.bot_id);
+  const username =
+    asString(message.username) ?? asString(payload.username) ?? author;
   return normalizeCrossChannelCommentEvent({
     source: "slack",
     externalId: `slack:${team ?? "workspace"}:${channelId}:${ts}`,
@@ -412,10 +450,10 @@ function normalizeSlackPayload(payload: Record<string, unknown>): NormalizedCros
     channelId,
     accountId: team,
     author: compactObject({
-      id: asString(payload.user) ?? asString(payload.username),
-      name: asString(payload.username) ?? asString(payload.user),
+      id: author,
+      name: username,
     }),
-    body: asString(payload.text) ?? "Slack message",
+    body: asString(message.text) ?? asString(payload.text) ?? "Slack message",
     createdAt: slackTsToIso(ts),
     visibility: "internal",
     raw: payload,

--- a/packages/agent/src/api/cross-channel-ingest.ts
+++ b/packages/agent/src/api/cross-channel-ingest.ts
@@ -1,0 +1,607 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+export type CrossChannelCommentSource =
+  | "github"
+  | "discord"
+  | "telegram"
+  | "slack"
+  | "gmail"
+  | "ops"
+  | "stream555";
+
+export type CrossChannelVisibility =
+  | "public"
+  | "internal"
+  | "private"
+  | "unknown";
+
+export type CrossChannelActionability =
+  | "none"
+  | "needs_reply"
+  | "needs_review"
+  | "needs_deploy_approval"
+  | "incident"
+  | "follow_up";
+
+export interface CrossChannelAuthor {
+  id?: string;
+  name?: string;
+  url?: string;
+  email?: string;
+}
+
+export interface CrossChannelAttachment {
+  id?: string;
+  name?: string;
+  url?: string;
+  contentType?: string;
+}
+
+export interface CrossChannelCommentInput {
+  source: CrossChannelCommentSource;
+  externalId: string;
+  threadId: string;
+  channelId?: string;
+  accountId?: string;
+  author?: CrossChannelAuthor;
+  body: string;
+  createdAt?: string | number | Date;
+  updatedAt?: string | number | Date;
+  receivedAt?: string | number | Date;
+  permalink?: string;
+  visibility?: CrossChannelVisibility;
+  actionability?: CrossChannelActionability;
+  attachments?: CrossChannelAttachment[];
+  provenance?: Record<string, unknown>;
+  raw?: unknown;
+}
+
+export interface CrossChannelKnowledgeFragment {
+  title: string;
+  text: string;
+  metadata: {
+    source: CrossChannelCommentSource;
+    externalId: string;
+    threadId: string;
+    channelId?: string;
+    permalink?: string;
+  };
+}
+
+export interface NormalizedCrossChannelComment
+  extends Omit<CrossChannelCommentInput, "createdAt" | "updatedAt" | "receivedAt"> {
+  id: string;
+  dedupeKey: string;
+  body: string;
+  createdAt?: string;
+  updatedAt?: string;
+  receivedAt: string;
+  knowledgeFragment: CrossChannelKnowledgeFragment;
+}
+
+export interface SourcePayloadInput {
+  source: CrossChannelCommentSource;
+  payload: Record<string, unknown>;
+}
+
+export interface CrossChannelIngestResult {
+  created: boolean;
+  comment: NormalizedCrossChannelComment;
+}
+
+type StoreOptions = {
+  rootDir: string;
+  now?: () => number;
+};
+
+const MAX_BODY_CHARS = 32_000;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function toIsoTimestamp(
+  value: string | number | Date | undefined,
+): string | undefined {
+  if (value == null) return undefined;
+  const date =
+    value instanceof Date
+      ? value
+      : typeof value === "number"
+        ? new Date(value < 10_000_000_000 ? value * 1000 : value)
+        : new Date(value);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return date.toISOString();
+}
+
+function hashStable(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex").slice(0, 24);
+}
+
+function compactObject<T extends Record<string, unknown>>(input: T): T {
+  for (const key of Object.keys(input)) {
+    if (input[key] === undefined) {
+      delete input[key];
+    }
+  }
+  return input;
+}
+
+export function redactCrossChannelSecrets(text: string): string {
+  return text
+    .replace(/\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g, "[REDACTED:github-token]")
+    .replace(/\bsk-(?:proj-)?[A-Za-z0-9_-]{8,}\b/g, "[REDACTED:openai-token]")
+    .replace(/\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g, "[REDACTED:slack-token]")
+    .replace(/\b(?:live|sk_us-[a-z0-9-]+)_[A-Za-z0-9_-]{8,}\b/gi, "[REDACTED:stream-key]")
+    .replace(/\bBasic\s+[A-Za-z0-9+/=]{16,}\b/g, "Basic [REDACTED:basic-auth]")
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{16,}\b/g, "Bearer [REDACTED:bearer-token]");
+}
+
+function redactDeep(value: unknown): unknown {
+  if (typeof value === "string") {
+    return redactCrossChannelSecrets(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactDeep(item));
+  }
+  if (value && typeof value === "object") {
+    const output: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value)) {
+      output[key] = redactDeep(nested);
+    }
+    return output;
+  }
+  return value;
+}
+
+function inferActionability(
+  source: CrossChannelCommentSource,
+  body: string,
+  explicit?: CrossChannelActionability,
+): CrossChannelActionability {
+  if (explicit) return explicit;
+  const lower = body.toLowerCase();
+  if (source === "ops" && lower.includes("approval")) {
+    return "needs_deploy_approval";
+  }
+  if (source === "github") {
+    return "needs_review";
+  }
+  if (lower.includes("urgent") || lower.includes("incident")) {
+    return "incident";
+  }
+  if (lower.includes("please") || lower.includes("?")) {
+    return "needs_reply";
+  }
+  return "none";
+}
+
+function defaultVisibility(source: CrossChannelCommentSource): CrossChannelVisibility {
+  if (source === "gmail") return "private";
+  if (source === "stream555") return "public";
+  return "internal";
+}
+
+export function normalizeCrossChannelCommentEvent(
+  input: CrossChannelCommentInput,
+  now: () => number = () => Date.now(),
+): NormalizedCrossChannelComment {
+  if (!input.source) {
+    throw new Error("source is required");
+  }
+  if (!input.externalId?.trim()) {
+    throw new Error("externalId is required");
+  }
+  if (!input.threadId?.trim()) {
+    throw new Error("threadId is required");
+  }
+  if (!input.body?.trim()) {
+    throw new Error("body is required");
+  }
+
+  const body = redactCrossChannelSecrets(input.body).slice(0, MAX_BODY_CHARS);
+  const source = input.source;
+  const externalId = input.externalId.trim();
+  const threadId = input.threadId.trim();
+  const channelId = input.channelId?.trim() || undefined;
+  const permalink = input.permalink?.trim() || undefined;
+  const dedupeKey = `${source}:${input.accountId ?? channelId ?? "default"}:${externalId}`;
+  const author = compactObject({
+    id: input.author?.id,
+    name: input.author?.name,
+    url: input.author?.url,
+    email: input.author?.email,
+  });
+  const authorName = author.name ?? author.id ?? author.email ?? "unknown";
+  const metadata = compactObject({
+    source,
+    externalId,
+    threadId,
+    channelId,
+    permalink,
+  });
+  const knowledgeFragment = {
+    title: `${source} comment from ${authorName}`,
+    text: [
+      `Source: ${source}`,
+      `Thread: ${threadId}`,
+      `Author: ${authorName}`,
+      permalink ? `Link: ${permalink}` : undefined,
+      "",
+      body,
+    ]
+      .filter((line) => line !== undefined)
+      .join("\n"),
+    metadata,
+  };
+
+  return compactObject({
+    ...input,
+    id: hashStable(dedupeKey),
+    dedupeKey,
+    source,
+    externalId,
+    threadId,
+    channelId,
+    author,
+    body,
+    createdAt: toIsoTimestamp(input.createdAt),
+    updatedAt: toIsoTimestamp(input.updatedAt),
+    receivedAt: toIsoTimestamp(input.receivedAt) ?? new Date(now()).toISOString(),
+    permalink,
+    visibility: input.visibility ?? defaultVisibility(source),
+    actionability: inferActionability(source, body, input.actionability),
+    attachments: input.attachments ?? [],
+    provenance: input.provenance ?? {},
+    raw: input.raw ? redactDeep(input.raw) : undefined,
+    knowledgeFragment,
+  }) as NormalizedCrossChannelComment;
+}
+
+export function normalizeCrossChannelSourcePayload(
+  input: SourcePayloadInput,
+): NormalizedCrossChannelComment {
+  switch (input.source) {
+    case "github":
+      return normalizeGitHubPayload(input.payload);
+    case "discord":
+      return normalizeDiscordPayload(input.payload);
+    case "telegram":
+      return normalizeTelegramPayload(input.payload);
+    case "slack":
+      return normalizeSlackPayload(input.payload);
+    case "gmail":
+      return normalizeGmailPayload(input.payload);
+    case "ops":
+      return normalizeOpsPayload(input.payload);
+    case "stream555":
+      return normalizeStream555Payload(input.payload);
+  }
+}
+
+function normalizeGitHubPayload(payload: Record<string, unknown>): NormalizedCrossChannelComment {
+  const repo = asRecord(payload.repository);
+  const issue = asRecord(payload.issue);
+  const comment = asRecord(payload.comment);
+  const user = asRecord(comment.user);
+  const review = asRecord(payload.review);
+  const reviewComment = asRecord(payload.review_comment);
+  const target = Object.keys(comment).length > 0 ? comment : Object.keys(reviewComment).length > 0 ? reviewComment : review;
+  const targetUser = asRecord(target.user);
+  const repoFullName = asString(repo.full_name) ?? "unknown/repo";
+  const number = asNumber(issue.number) ?? asNumber(asRecord(payload.pull_request).number);
+  const isPullRequest = Boolean(issue.pull_request) || Boolean(payload.pull_request);
+  const kind =
+    Object.keys(reviewComment).length > 0
+      ? "review-comment"
+      : Object.keys(review).length > 0
+        ? "review"
+        : "issue-comment";
+  const targetId = asString(target.id) ?? String(asNumber(target.id) ?? hashStable(JSON.stringify(target)));
+  const body =
+    asString(target.body) ??
+    asString(issue.body) ??
+    asString(asRecord(payload.pull_request).body) ??
+    asString(issue.title) ??
+    "GitHub event";
+  const threadKind = isPullRequest ? "pull" : "issue";
+  const threadId =
+    number != null
+      ? `github:${repoFullName}:${threadKind}:${number}`
+      : `github:${repoFullName}`;
+
+  return normalizeCrossChannelCommentEvent({
+    source: "github",
+    externalId: `github:${repoFullName}:${kind}:${targetId}`,
+    threadId,
+    channelId: repoFullName,
+    author: compactObject({
+      id: asString(targetUser.login) ?? asString(user.login),
+      name: asString(targetUser.login) ?? asString(user.login),
+      url: asString(targetUser.html_url) ?? asString(user.html_url),
+    }),
+    body,
+    createdAt: asString(target.created_at),
+    updatedAt: asString(target.updated_at),
+    permalink:
+      asString(target.html_url) ??
+      asString(issue.html_url) ??
+      asString(asRecord(payload.pull_request).html_url),
+    visibility: "internal",
+    actionability: isPullRequest ? "needs_review" : "needs_reply",
+    provenance: compactObject({
+      adapter: `github.${kind === "issue-comment" ? "issue_comment" : kind}`,
+      repository: repoFullName,
+      issue: isPullRequest ? undefined : number,
+      pullRequest: isPullRequest ? number : undefined,
+      action: asString(payload.action),
+    }),
+    raw: payload,
+  });
+}
+
+function normalizeDiscordPayload(payload: Record<string, unknown>): NormalizedCrossChannelComment {
+  const author = asRecord(payload.author);
+  const id = asString(payload.id) ?? hashStable(JSON.stringify(payload));
+  const channelId = asString(payload.channel_id) ?? "unknown-channel";
+  const guildId = asString(payload.guild_id);
+  return normalizeCrossChannelCommentEvent({
+    source: "discord",
+    externalId: `discord:${channelId}:${id}`,
+    threadId: `discord:${guildId ?? "dm"}:${asString(payload.thread_id) ?? channelId}`,
+    channelId,
+    accountId: guildId,
+    author: compactObject({
+      id: asString(author.id),
+      name: asString(author.username) ?? asString(author.global_name),
+    }),
+    body: asString(payload.content) ?? "Discord message",
+    createdAt: asString(payload.timestamp),
+    updatedAt: asString(payload.edited_timestamp),
+    visibility: guildId ? "internal" : "private",
+    raw: payload,
+  });
+}
+
+function normalizeTelegramPayload(payload: Record<string, unknown>): NormalizedCrossChannelComment {
+  const chat = asRecord(payload.chat);
+  const from = asRecord(payload.from);
+  const chatId = String(asString(chat.id) ?? asNumber(chat.id) ?? "unknown-chat");
+  const messageId = String(asNumber(payload.message_id) ?? asString(payload.message_id) ?? hashStable(JSON.stringify(payload)));
+  return normalizeCrossChannelCommentEvent({
+    source: "telegram",
+    externalId: `telegram:${chatId}:${messageId}`,
+    threadId: `telegram:${chatId}:${asString(payload.message_thread_id) ?? "main"}`,
+    channelId: chatId,
+    author: compactObject({
+      id: String(asString(from.id) ?? asNumber(from.id) ?? ""),
+      name: asString(from.username) ?? asString(from.first_name),
+    }),
+    body: asString(payload.text) ?? asString(payload.caption) ?? "Telegram message",
+    createdAt: asNumber(payload.date),
+    visibility: asString(chat.type) === "private" ? "private" : "internal",
+    raw: payload,
+  });
+}
+
+function normalizeSlackPayload(payload: Record<string, unknown>): NormalizedCrossChannelComment {
+  const team = asString(payload.team) ?? asString(payload.team_id);
+  const channelId = asString(payload.channel) ?? "unknown-channel";
+  const ts = asString(payload.ts) ?? hashStable(JSON.stringify(payload));
+  const threadTs = asString(payload.thread_ts) ?? ts;
+  return normalizeCrossChannelCommentEvent({
+    source: "slack",
+    externalId: `slack:${team ?? "workspace"}:${channelId}:${ts}`,
+    threadId: `slack:${team ?? "workspace"}:${channelId}:${threadTs}`,
+    channelId,
+    accountId: team,
+    author: compactObject({
+      id: asString(payload.user) ?? asString(payload.username),
+      name: asString(payload.username) ?? asString(payload.user),
+    }),
+    body: asString(payload.text) ?? "Slack message",
+    createdAt: slackTsToIso(ts),
+    visibility: "internal",
+    raw: payload,
+  });
+}
+
+function slackTsToIso(ts: string): string | undefined {
+  const seconds = Number(ts.split(".")[0]);
+  return Number.isFinite(seconds) ? new Date(seconds * 1000).toISOString() : undefined;
+}
+
+function normalizeGmailPayload(payload: Record<string, unknown>): NormalizedCrossChannelComment {
+  const id = asString(payload.id) ?? hashStable(JSON.stringify(payload));
+  const threadId = asString(payload.threadId) ?? id;
+  const subject = asString(payload.subject);
+  const snippet = asString(payload.snippet) ?? asString(payload.body) ?? "Gmail message";
+  return normalizeCrossChannelCommentEvent({
+    source: "gmail",
+    externalId: `gmail:${id}`,
+    threadId: `gmail:${threadId}`,
+    channelId: "gmail",
+    author: parseEmailAuthor(asString(payload.from)),
+    body: subject ? `${subject}\n\n${snippet}` : snippet,
+    createdAt: asString(payload.internalDate)
+      ? Number(asString(payload.internalDate))
+      : asString(payload.date),
+    visibility: "private",
+    actionability: "needs_reply",
+    raw: payload,
+  });
+}
+
+function parseEmailAuthor(input: string | undefined): CrossChannelAuthor {
+  if (!input) return {};
+  const match = /^(.*?)\s*<([^>]+)>$/.exec(input);
+  if (match) {
+    return compactObject({ name: match[1]?.trim(), email: match[2]?.trim() });
+  }
+  return input.includes("@") ? { email: input } : { name: input };
+}
+
+function normalizeOpsPayload(payload: Record<string, unknown>): NormalizedCrossChannelComment {
+  const id = asString(payload.id) ?? hashStable(JSON.stringify(payload));
+  const environment = asString(payload.environment) ?? "unknown";
+  const service = asString(payload.service) ?? "unknown-service";
+  const status = asString(payload.status) ?? "unknown";
+  return normalizeCrossChannelCommentEvent({
+    source: "ops",
+    externalId: `ops:${environment}:${service}:${id}`,
+    threadId: `ops:${environment}:${service}`,
+    channelId: `${environment}:${service}`,
+    author: { id: "ops", name: "Ops" },
+    body: asString(payload.message) ?? `${service} ${status}`,
+    createdAt: asString(payload.createdAt) ?? asString(payload.startedAt),
+    visibility: "internal",
+    actionability:
+      status.includes("approval") || status === "requires_approval"
+        ? "needs_deploy_approval"
+        : "none",
+    provenance: compactObject({
+      adapter: "ops.event",
+      environment,
+      service,
+      status,
+    }),
+    raw: payload,
+  });
+}
+
+function normalizeStream555Payload(payload: Record<string, unknown>): NormalizedCrossChannelComment {
+  const id = asString(payload.id) ?? hashStable(JSON.stringify(payload));
+  const channel = asString(payload.channel) ?? "alice-cam";
+  return normalizeCrossChannelCommentEvent({
+    source: "stream555",
+    externalId: `stream555:${channel}:${id}`,
+    threadId: `stream555:${channel}`,
+    channelId: channel,
+    author: compactObject({
+      id: asString(payload.userId) ?? asString(payload.user),
+      name: asString(payload.user) ?? asString(payload.displayName),
+    }),
+    body: asString(payload.text) ?? asString(payload.body) ?? "555stream comment",
+    createdAt: asString(payload.createdAt) ?? asNumber(payload.createdAt),
+    visibility: "public",
+    raw: payload,
+  });
+}
+
+export function createCrossChannelIngestStore(options: StoreOptions) {
+  const rootDir = options.rootDir;
+  const paths = {
+    rootDir,
+    rawAuditLog: path.join(rootDir, "raw-events.jsonl"),
+    commentsFile: path.join(rootDir, "comments.json"),
+  };
+  const now = options.now ?? (() => Date.now());
+
+  function readComments(): NormalizedCrossChannelComment[] {
+    try {
+      const raw = JSON.parse(fs.readFileSync(paths.commentsFile, "utf-8"));
+      return Array.isArray(raw?.items) ? raw.items : [];
+    } catch {
+      return [];
+    }
+  }
+
+  function writeComments(items: NormalizedCrossChannelComment[]): void {
+    fs.mkdirSync(rootDir, { recursive: true });
+    fs.writeFileSync(
+      paths.commentsFile,
+      JSON.stringify({ version: 1, items }, null, 2),
+      "utf-8",
+    );
+  }
+
+  return {
+    paths,
+    ingest(input: CrossChannelCommentInput | SourcePayloadInput): CrossChannelIngestResult {
+      fs.mkdirSync(rootDir, { recursive: true });
+      const comment =
+        "payload" in input
+          ? normalizeCrossChannelSourcePayload(input)
+          : normalizeCrossChannelCommentEvent(input, now);
+      const items = readComments();
+      const index = items.findIndex((item) => item.dedupeKey === comment.dedupeKey);
+      const created = index === -1;
+      if (created) {
+        items.push(comment);
+      } else {
+        items[index] = {
+          ...items[index],
+          ...comment,
+          receivedAt: items[index]?.receivedAt ?? comment.receivedAt,
+        };
+      }
+      writeComments(items);
+      fs.appendFileSync(
+        paths.rawAuditLog,
+        `${JSON.stringify({
+          receivedAt: new Date(now()).toISOString(),
+          raw: redactDeep(input),
+          dedupeKey: comment.dedupeKey,
+        })}\n`,
+        "utf-8",
+      );
+      return { created, comment: created ? comment : items[index] };
+    },
+    list(query: {
+      source?: CrossChannelCommentSource;
+      limit?: number;
+      since?: string;
+    } = {}) {
+      let items = readComments();
+      if (query.source) {
+        items = items.filter((item) => item.source === query.source);
+      }
+      if (query.since) {
+        const since = new Date(query.since).getTime();
+        if (Number.isFinite(since)) {
+          items = items.filter(
+            (item) => new Date(item.updatedAt ?? item.createdAt ?? item.receivedAt).getTime() >= since,
+          );
+        }
+      }
+      items = items.sort((a, b) =>
+        (b.updatedAt ?? b.createdAt ?? b.receivedAt).localeCompare(
+          a.updatedAt ?? a.createdAt ?? a.receivedAt,
+        ),
+      );
+      const limit = Math.max(1, Math.min(query.limit ?? 100, 500));
+      return { items: items.slice(0, limit), total: items.length };
+    },
+    status() {
+      const items = readComments();
+      const bySource: Record<string, number> = {};
+      for (const item of items) {
+        bySource[item.source] = (bySource[item.source] ?? 0) + 1;
+      }
+      return {
+        total: items.length,
+        bySource,
+        lastReceivedAt: items
+          .map((item) => item.receivedAt)
+          .sort()
+          .at(-1) ?? null,
+      };
+    },
+  };
+}

--- a/packages/agent/src/api/server-auth.test.ts
+++ b/packages/agent/src/api/server-auth.test.ts
@@ -19,6 +19,8 @@ describe("agent API auth disable regression guard", () => {
     expect(source).toContain("env.API_AUTH_DISABLED");
     expect(source).toContain("if (isApiAuthDisabled()) return undefined;");
     expect(source).toContain("if (isApiAuthDisabled()) return true;");
+    expect(source).toContain('from "./cloudflare-access-auth.js";');
+    expect(source).toContain("if (isCloudflareAccessAuthenticated(req)) return true;");
   });
 
   it("keeps auth-disabled aliases wired in the monolithic server path", () => {
@@ -31,5 +33,7 @@ describe("agent API auth disable regression guard", () => {
     expect(source).toContain("!isApiAuthDisabled() &&");
     expect(source).toContain("if (isApiAuthDisabled()) return undefined;");
     expect(source).toContain("if (isApiAuthDisabled()) return true;");
+    expect(source).toContain('from "./cloudflare-access-auth.js";');
+    expect(source).toContain("if (isCloudflareAccessAuthenticated(req)) return true;");
   });
 });

--- a/packages/agent/src/api/server-auth.ts
+++ b/packages/agent/src/api/server-auth.ts
@@ -14,6 +14,7 @@ import {
   setApiToken,
 } from "../config/runtime-env.js";
 import { isCloudProvisionedContainer } from "./cloud-provisioning.js";
+import { isCloudflareAccessAuthenticated } from "./cloudflare-access-auth.js";
 import { BLOCKED_ENV_KEYS } from "./plugin-discovery-helpers.js";
 import { sendJsonError } from "./http-helpers.js";
 import type { ConversationMeta } from "./server-helpers.js";
@@ -147,6 +148,7 @@ export function ensureApiTokenForBindHost(host: string): void {
 
 export function isAuthorized(req: http.IncomingMessage): boolean {
   if (isApiAuthDisabled()) return true;
+  if (isCloudflareAccessAuthenticated(req)) return true;
 
   const expected = getConfiguredApiToken();
   if (!expected) return !isCloudProvisionedContainer();

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -143,6 +143,8 @@ import { handleAgentLifecycleRoutes } from "./agent-lifecycle-routes.js";
 import { detectRuntimeModel, resolveProviderFromModel } from "./agent-model.js";
 import { handleAgentStatusRoutes } from "./agent-status-routes.js";
 import { handleAgentTransferRoutes } from "./agent-transfer-routes.js";
+import { handleAliceCodingPolicyRoutes } from "./alice-coding-policy-routes.js";
+import { handleAliceCorpusRoutes } from "./alice-corpus-routes.js";
 import { handleAliceOperatorRoutes } from "./alice-operator-routes.js";
 import { handleAppPackageRoutes } from "./app-package-routes.js";
 import { handleAppsRoutes } from "./apps-routes.js";
@@ -172,6 +174,7 @@ import {
 } from "./chat-routes.js";
 import { handleCloudBillingRoute } from "./cloud-billing-routes.js";
 import { handleCloudCompatRoute } from "./cloud-compat-routes.js";
+import { isCloudflareAccessAuthenticated } from "./cloudflare-access-auth.js";
 import { isCloudProvisionedContainer } from "./cloud-provisioning.js";
 import { handleCloudRelayRoute } from "./cloud-relay-routes.js";
 import { type CloudRouteState, handleCloudRoute } from "./cloud-routes.js";
@@ -181,6 +184,7 @@ import { handleConfigRoutes } from "./config-routes.js";
 import { ConnectorHealthMonitor } from "./connector-health.js";
 import { handleConnectorRoutes } from "./connector-routes.js";
 import { handleConversationRoutes } from "./conversation-routes.js";
+import { handleCrossChannelIngestRoutes } from "./cross-channel-ingest-routes.js";
 import type {
   SwarmEvent,
   TaskCompletionSummary,
@@ -3321,6 +3325,7 @@ export function ensureApiTokenForBindHost(host: string): void {
 
 export function isAuthorized(req: http.IncomingMessage): boolean {
   if (isApiAuthDisabled()) return true;
+  if (isCloudflareAccessAuthenticated(req)) return true;
 
   const expected = getConfiguredApiToken();
   if (!expected) return !isCloudProvisionedContainer();
@@ -5961,6 +5966,41 @@ async function handleRequest(
     return;
   }
 
+  if (pathname.startsWith("/api/alice/coding")) {
+    if (
+      await handleAliceCodingPolicyRoutes({
+        req,
+        res,
+        method,
+        pathname,
+        config: state.config,
+        json,
+        error,
+        readJsonBody,
+      })
+    ) {
+      return;
+    }
+  }
+
+  if (pathname.startsWith("/api/alice/corpus")) {
+    if (
+      await handleAliceCorpusRoutes({
+        req,
+        res,
+        method,
+        pathname,
+        url,
+        config: state.config,
+        stateDir: resolveStateDir(),
+        json,
+        error,
+      })
+    ) {
+      return;
+    }
+  }
+
   // ═══════════════════════════════════════════════════════════════════════
   // Config routes (extracted to config-routes.ts)
   // ═══════════════════════════════════════════════════════════════════════
@@ -6568,6 +6608,25 @@ async function handleRequest(
         resolveMcpServersRejection,
         resolveMcpTerminalAuthorizationRejection,
         decodePathComponent,
+      })
+    ) {
+      return;
+    }
+  }
+
+  if (pathname.startsWith("/api/ingest/comments")) {
+    if (
+      await handleCrossChannelIngestRoutes({
+        req,
+        res,
+        method,
+        pathname,
+        url,
+        json,
+        error,
+        readJsonBody,
+        stateDir: resolveStateDir(),
+        config: state.config,
       })
     ) {
       return;

--- a/packages/agent/src/config/types.eliza.ts
+++ b/packages/agent/src/config/types.eliza.ts
@@ -668,6 +668,45 @@ export type ConnectorFieldValue =
  */
 export type ConnectorConfig = { [key: string]: ConnectorFieldValue };
 
+export type AliceCrossChannelIngestConfig = {
+  enabled?: boolean;
+  sources?: Array<
+    "github" | "discord" | "telegram" | "slack" | "gmail" | "ops" | "stream555"
+  >;
+  /** Persist raw redacted envelopes and normalized comments under the state dir. */
+  storeDir?: string;
+  /** Project eligible comments into knowledge/memory for retrieval. Default: true. */
+  knowledgeProjection?: boolean;
+};
+
+export type AliceCorpusRootConfig = {
+  id: string;
+  path: string;
+};
+
+export type AliceCorpusConfig = {
+  enabled?: boolean;
+  /** Configured source-of-truth roots Alice may index. Paths may be absolute or runtime-cwd-relative. */
+  roots?: AliceCorpusRootConfig[];
+};
+
+export type AliceCodingConfig = {
+  /** Repositories Alice may inspect, build, test, and open PRs against. */
+  allowedRepos?: string[];
+  /** Staging deploys may be automatic or approval-gated. Default: allow. */
+  stagingDeploys?: "allow" | "approval";
+  /** Production deploys are approval-gated or disabled. Default: approval. */
+  productionDeploys?: "approval" | "deny";
+  /** Required deploy rail so all deploys are visible in Ops. Default: webhook. */
+  deployRail?: "webhook";
+};
+
+export type AliceOperationalConfig = {
+  ingest?: AliceCrossChannelIngestConfig;
+  corpus?: AliceCorpusConfig;
+  coding?: AliceCodingConfig;
+};
+
 export type ElizaConfig = {
   meta?: {
     /** Explicit onboarding completion marker. Reset clears the entire state dir. */
@@ -772,6 +811,8 @@ export type ElizaConfig = {
   media?: MediaConfig;
   /** Messaging connector configuration (Telegram, Discord, Slack, etc.). */
   connectors?: Record<string, ConnectorConfig>;
+  /** Alice production operating policy: cross-channel ingest and coding/deploy autonomy. */
+  alice?: AliceOperationalConfig;
   /** MCP server configuration. */
   mcp?: {
     servers?: Record<

--- a/test/vitest/default.config.ts
+++ b/test/vitest/default.config.ts
@@ -1,0 +1,9 @@
+export default {
+  test: {
+    globals: false,
+    environment: "node",
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    isolate: true,
+  },
+};


### PR DESCRIPTION
## Summary

Adds the first support-code layer for Alice cross-channel ingest, safe corpus inventory, coding/deploy guardrails, and Cloudflare Access-only auth behavior.

## What changed

- Adds normalized comment ingest for `github`, `discord`, `telegram`, `slack`, `gmail`, `ops`, and `stream555` payloads.
- Persists redacted raw ingest envelopes, normalized comments, provenance, dedupe keys, and knowledge fragments.
- Adds Alice corpus manifest/snapshot APIs for safe repo/docs/runbook inventory with secret/build-artifact/media exclusions.
- Adds Alice coding/deploy policy APIs that allow staging work but require explicit approval for production deploys.
- Adds Cloudflare Access trust handling so `alice.rndrntwrk.com` can bypass Milady pairing when Access headers are present and trust is enabled.
- Adds focused unit and route coverage for ingest, corpus manifests, coding policy, and Cloudflare auth behavior.

## Important scope notes

- This PR sets up support code and APIs. It does not yet backfill all ecosystem data or wire live external webhooks/connectors.
- `stream555` is supported as a normalized ingest source, but X/YouTube/Twitch/Kick/Pump live comment APIs are not wired in this PR.
- Corpus manifest means "safe inventory of what Alice may extract", not "the full corpus has already been extracted and embedded".
- Production deploy execution remains guarded and should continue through Ops-visible deploy rails only.

## Verification

- Focused Vitest coverage passed for the new ingest, corpus, coding-policy, Cloudflare-auth, and server wiring tests.
- Biome check passed on touched files.
- Full root typecheck was attempted but remains blocked in this isolated worktree by missing workspace/submodule dependency graph and ambient types that predate this PR.

## Next

- Configure staging/prod `milady.json` roots and ingest store directories.
- Enable Cloudflare Access trust env in deployment: `MILADY_TRUST_CLOUDFLARE_ACCESS=1`.
- Wire live GitHub, Slack, Discord, Telegram, Gmail, Ops, and 555stream event producers into `/api/ingest/comments`.
- Add the knowledge projection job that embeds selected corpus and comment fragments into Alice RAG/memory.
- Wire coding-agent execution to call the policy API before clone/build/test/PR/deploy actions.
