### PR TITLE
ops(alice): spike durable corpus store

### DIFF
--- a/docs/ops/alice-durable-corpus-store-spike.md
+++ b/docs/ops/alice-durable-corpus-store-spike.md
@@ -1,0 +1,131 @@
+# Alice durable corpus store spike
+
+## Purpose
+
+The corpus-ingest recovery sequence made seeding safer with snapshots,
+checkpointing, startup probes, and staging acceptance. The remaining
+architectural gap is that the runtime still treats the corpus mostly as rows
+inside the live memory database. A durable corpus store gives Alice an
+auditable source snapshot that can be compared, restored, or re-ingested
+without depending on a half-written `memories` table.
+
+This spike adds a low-risk filesystem-backed store under Alice's state
+directory. It does **not** change retrieval behavior, chat behavior, or the
+bulk knowledge API.
+
+## What landed
+
+The Alice corpus API now writes two artifacts when an operator calls:
+
+```http
+POST /api/alice/corpus/snapshot
+```
+
+1. The legacy manifest at:
+
+```text
+<stateDir>/alice/corpus-manifest.json
+```
+
+2. A durable content-addressed store at:
+
+```text
+<stateDir>/alice/corpus-store/
+  latest.json
+  snapshots/<snapshotId>.json
+  objects/sha256/<prefix>/<sha256>
+```
+
+The durable snapshot contains:
+
+* `snapshotId` - first 32 hex chars of the stable corpus hash.
+* `corpusSha` - SHA-256 over the sorted `(rootId, relativePath, contentType,
+  sha256, byteSize)` tuples.
+* `items[]` - root id, relative path, content type, byte size, SHA, and object
+  path.
+* No per-file `absolutePath` entries. Runtime-local source paths are used only
+  while writing the store; the stored snapshot points at content-addressed
+  objects.
+
+Operators can inspect the latest durable snapshot with:
+
+```http
+GET /api/alice/corpus/snapshot/latest
+```
+
+## Why filesystem first
+
+The current production risk is partial mutation of the live knowledge rows.
+The fastest safe improvement is to keep the corpus source snapshot beside the
+runtime state, independent of those rows.
+
+Filesystem store advantages:
+
+* No schema migration in the runtime DB.
+* No change to the upstream `@elizaos/plugin-knowledge` tables.
+* Works with the same PVC/S3 snapshot posture the recovery plan already uses.
+* Dedupes unchanged corpus bytes by SHA.
+* Lets Ops prove "this is the corpus the runtime saw" without querying vector
+  rows.
+
+## Boundaries
+
+This is still a spike. It intentionally does not:
+
+* Make `/api/knowledge/documents/bulk` idempotent.
+* Replace the PR #4 atomic-swap staging Job.
+* Write a new SQL table.
+* Automatically rehydrate `memories` from the object store on startup.
+* Promote production corpus ingest.
+
+## Promotion path
+
+The next production-grade step is a SQL-backed corpus ledger:
+
+```sql
+alice_corpus_runs(
+  id uuid primary key,
+  corpus_sha text not null,
+  source text not null,
+  status text not null,
+  started_at timestamptz not null,
+  completed_at timestamptz,
+  manifest_json jsonb not null
+);
+
+alice_corpus_documents(
+  corpus_sha text not null,
+  root_id text not null,
+  relative_path text not null,
+  content_sha text not null,
+  byte_size bigint not null,
+  knowledge_document_id uuid,
+  status text not null,
+  primary key (corpus_sha, root_id, relative_path)
+);
+```
+
+That ledger is what eventually makes the bulk ingest API idempotent by
+`(corpusSha, rootId, relativePath, contentSha)` instead of by fresh generated
+document ids.
+
+## Acceptance for this spike
+
+* `POST /api/alice/corpus/snapshot` still writes the legacy manifest.
+* The same request writes content-addressed objects and `latest.json`.
+* Re-running the same snapshot writes zero duplicate objects.
+* Source-file mutation between manifest build and store write fails closed.
+* `GET /api/alice/corpus/snapshot/latest` returns the stored snapshot or 404
+  when none exists.
+
+## Operational note
+
+The default store path is:
+
+```text
+<stateDir>/alice/corpus-store
+```
+
+It can be overridden with `alice.corpus.storeDir` in config. Relative paths are
+resolved from the runtime working directory; absolute paths are accepted for
+special deployments.

