### PR TITLE
agent: instrument knowledge bulk ingest with per-doc timing

### DIFF
--- a/packages/agent/src/api/knowledge-routes.ts
+++ b/packages/agent/src/api/knowledge-routes.ts
@@ -1045,8 +1045,8 @@ export async function handleKnowledgeRoutes(
 
     const batchStartedAt = Date.now();
     const totalContentBytes = body.documents.reduce((sum, doc) => {
-      const len = typeof doc?.content === "string" ? doc.content.length : 0;
-      return sum + len;
+      if (typeof doc?.content !== "string") return sum;
+      return sum + Buffer.byteLength(doc.content, "utf8");
     }, 0);
 
     logger.info(
@@ -1073,17 +1073,40 @@ export async function handleKnowledgeRoutes(
 
     for (const [index, document] of body.documents.entries()) {
       const filename = document?.filename || `document-${index + 1}`;
+      const docStartedAt = Date.now();
+
       if (
         typeof document?.content !== "string" ||
         typeof document?.filename !== "string" ||
         document.content.trim().length === 0 ||
         document.filename.trim().length === 0
       ) {
+        const docElapsedMs = Date.now() - docStartedAt;
+        const contentBytes =
+          typeof document?.content === "string"
+            ? Buffer.byteLength(document.content, "utf8")
+            : 0;
+        const validationError =
+          "content and filename must be non-empty strings";
+        logger.warn(
+          {
+            boundary: "knowledge-bulk-doc",
+            agentId,
+            index,
+            filename,
+            elapsedMs: docElapsedMs,
+            contentBytes,
+            error: validationError,
+            kind: "validation",
+          },
+          `[knowledge-bulk-doc] Document validation failed: ${filename}`,
+        );
         results.push({
           index,
           ok: false,
           filename,
-          error: "content and filename must be non-empty strings",
+          elapsedMs: docElapsedMs,
+          error: validationError,
         });
         continue;
       }
@@ -1094,7 +1117,11 @@ export async function handleKnowledgeRoutes(
         filename: document.filename.trim(),
       };
 
-      const docStartedAt = Date.now();
+      const docContentBytes = Buffer.byteLength(
+        normalizedDocument.content,
+        "utf8",
+      );
+
       try {
         const uploadResult = await addKnowledgeDocument(
           knowledgeService,
@@ -1111,7 +1138,7 @@ export async function handleKnowledgeRoutes(
             fragmentCount: uploadResult.fragmentCount,
             elapsedMs: docElapsedMs,
             phaseElapsedMs: uploadResult.phaseElapsedMs,
-            contentBytes: normalizedDocument.content.length,
+            contentBytes: docContentBytes,
           },
           `[knowledge-bulk-doc] Document ingested: ${filename} in ${docElapsedMs}ms`,
         );
@@ -1134,8 +1161,9 @@ export async function handleKnowledgeRoutes(
             index,
             filename,
             elapsedMs: docElapsedMs,
-            contentBytes: normalizedDocument.content.length,
+            contentBytes: docContentBytes,
             error: String(err),
+            kind: "runtime",
           },
           `[knowledge-bulk-doc] Document failed: ${filename} after ${docElapsedMs}ms`,
         );

--- a/packages/agent/src/api/knowledge-routes.ts
+++ b/packages/agent/src/api/knowledge-routes.ts
@@ -7,7 +7,12 @@ import {
 import { request as requestHttps } from "node:https";
 import net from "node:net";
 import { Readable } from "node:stream";
-import type { AgentRuntime, Memory, UUID } from "@elizaos/core";
+import {
+  type AgentRuntime,
+  logger,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
 import {
   isBlockedPrivateOrLinkLocalIp,
   normalizeHostLike,
@@ -878,7 +883,14 @@ export async function handleKnowledgeRoutes(
     documentId: UUID;
     fragmentCount: number;
     warnings?: string[];
+    elapsedMs: number;
+    phaseElapsedMs: {
+      imageDescription: number;
+      addKnowledge: number;
+    };
   }> {
+    const startedAt = Date.now();
+    let imageDescriptionMs = 0;
     let content = document.content;
     let contentType = document.contentType || "text/plain";
     const warnings: string[] = [];
@@ -890,6 +902,7 @@ export async function handleKnowledgeRoutes(
         (document.metadata as Record<string, unknown>)
           ?.includeImageDescriptions === true;
       if (includeDescriptions && runtime) {
+        const imageDescriptionStart = Date.now();
         try {
           const { ModelType } = await import("@elizaos/core");
           const dataUri = `data:${contentType};base64,${content}`;
@@ -912,6 +925,7 @@ export async function handleKnowledgeRoutes(
           content = `[Image: ${document.filename}] — Image description unavailable (model error).`;
           contentType = "text/plain";
         }
+        imageDescriptionMs = Date.now() - imageDescriptionStart;
       } else {
         // No vision requested — store as a reference entry
         content = `[Image: ${document.filename}] — Image uploaded without text extraction.`;
@@ -924,6 +938,7 @@ export async function handleKnowledgeRoutes(
       contentType = "text/markdown";
     }
 
+    const addKnowledgeStart = Date.now();
     const result = await service.addKnowledge({
       agentId,
       worldId: agentId,
@@ -935,6 +950,7 @@ export async function handleKnowledgeRoutes(
       content,
       metadata: document.metadata,
     });
+    const addKnowledgeMs = Date.now() - addKnowledgeStart;
 
     const warningsValue = (result as { warnings?: unknown }).warnings;
     if (Array.isArray(warningsValue)) {
@@ -947,6 +963,11 @@ export async function handleKnowledgeRoutes(
       documentId: result.clientDocumentId,
       fragmentCount: result.fragmentCount,
       warnings: warnings.length > 0 ? warnings : undefined,
+      elapsedMs: Date.now() - startedAt,
+      phaseElapsedMs: {
+        imageDescription: imageDescriptionMs,
+        addKnowledge: addKnowledgeMs,
+      },
     };
   }
 
@@ -963,7 +984,13 @@ export async function handleKnowledgeRoutes(
       return true;
     }
 
-    let result: { documentId: string; fragmentCount: number; warnings?: string[] };
+    let result: {
+      documentId: string;
+      fragmentCount: number;
+      warnings?: string[];
+      elapsedMs: number;
+      phaseElapsedMs: { imageDescription: number; addKnowledge: number };
+    };
     try {
       result = await addKnowledgeDocument(knowledgeService, body);
     } catch (err) {
@@ -971,10 +998,24 @@ export async function handleKnowledgeRoutes(
       return true;
     }
 
+    logger.info(
+      {
+        boundary: "knowledge-doc",
+        agentId,
+        filename: body.filename,
+        documentId: result.documentId,
+        fragmentCount: result.fragmentCount,
+        elapsedMs: result.elapsedMs,
+        phaseElapsedMs: result.phaseElapsedMs,
+      },
+      `[knowledge-doc] Document ingested: ${body.filename}`,
+    );
+
     json(res, {
       ok: true,
       documentId: result.documentId,
       fragmentCount: result.fragmentCount,
+      elapsedMs: result.elapsedMs,
       warnings: result.warnings,
     });
     return true;
@@ -1002,12 +1043,30 @@ export async function handleKnowledgeRoutes(
       return true;
     }
 
+    const batchStartedAt = Date.now();
+    const totalContentBytes = body.documents.reduce((sum, doc) => {
+      const len = typeof doc?.content === "string" ? doc.content.length : 0;
+      return sum + len;
+    }, 0);
+
+    logger.info(
+      {
+        boundary: "knowledge-bulk",
+        agentId,
+        documentCount: body.documents.length,
+        totalContentBytes,
+      },
+      `[knowledge-bulk] Begin bulk ingest of ${body.documents.length} documents (${totalContentBytes} bytes)`,
+    );
+
     const results: Array<{
       index: number;
       ok: boolean;
       filename: string;
       documentId?: UUID;
       fragmentCount?: number;
+      elapsedMs?: number;
+      phaseElapsedMs?: { imageDescription: number; addKnowledge: number };
       error?: string;
       warnings?: string[];
     }> = [];
@@ -1035,10 +1094,26 @@ export async function handleKnowledgeRoutes(
         filename: document.filename.trim(),
       };
 
+      const docStartedAt = Date.now();
       try {
         const uploadResult = await addKnowledgeDocument(
           knowledgeService,
           normalizedDocument,
+        );
+        const docElapsedMs = Date.now() - docStartedAt;
+        logger.info(
+          {
+            boundary: "knowledge-bulk-doc",
+            agentId,
+            index,
+            filename,
+            documentId: uploadResult.documentId,
+            fragmentCount: uploadResult.fragmentCount,
+            elapsedMs: docElapsedMs,
+            phaseElapsedMs: uploadResult.phaseElapsedMs,
+            contentBytes: normalizedDocument.content.length,
+          },
+          `[knowledge-bulk-doc] Document ingested: ${filename} in ${docElapsedMs}ms`,
         );
         results.push({
           index,
@@ -1046,13 +1121,29 @@ export async function handleKnowledgeRoutes(
           filename,
           documentId: uploadResult.documentId,
           fragmentCount: uploadResult.fragmentCount,
+          elapsedMs: docElapsedMs,
+          phaseElapsedMs: uploadResult.phaseElapsedMs,
           warnings: uploadResult.warnings,
         });
       } catch (err) {
+        const docElapsedMs = Date.now() - docStartedAt;
+        logger.warn(
+          {
+            boundary: "knowledge-bulk-doc",
+            agentId,
+            index,
+            filename,
+            elapsedMs: docElapsedMs,
+            contentBytes: normalizedDocument.content.length,
+            error: String(err),
+          },
+          `[knowledge-bulk-doc] Document failed: ${filename} after ${docElapsedMs}ms`,
+        );
         results.push({
           index,
           ok: false,
           filename,
+          elapsedMs: docElapsedMs,
           error: String(err),
         });
       }
@@ -1060,12 +1151,54 @@ export async function handleKnowledgeRoutes(
 
     const successCount = results.filter((item) => item.ok).length;
     const failureCount = results.length - successCount;
+    const totalElapsedMs = Date.now() - batchStartedAt;
+
+    const sortedDocDurations = results
+      .map((item) =>
+        typeof item.elapsedMs === "number" ? item.elapsedMs : null,
+      )
+      .filter((value): value is number => value !== null)
+      .sort((a, b) => a - b);
+
+    const percentile = (sorted: number[], p: number): number => {
+      if (sorted.length === 0) return 0;
+      const idx = Math.min(
+        sorted.length - 1,
+        Math.floor((p / 100) * sorted.length),
+      );
+      return sorted[idx];
+    };
+
+    const perDocElapsedMs = {
+      p50: percentile(sortedDocDurations, 50),
+      p95: percentile(sortedDocDurations, 95),
+      max:
+        sortedDocDurations.length > 0
+          ? sortedDocDurations[sortedDocDurations.length - 1]
+          : 0,
+    };
+
+    logger.info(
+      {
+        boundary: "knowledge-bulk",
+        agentId,
+        documentCount: body.documents.length,
+        successCount,
+        failureCount,
+        totalContentBytes,
+        totalElapsedMs,
+        perDocElapsedMs,
+      },
+      `[knowledge-bulk] Completed bulk ingest: ${successCount}/${body.documents.length} ok, ${failureCount} failed in ${totalElapsedMs}ms (p50=${perDocElapsedMs.p50}ms p95=${perDocElapsedMs.p95}ms max=${perDocElapsedMs.max}ms)`,
+    );
 
     json(res, {
       ok: failureCount === 0,
       total: results.length,
       successCount,
       failureCount,
+      totalElapsedMs,
+      perDocElapsedMs,
       results,
     });
     return true;


### PR DESCRIPTION
## Summary
Instrumentation-only changes to the knowledge ingest API. Adds per-document and per-batch elapsed-time logging plus matching response fields. **No behavior changes** — same code paths, same status codes, same error semantics.

This is **PR #3 of 7** in the Alice corpus ingestion recovery plan ([2026-05-02 plan](https://github.com/rndrntwrk/555-bot/blob/alice/docs/2026-05-02-alice-corpus-ingestion-recovery.md)). It pairs with the 555-bot seeder (PR #2 / #187) which currently records `uploadElapsedMs: 0` because there's no server-side timing to read from.

## Why
The PGlite adapter does an O(n) embedding-uniqueness scan per `createMemory()`, so per-fragment cost grows linearly with corpus size and per-document cost grows ~quadratically with fragment count. Without server-side timing we can't:
- distinguish API serialization cost from PGlite per-fragment cost
- empirically size the n² penalty before staging
- give the seeder a real `uploadElapsedMs` to log per document

## What changed
`packages/agent/src/api/knowledge-routes.ts`:
- Import `logger` from `@elizaos/core` (matches the `lifeops-routes.ts` pattern)
- `addKnowledgeDocument` now returns:
  - `elapsedMs` — total document elapsed
  - `phaseElapsedMs.imageDescription` — image→text-description model call (0 if not an image)
  - `phaseElapsedMs.addKnowledge` — `service.addKnowledge` call only (this is where PGlite per-fragment cost shows up)
- `POST /api/knowledge/documents` — emits `boundary: "knowledge-doc"` info log; response includes `elapsedMs`
- `POST /api/knowledge/documents/bulk`:
  - Emits `boundary: "knowledge-bulk"` info log on entry (documentCount, totalContentBytes)
  - Per-document `boundary: "knowledge-bulk-doc"` info log on success (filename, documentId, fragmentCount, elapsedMs, phaseElapsedMs, contentBytes)
  - Per-document `boundary: "knowledge-bulk-doc"` warn log on failure
  - Final `boundary: "knowledge-bulk"` info log on completion (successCount, failureCount, totalElapsedMs, perDocElapsedMs.{p50,p95,max})
  - Response body adds `totalElapsedMs`, `perDocElapsedMs`, plus per-result `elapsedMs` / `phaseElapsedMs`

## Rollout — DO NOT RETAG `MILAIDY_RUNTIME_BRANCH`
This change is safe to land but **the 555-bot deploy workflow pulls milaidy code via the `MILAIDY_RUNTIME_BRANCH` tag during the docker image build**. Retagging that branch from this commit would push these changes into the next 555-bot deploy.

**Wait until PR #4** (staging corpus-ingest Job + DB backup + cleanup-on-failure in 555stream) is ready to drive a DB-restorable staging rollout. The 555-bot kill switch (`vars.CORPUS_INGEST_UNLOCKED`) is the runtime gate, but the runtime-branch retag is the trigger that bakes these instrumentation changes into the image.

The 555-bot seeder (PR #2 / #187 at `scripts/seed-knowledge.ts`) already accepts an `elapsedMs` field on each per-document result — once this PR's milaidy code is built into the staging image, the seeder will start populating `uploadElapsedMs` from the response instead of hardcoding 0.

## What's NOT in this PR
- PGlite adapter timing (per-fragment `createMemory`, `searchMemoriesByEmbedding`) — that lives in upstream `@elizaos/plugin-sql` and would require forking. The per-document `phaseElapsedMs.addKnowledge` here is a sufficient n²-shape signal for staging; deferred to a follow-up.
- Single-doc `/url` endpoint timing — narrow scope; only the bulk path is on the corpus ingest hot path.

## Test plan
- [ ] Local typecheck (requires `eliza` submodule init: `git submodule update --init --recursive eliza`)
- [ ] Boot agent locally, POST a 2-doc bulk request to `/api/knowledge/documents/bulk`; verify `knowledge-bulk` and `knowledge-bulk-doc` logs appear with non-zero `elapsedMs`
- [ ] Verify response body now contains `totalElapsedMs`, `perDocElapsedMs`, and per-result `elapsedMs`
- [ ] Verify single-doc `/api/knowledge/documents` POST still returns expected shape with the added `elapsedMs` field

## Refs
- Recovery plan: `docs/superpowers/plans/2026-05-02-alice-corpus-ingestion-recovery.md` (also mirrored at `555-bot/docs/`)
- Pairs with: `555-bot` PR #187 (seeder diagnostics + checkpointing)
- Blocked-on retag by: PR #4 (555stream staging corpus-ingest Job)