--- a/packages/agent/src/api/alice-corpus-manifest-routes.test.ts
+++ b/packages/agent/src/api/alice-corpus-manifest-routes.test.ts
@@ -49,6 +49,7 @@ function makeContext({
         alice: {
           corpus: {
             roots: [{ id: "milaidy", path: repoRoot }],
+            storeDir: path.join(stateDir, "durable-corpus-store"),
           },
         },
       },
@@ -68,9 +69,13 @@ describe("handleAliceCorpusRoutes", () => {
   it("builds a configured corpus manifest without secrets or backups", async () => {
     const repoRoot = makeTempDir();
     const stateDir = makeTempDir();
-    writeFile(repoRoot, "packages/agent/src/api/server.ts", "export const api = true;\n");
+    writeFile(
+      repoRoot,
+      "packages/agent/src/api/server.ts",
+      "export const api = true;\n",
+    );
     writeFile(repoRoot, ".env.production", "OPENAI_API_KEY=sk-secret\n");
-    writeFile(repoRoot, "backup/old-config.json", "{\"token\":\"ghp_secret\"}");
+    writeFile(repoRoot, "backup/old-config.json", '{"token":"ghp_secret"}');
 
     const { ctx, jsonCalls } = makeContext({
       method: "GET",
@@ -106,16 +111,73 @@ describe("handleAliceCorpusRoutes", () => {
     await handleAliceCorpusRoutes(ctx);
 
     const snapshotPath = path.join(stateDir, "alice", "corpus-manifest.json");
+    const storeDir = path.join(stateDir, "durable-corpus-store");
     expect(jsonCalls[0]?.data).toMatchObject({
       ok: true,
       snapshotPath,
       manifest: {
         items: [{ relativePath: "README.md" }],
       },
+      store: {
+        snapshotId: expect.stringMatching(/^[a-f0-9]{32}$/),
+        corpusSha: expect.stringMatching(/^[a-f0-9]{64}$/),
+        objectCount: 1,
+        objectsWritten: 1,
+        existingObjects: 0,
+      },
     });
     expect(JSON.parse(fs.readFileSync(snapshotPath, "utf-8"))).toMatchObject({
       version: 1,
       items: [{ relativePath: "README.md" }],
     });
+    expect(fs.existsSync(path.join(storeDir, "latest.json"))).toBe(true);
+  });
+
+  it("returns the latest durable corpus snapshot", async () => {
+    const repoRoot = makeTempDir();
+    const stateDir = makeTempDir();
+    writeFile(repoRoot, "README.md", "# Alice\n");
+
+    const post = makeContext({
+      method: "POST",
+      pathname: "/api/alice/corpus/snapshot",
+      repoRoot,
+      stateDir,
+    });
+    await handleAliceCorpusRoutes(post.ctx);
+
+    const get = makeContext({
+      method: "GET",
+      pathname: "/api/alice/corpus/snapshot/latest",
+      repoRoot,
+      stateDir,
+    });
+    await handleAliceCorpusRoutes(get.ctx);
+
+    expect(get.jsonCalls[0]?.data).toMatchObject({
+      ok: true,
+      snapshot: {
+        snapshotId: expect.stringMatching(/^[a-f0-9]{32}$/),
+        items: [{ relativePath: "README.md" }],
+      },
+    });
+  });
+
+  it("returns 404 when no durable corpus snapshot exists", async () => {
+    const repoRoot = makeTempDir();
+    const stateDir = makeTempDir();
+
+    const { ctx, errorCalls } = makeContext({
+      method: "GET",
+      pathname: "/api/alice/corpus/snapshot/latest",
+      repoRoot,
+      stateDir,
+    });
+
+    await handleAliceCorpusRoutes(ctx);
+
+    expect(errorCalls).toEqual([
+      { message: "No Alice corpus snapshot has been written", status: 404 },
+    ]);
   });
 });

--- a/packages/agent/src/api/alice-corpus-routes.ts
+++ b/packages/agent/src/api/alice-corpus-routes.ts
@@ -7,6 +7,10 @@ import {
   type AliceCorpusRoot,
   buildAliceCorpusManifest,
 } from "./alice-corpus-manifest.js";
+import {
+  readLatestAliceCorpusStoreSnapshot,
+  writeAliceCorpusStoreSnapshot,
+} from "./alice-corpus-store.js";
 
 export interface AliceCorpusRouteContext {
   req: http.IncomingMessage;
@@ -42,19 +46,56 @@ function resolveCorpusRoots(
 }
 
 function resolveSnapshotPath(stateDir?: string): string {
-  return path.join(stateDir ?? resolveStateDir(), "alice", "corpus-manifest.json");
+  return path.join(
+    stateDir ?? resolveStateDir(),
+    "alice",
+    "corpus-manifest.json",
+  );
+}
+
+function resolveStoreDir(
+  config: Pick<ElizaConfig, "alice">,
+  stateDir: string | undefined,
+  cwd: string,
+): string {
+  const configuredStoreDir = config.alice?.corpus?.storeDir;
+  if (typeof configuredStoreDir === "string" && configuredStoreDir.trim()) {
+    return path.resolve(cwd, configuredStoreDir);
+  }
+  return path.join(stateDir ?? resolveStateDir(), "alice", "corpus-store");
 }
 
 export async function handleAliceCorpusRoutes(
   ctx: AliceCorpusRouteContext,
 ): Promise<boolean> {
-  const { res, method, pathname, config, stateDir, cwd = process.cwd(), json, error } = ctx;
+  const {
+    res,
+    method,
+    pathname,
+    config,
+    stateDir,
+    cwd = process.cwd(),
+    json,
+    error,
+  } = ctx;
 
   if (
     pathname !== "/api/alice/corpus/manifest" &&
-    pathname !== "/api/alice/corpus/snapshot"
+    pathname !== "/api/alice/corpus/snapshot" &&
+    pathname !== "/api/alice/corpus/snapshot/latest"
   ) {
     return false;
+  }
+
+  if (method === "GET" && pathname === "/api/alice/corpus/snapshot/latest") {
+    const storeDir = resolveStoreDir(config, stateDir, cwd);
+    const snapshot = readLatestAliceCorpusStoreSnapshot(storeDir);
+    if (!snapshot) {
+      error(res, "No Alice corpus snapshot has been written", 404);
+      return true;
+    }
+    json(res, { ok: true, storeDir, snapshot });
+    return true;
   }
 
   const manifest = buildAliceCorpusManifest({
@@ -69,8 +110,30 @@ export async function handleAliceCorpusRoutes(
   if (method === "POST" && pathname === "/api/alice/corpus/snapshot") {
     const snapshotPath = resolveSnapshotPath(stateDir);
     fs.mkdirSync(path.dirname(snapshotPath), { recursive: true });
-    fs.writeFileSync(snapshotPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
-    json(res, { ok: true, snapshotPath, manifest });
+    fs.writeFileSync(
+      snapshotPath,
+      `${JSON.stringify(manifest, null, 2)}\n`,
+      "utf-8",
+    );
+    const store = writeAliceCorpusStoreSnapshot({
+      storeDir: resolveStoreDir(config, stateDir, cwd),
+      manifest,
+    });
+    json(res, {
+      ok: true,
+      snapshotPath,
+      manifest,
+      store: {
+        snapshotId: store.snapshot.snapshotId,
+        corpusSha: store.snapshot.corpusSha,
+        snapshotPath: store.snapshotPath,
+        latestPath: store.latestPath,
+        objectCount: store.objectCount,
+        objectsWritten: store.objectsWritten,
+        existingObjects: store.existingObjects,
+        bytesWritten: store.bytesWritten,
+      },
+    });
     return true;
   }
 

--- a/packages/agent/src/api/alice-corpus-store.test.ts
+++ b/packages/agent/src/api/alice-corpus-store.test.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildAliceCorpusManifest } from "./alice-corpus-manifest";
+import {
+  computeAliceCorpusSha,
+  readLatestAliceCorpusStoreSnapshot,
+  writeAliceCorpusStoreSnapshot,
+} from "./alice-corpus-store";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "alice-corpus-store-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeFile(root: string, relativePath: string, content: string): void {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf-8");
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("alice corpus durable store", () => {
+  it("writes content-addressed objects and a latest snapshot pointer", () => {
+    const root = makeTempDir();
+    const storeDir = makeTempDir();
+    writeFile(root, "README.md", "# Alice\n");
+    writeFile(root, "docs/runbook.md", "# Runbook\n");
+
+    const manifest = buildAliceCorpusManifest({
+      roots: [{ id: "milaidy", path: root }],
+      generatedAt: "2026-05-02T12:00:00.000Z",
+    });
+
+    const result = writeAliceCorpusStoreSnapshot({
+      storeDir,
+      manifest,
+      storedAt: "2026-05-02T12:01:00.000Z",
+    });
+
+    expect(result.snapshot).toMatchObject({
+      version: 1,
+      snapshotId: computeAliceCorpusSha(manifest).slice(0, 32),
+      corpusSha: computeAliceCorpusSha(manifest),
+      items: [
+        {
+          relativePath: "README.md",
+          objectPath: expect.stringMatching(/^objects\/sha256\//),
+        },
+        {
+          relativePath: "docs/runbook.md",
+          objectPath: expect.stringMatching(/^objects\/sha256\//),
+        },
+      ],
+    });
+    expect(result.objectCount).toBe(2);
+    expect(result.objectsWritten).toBe(2);
+    expect(result.existingObjects).toBe(0);
+    expect(fs.existsSync(result.snapshotPath)).toBe(true);
+    expect(fs.existsSync(result.latestPath)).toBe(true);
+
+    const latest = readLatestAliceCorpusStoreSnapshot(storeDir);
+    expect(latest).toEqual(result.snapshot);
+    for (const item of result.snapshot.items) {
+      expect(fs.existsSync(path.join(storeDir, item.objectPath))).toBe(true);
+      expect(item).not.toHaveProperty("absolutePath");
+    }
+  });
+
+  it("dedupes repeated writes by object sha", () => {
+    const root = makeTempDir();
+    const storeDir = makeTempDir();
+    writeFile(root, "README.md", "# Alice\n");
+
+    const manifest = buildAliceCorpusManifest({
+      roots: [{ id: "milaidy", path: root }],
+      generatedAt: "2026-05-02T12:00:00.000Z",
+    });
+
+    const first = writeAliceCorpusStoreSnapshot({ storeDir, manifest });
+    const second = writeAliceCorpusStoreSnapshot({ storeDir, manifest });
+
+    expect(second.snapshot.snapshotId).toBe(first.snapshot.snapshotId);
+    expect(second.objectsWritten).toBe(0);
+    expect(second.existingObjects).toBe(1);
+  });
+
+  it("fails closed if source bytes change after manifest generation", () => {
+    const root = makeTempDir();
+    const storeDir = makeTempDir();
+    writeFile(root, "README.md", "# Alice\n");
+
+    const manifest = buildAliceCorpusManifest({
+      roots: [{ id: "milaidy", path: root }],
+      generatedAt: "2026-05-02T12:00:00.000Z",
+    });
+    writeFile(root, "README.md", "# Changed\n");
+
+    expect(() => writeAliceCorpusStoreSnapshot({ storeDir, manifest })).toThrow(
+      /Corpus source changed while writing store/,
+    );
+  });
+});

--- a/packages/agent/src/api/alice-corpus-store.ts
+++ b/packages/agent/src/api/alice-corpus-store.ts
@@ -1,0 +1,218 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type {
+  AliceCorpusManifest,
+  AliceCorpusManifestItem,
+} from "./alice-corpus-manifest.js";
+
+export interface AliceCorpusStoredItem {
+  rootId: string;
+  relativePath: string;
+  contentType: AliceCorpusManifestItem["contentType"];
+  sha256: string;
+  byteSize: number;
+  objectPath: string;
+}
+
+export interface AliceCorpusStoredSnapshot {
+  version: 1;
+  snapshotId: string;
+  corpusSha: string;
+  generatedAt: string;
+  storedAt: string;
+  roots: AliceCorpusManifest["roots"];
+  excludedCount: number;
+  items: AliceCorpusStoredItem[];
+}
+
+export interface AliceCorpusLatestPointer {
+  version: 1;
+  snapshotId: string;
+  corpusSha: string;
+  snapshotPath: string;
+  storedAt: string;
+}
+
+export interface AliceCorpusStoreWriteResult {
+  snapshot: AliceCorpusStoredSnapshot;
+  snapshotPath: string;
+  latestPath: string;
+  objectCount: number;
+  objectsWritten: number;
+  existingObjects: number;
+  bytesWritten: number;
+}
+
+export interface WriteAliceCorpusStoreOptions {
+  storeDir: string;
+  manifest: AliceCorpusManifest;
+  storedAt?: string;
+}
+
+function sha256(buffer: Buffer): string {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+function stableJson(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+export function computeAliceCorpusSha(manifest: AliceCorpusManifest): string {
+  const normalized = manifest.items
+    .map((item) => ({
+      rootId: item.rootId,
+      relativePath: item.relativePath,
+      contentType: item.contentType,
+      sha256: item.sha256,
+      byteSize: item.byteSize,
+    }))
+    .sort((left, right) => {
+      const leftKey = `${left.rootId}/${left.relativePath}`;
+      const rightKey = `${right.rootId}/${right.relativePath}`;
+      return leftKey.localeCompare(rightKey);
+    });
+  return sha256(Buffer.from(JSON.stringify(normalized), "utf-8"));
+}
+
+function objectRelativePath(sha: string): string {
+  return path.join("objects", "sha256", sha.slice(0, 2), sha);
+}
+
+function writeJsonAtomic(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmpPath, stableJson(value), "utf-8");
+  fs.renameSync(tmpPath, filePath);
+}
+
+function readAndVerifySource(item: AliceCorpusManifestItem): Buffer {
+  const bytes = fs.readFileSync(item.absolutePath);
+  const actualSha = sha256(bytes);
+  if (actualSha !== item.sha256) {
+    throw new Error(
+      `Corpus source changed while writing store: ${item.rootId}/${item.relativePath} expected ${item.sha256} got ${actualSha}`,
+    );
+  }
+  if (bytes.byteLength !== item.byteSize) {
+    throw new Error(
+      `Corpus source size changed while writing store: ${item.rootId}/${item.relativePath} expected ${item.byteSize} got ${bytes.byteLength}`,
+    );
+  }
+  return bytes;
+}
+
+function ensureObject(
+  storeDir: string,
+  item: AliceCorpusManifestItem,
+): {
+  relativePath: string;
+  written: boolean;
+  byteSize: number;
+} {
+  const relativePath = objectRelativePath(item.sha256);
+  const objectPath = path.join(storeDir, relativePath);
+  if (fs.existsSync(objectPath)) {
+    const existing = fs.readFileSync(objectPath);
+    const existingSha = sha256(existing);
+    if (existingSha !== item.sha256) {
+      throw new Error(
+        `Corpus object hash mismatch for ${relativePath}: expected ${item.sha256} got ${existingSha}`,
+      );
+    }
+    return { relativePath, written: false, byteSize: existing.byteLength };
+  }
+
+  const source = readAndVerifySource(item);
+  fs.mkdirSync(path.dirname(objectPath), { recursive: true });
+  fs.writeFileSync(objectPath, source);
+  return { relativePath, written: true, byteSize: source.byteLength };
+}
+
+export function writeAliceCorpusStoreSnapshot(
+  options: WriteAliceCorpusStoreOptions,
+): AliceCorpusStoreWriteResult {
+  const storeDir = path.resolve(options.storeDir);
+  const storedAt = options.storedAt ?? new Date().toISOString();
+  const corpusSha = computeAliceCorpusSha(options.manifest);
+  const snapshotId = corpusSha.slice(0, 32);
+  const items: AliceCorpusStoredItem[] = [];
+  let objectsWritten = 0;
+  let existingObjects = 0;
+  let bytesWritten = 0;
+
+  for (const item of options.manifest.items) {
+    const object = ensureObject(storeDir, item);
+    if (object.written) {
+      objectsWritten += 1;
+      bytesWritten += object.byteSize;
+    } else {
+      existingObjects += 1;
+    }
+    items.push({
+      rootId: item.rootId,
+      relativePath: item.relativePath,
+      contentType: item.contentType,
+      sha256: item.sha256,
+      byteSize: item.byteSize,
+      objectPath: object.relativePath.split(path.sep).join("/"),
+    });
+  }
+
+  const snapshot: AliceCorpusStoredSnapshot = {
+    version: 1,
+    snapshotId,
+    corpusSha,
+    generatedAt: options.manifest.generatedAt,
+    storedAt,
+    roots: options.manifest.roots,
+    excludedCount: options.manifest.excludedCount,
+    items,
+  };
+
+  const snapshotPath = path.join(storeDir, "snapshots", `${snapshotId}.json`);
+  writeJsonAtomic(snapshotPath, snapshot);
+
+  const latestPath = path.join(storeDir, "latest.json");
+  const latest: AliceCorpusLatestPointer = {
+    version: 1,
+    snapshotId,
+    corpusSha,
+    snapshotPath: path
+      .relative(storeDir, snapshotPath)
+      .split(path.sep)
+      .join("/"),
+    storedAt,
+  };
+  writeJsonAtomic(latestPath, latest);
+
+  return {
+    snapshot,
+    snapshotPath,
+    latestPath,
+    objectCount: items.length,
+    objectsWritten,
+    existingObjects,
+    bytesWritten,
+  };
+}
+
+export function readLatestAliceCorpusStoreSnapshot(
+  storeDir: string,
+): AliceCorpusStoredSnapshot | null {
+  const resolvedStoreDir = path.resolve(storeDir);
+  const latestPath = path.join(resolvedStoreDir, "latest.json");
+  if (!fs.existsSync(latestPath)) return null;
+  const latest = JSON.parse(
+    fs.readFileSync(latestPath, "utf-8"),
+  ) as AliceCorpusLatestPointer;
+  const snapshotPath = path.resolve(resolvedStoreDir, latest.snapshotPath);
+  if (!snapshotPath.startsWith(resolvedStoreDir + path.sep)) {
+    throw new Error(
+      `Invalid corpus snapshot path outside store: ${latest.snapshotPath}`,
+    );
+  }
+  return JSON.parse(
+    fs.readFileSync(snapshotPath, "utf-8"),
+  ) as AliceCorpusStoredSnapshot;
+}

--- a/packages/agent/src/config/types.eliza.ts
+++ b/packages/agent/src/config/types.eliza.ts
@@ -688,6 +688,8 @@ export type AliceCorpusConfig = {
   enabled?: boolean;
   /** Configured source-of-truth roots Alice may index. Paths may be absolute or runtime-cwd-relative. */
   roots?: AliceCorpusRootConfig[];
+  /** Durable corpus snapshot store. Defaults to `<stateDir>/alice/corpus-store`. */
+  storeDir?: string;
 };
 
 export type AliceCodingConfig = {


### PR DESCRIPTION
## Summary
- add a filesystem-backed durable corpus store under the Alice state dir
- make POST /api/alice/corpus/snapshot write content-addressed objects, latest.json, and the legacy manifest
- add GET /api/alice/corpus/snapshot/latest for inspecting the latest stored corpus snapshot
- document the spike boundaries and the next SQL-backed ledger path

## Safety
- no retrieval behavior change
- no DB schema change
- no bulk ingest API behavior change
- no corpus ingest, deploy, or production action
- stored snapshot items omit per-file absolutePath and point at content-addressed objects

## Verification
- node --experimental-strip-types --check packages/agent/src/api/alice-corpus-store.ts
- node --experimental-strip-types --check packages/agent/src/api/alice-corpus-routes.ts
- bunx vitest run packages/agent/src/api/alice-corpus-manifest.test.ts packages/agent/src/api/alice-corpus-store.test.ts packages/agent/src/api/alice-corpus-manifest-routes.test.ts
- BUN_TMPDIR=/private/tmp/bun-tmp bunx @biomejs/biome check packages/agent/src/api/alice-corpus-store.ts packages/agent/src/api/alice-corpus-store.test.ts packages/agent/src/api/alice-corpus-routes.ts packages/agent/src/api/alice-corpus-manifest-routes.test.ts packages/agent/src/config/types.eliza.ts
- git diff --cached --check

## Note
Full packages/agent typecheck was attempted but this clean worktree lacks the bun/node type definitions required by tsconfig (`Cannot find type definition file for bun/node`). Targeted syntax, lint, and unit coverage passed.