### PR TITLE
fix(alice): restore prod client and plugin route fallbacks

### DIFF
--- a/packages/app-core/src/api/api-barrel-client.test.ts
+++ b/packages/app-core/src/api/api-barrel-client.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { client, MiladyClient } from "./index";
+
+describe("@miladyai/app-core/api barrel", () => {
+  it("exports the production app client with the dashboard methods used by the shell", () => {
+    const freshClient = new MiladyClient("http://127.0.0.1:31337");
+
+    for (const methodName of [
+      "getLifeOpsOverview",
+      "listAppRuns",
+      "listCodingAgentTaskThreads",
+      "getPlugins",
+      "getCompanionStageState",
+    ]) {
+      expect(
+        typeof (client as unknown as Record<string, unknown>)[methodName],
+        methodName,
+      ).toBe("function");
+      expect(
+        typeof (freshClient as unknown as Record<string, unknown>)[methodName],
+        methodName,
+      ).toBe("function");
+    }
+  });
+});

--- a/packages/app-core/src/api/client-agent.ts
+++ b/packages/app-core/src/api/client-agent.ts
@@ -24,6 +24,10 @@ import {
   type WebsiteBlockerPermissionResult,
   type WebsiteBlockerStatusResult,
 } from "../bridge/native-plugins";
+import type {
+  CompanionStageState,
+  PartialCompanionStageState,
+} from "../components/companion/companion-stage-state";
 import { TERMINAL_STATUSES } from "../coding";
 import { MiladyClient } from "./client-base";
 import type {
@@ -40,6 +44,7 @@ import type {
   ConfigSchemaResponse,
   CorePluginsResponse,
   CreateTriggerRequest,
+  EmoteInfo,
   ExtensionStatus,
   LogsFilter,
   LogsResponse,
@@ -175,6 +180,23 @@ declare module "./client-base" {
       mode: string,
     ): Promise<{ ok: boolean; tradePermissionMode: string }>;
     playEmote(emoteId: string): Promise<{ ok: boolean }>;
+    getEmotes(): Promise<{ emotes: EmoteInfo[] }>;
+    getBroadcastScene(channel: string): Promise<{
+      ok: boolean;
+      channel: string;
+      scene: {
+        selectedVrmIndex: number | null;
+        hasCustomVrm: boolean;
+        hasCustomBackground: boolean;
+      };
+    }>;
+    getCompanionStageState(): Promise<{
+      ok: boolean;
+      state: CompanionStageState;
+    }>;
+    setCompanionStageState(
+      patch: PartialCompanionStageState,
+    ): Promise<{ ok: boolean; state: CompanionStageState }>;
     runTerminalCommand(command: string): Promise<{ ok: boolean }>;
     getOnboardingStatus(): Promise<{
       complete: boolean;
@@ -655,6 +677,50 @@ MiladyClient.prototype.playEmote = async function (
   return this.fetch("/api/emote", {
     method: "POST",
     body: JSON.stringify({ emoteId }),
+  });
+};
+
+MiladyClient.prototype.getEmotes = async function (this: MiladyClient) {
+  return this.fetch("/api/emotes");
+};
+
+MiladyClient.prototype.getBroadcastScene = async function (
+  this: MiladyClient,
+  channel,
+) {
+  return this.fetch(`/api/broadcast/${encodeURIComponent(channel)}/scene`);
+};
+
+MiladyClient.prototype.getCompanionStageState = async function (
+  this: MiladyClient,
+) {
+  // Public broadcast viewers are not allowed through the authenticated
+  // companion endpoint. Use the unauthenticated broadcast stage route for the
+  // public camera-only transport, matching the legacy monolithic client.
+  if (typeof window !== "undefined") {
+    const pathMatch = window.location.pathname.match(
+      /^\/broadcast\/([a-zA-Z0-9-]+)\/?$/,
+    );
+    const hasInjectedConfig = !!(
+      window as unknown as { __injectedShowConfig?: unknown }
+    ).__injectedShowConfig;
+    if (pathMatch && !hasInjectedConfig) {
+      const channel = pathMatch[1];
+      if (channel === "alice-cam") {
+        return this.fetch(`/api/broadcast/${encodeURIComponent(channel)}/stage`);
+      }
+    }
+  }
+  return this.fetch("/api/companion/stage");
+};
+
+MiladyClient.prototype.setCompanionStageState = async function (
+  this: MiladyClient,
+  patch,
+) {
+  return this.fetch("/api/companion/stage", {
+    method: "POST",
+    body: JSON.stringify({ patch }),
   });
 };
 

--- a/packages/app-core/src/api/client-types-core.ts
+++ b/packages/app-core/src/api/client-types-core.ts
@@ -126,6 +126,26 @@ export interface TradePermissionModeResponse {
   options: TradePermissionMode[];
 }
 
+export type EmoteCategory =
+  | "greeting"
+  | "emotion"
+  | "dance"
+  | "combat"
+  | "idle"
+  | "movement"
+  | "gesture"
+  | "other";
+
+export interface EmoteInfo {
+  id: string;
+  name: string;
+  description: string;
+  path: string;
+  duration: number;
+  loop: boolean;
+  category: EmoteCategory;
+}
+
 export interface ApplyProductionWalletDefaultsResponse {
   ok: boolean;
   profile: "pure-privy-safe";

--- a/packages/app-core/src/api/client.ts
+++ b/packages/app-core/src/api/client.ts
@@ -105,6 +105,11 @@ import type { ConfigUiHint } from "../types";
 import { stripAssistantStageDirections } from "../utils/assistant-text";
 import { getElizaApiBase, getElizaApiToken } from "../utils/eliza-globals";
 import { mergeStreamingText } from "../utils/streaming-text";
+import type {
+  AppRunSummary,
+  CodingAgentTaskThread,
+  LifeOpsOverview,
+} from "./client-types";
 
 export type {
   AllPermissionsState,
@@ -4214,6 +4219,9 @@ export class MiladyClient {
   async listInstalledApps(): Promise<InstalledAppInfo[]> {
     return this.fetch("/api/apps/installed");
   }
+  async listAppRuns(): Promise<AppRunSummary[]> {
+    return this.fetch("/api/apps/runs");
+  }
   async stopApp(name: string): Promise<AppStopResult> {
     return this.fetch("/api/apps/stop", {
       method: "POST",
@@ -4528,6 +4536,10 @@ export class MiladyClient {
     }
   > {
     return this.fetch("/api/workbench/overview");
+  }
+
+  async getLifeOpsOverview(): Promise<LifeOpsOverview> {
+    return this.fetch("/api/lifeops/overview");
   }
 
   async listWorkbenchTasks(): Promise<{ tasks: WorkbenchTask[] }> {
@@ -6055,6 +6067,25 @@ export class MiladyClient {
     } catch {
       return null;
     }
+  }
+
+  async listCodingAgentTaskThreads(options?: {
+    includeArchived?: boolean;
+    status?: string;
+    search?: string;
+    limit?: number;
+  }): Promise<CodingAgentTaskThread[]> {
+    const params = new URLSearchParams();
+    if (options?.includeArchived) params.set("includeArchived", "true");
+    if (options?.status) params.set("status", options.status);
+    if (options?.search) params.set("search", options.search);
+    if (typeof options?.limit === "number" && options.limit > 0) {
+      params.set("limit", String(options.limit));
+    }
+    const query = params.toString();
+    return this.fetch<CodingAgentTaskThread[]>(
+      `/api/coding-agents/coordinator/threads${query ? `?${query}` : ""}`,
+    );
   }
 
   async stopCodingAgent(sessionId: string): Promise<boolean> {

--- a/packages/app-core/src/api/index.ts
+++ b/packages/app-core/src/api/index.ts
@@ -1,1 +1,7 @@
 export * from "./client";
+export type {
+  AppRunSummary,
+  CodingAgentTaskThread,
+  CodingAgentTaskThreadDetail,
+  LifeOpsOverview,
+} from "./client-types";

--- a/packages/app-core/src/api/plugins-compat-routes.test.ts
+++ b/packages/app-core/src/api/plugins-compat-routes.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import * as configModule from "@miladyai/agent/config/config";
 import {
   loadElizaConfig,
   saveElizaConfig,
@@ -234,6 +235,54 @@ describe("buildPluginListResponse", () => {
     });
     expect(telegram.configured).toBe(true);
     expect(telegram.validationErrors).toEqual([]);
+  });
+
+  it("falls back to runtime-only plugins when registry metadata is unavailable", async () => {
+    process.env.ELIZA_API_TOKEN = "test-api-token";
+    const loadSpy = vi
+      .spyOn(configModule, "loadElizaConfig")
+      .mockImplementation(() => {
+        throw new Error("missing registry entries");
+      });
+
+    try {
+      const req = createAsyncJsonRequest(
+        {},
+        {
+          method: "GET",
+          url: "/api/plugins",
+          headers: {
+            authorization: "Bearer test-api-token",
+            host: "localhost:3000",
+          },
+        },
+      );
+      const { res, getJson, getStatus } = createMockHttpResponse<{
+        plugins: Array<Record<string, unknown>>;
+      }>();
+      const state = {
+        current: {
+          plugins: [{ name: "@elizaos/plugin-openai" }],
+        } as never,
+        pendingAgentName: null,
+        pendingRestartReasons: [],
+      };
+
+      const handled = await handlePluginsCompatRoutes(req, res, state);
+
+      expect(handled).toBe(true);
+      expect(getStatus()).toBe(200);
+      expect(getJson().plugins).toEqual([
+        expect.objectContaining({
+          id: "openai",
+          enabled: true,
+          isActive: true,
+          source: "runtime",
+        }),
+      ]);
+    } finally {
+      loadSpy.mockRestore();
+    }
   });
 
   it("marks Discord toggles as pending restart on the compat API route", async () => {

--- a/packages/app-core/src/api/plugins-compat-routes.ts
+++ b/packages/app-core/src/api/plugins-compat-routes.ts
@@ -610,6 +610,39 @@ function resolveLoadedPluginNames(runtime: AgentRuntime | null): Set<string> {
   return loadedNames;
 }
 
+function buildRuntimeOnlyPluginListResponse(runtime: AgentRuntime | null): {
+  plugins: Array<Record<string, unknown>>;
+} {
+  const plugins = Array.from(resolveLoadedPluginNames(runtime))
+    .sort((a, b) => a.localeCompare(b))
+    .map((pluginName) => {
+      const pluginId = normalizePluginId(pluginName);
+      return {
+        id: pluginId,
+        name: titleCasePluginId(pluginId),
+        description: "",
+        tags: [],
+        enabled: true,
+        configured: true,
+        category: "feature" satisfies PluginCategory,
+        source: "runtime",
+        configKeys: [],
+        parameters: [],
+        validationErrors: [],
+        validationWarnings: [
+          {
+            message:
+              "Plugin registry metadata was unavailable; showing runtime-loaded plugins only.",
+          },
+        ],
+        npmName: pluginName,
+        isActive: true,
+      };
+    });
+
+  return { plugins };
+}
+
 function isPluginLoaded(
   pluginId: string,
   npmName: string | undefined,
@@ -1012,7 +1045,15 @@ export async function handlePluginsCompatRoutes(
       return true;
     }
 
-    const pluginResponse = buildPluginListResponse(state.current);
+    let pluginResponse: ReturnType<typeof buildPluginListResponse>;
+    try {
+      pluginResponse = buildPluginListResponse(state.current);
+    } catch (err) {
+      logger.warn(
+        `[api/plugins] failed to build registry-backed plugin list; falling back to runtime-only list: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      pluginResponse = buildRuntimeOnlyPluginListResponse(state.current);
+    }
     const manifestPath = resolvePluginManifestPath();
     logger.debug(
       `[api/plugins] manifest=${manifestPath ?? "NOT_FOUND"} total=${pluginResponse.plugins.length} runtime=${state.current ? "active" : "null"}`,

--- a/scripts/init-submodules.mjs
+++ b/scripts/init-submodules.mjs
@@ -33,7 +33,15 @@ const SUBMODULE_READINESS_MARKERS = {
 // typescript/ that Windows git rejects as invalid filenames. Skip checkout
 // until elizaos-plugins/plugin-openrouter#25 is merged; the package is
 // available via npm in the meantime.
-const SKIP_SUBMODULES = new Set(["plugins/plugin-openrouter"]);
+//
+// elizaOS/cloud and elizaOS/clone-your-crush are optional upstream repos that
+// are private or moved. They are not required for the Milady/Alice runtime
+// image, so deploy builds must not fail when GitHub returns 404 for them.
+const SKIP_SUBMODULES = new Set([
+  "plugins/plugin-openrouter",
+  "cloud",
+  "examples/clone-your-crush",
+]);
 
 function getSubmoduleSkipReason(
   submodulePath,

--- a/scripts/init-submodules.test.ts
+++ b/scripts/init-submodules.test.ts
@@ -33,6 +33,15 @@ describe("shouldSkipSubmoduleInit", () => {
     ).toBe(true);
   });
 
+  it("skips optional upstream repos that are not required for runtime deploys", () => {
+    expect(shouldSkipSubmoduleInit("cloud", { skipLocal: false })).toBe(true);
+    expect(
+      shouldSkipSubmoduleInit("examples/clone-your-crush", {
+        skipLocal: false,
+      }),
+    ).toBe(true);
+  });
+
   it("skips the repo-local eliza checkout when local upstreams are disabled", () => {
     expect(shouldSkipSubmoduleInit("eliza", { skipLocal: true })).toBe(true);
     expect(


### PR DESCRIPTION
## Summary
- restores the currently-exported app client methods missing in prod (`getLifeOpsOverview`, `listAppRuns`, `listCodingAgentTaskThreads`)
- adds a barrel regression test for the exact dashboard methods used by the app shell
- makes `/api/plugins` fail soft to runtime-loaded plugins if registry metadata packaging is missing
- skips optional/moved upstream submodules (`cloud`, `examples/clone-your-crush`) so Alice bot deploy builds do not fail on GitHub 404s

## Verification
- `node --experimental-strip-types --check packages/app-core/src/api/client.ts`
- `node --experimental-strip-types --check packages/app-core/src/api/client-agent.ts`
- `node --experimental-strip-types --check packages/app-core/src/api/plugins-compat-routes.ts`
- `node --experimental-strip-types --check packages/app-core/src/api/index.ts`
- `node --experimental-strip-types --check packages/app-core/src/api/api-barrel-client.test.ts`
- `node --experimental-strip-types --check packages/app-core/src/api/plugins-compat-routes.test.ts`
- `node --experimental-strip-types --check scripts/init-submodules.mjs`
- `node --experimental-strip-types --check scripts/init-submodules.test.ts`
- `bunx vitest run scripts/init-submodules.test.ts`
- `git diff --check`

## Verification gap
Full app-core vitest cannot run in this clean worktree because `bun install` fails before install: the repo references absent `eliza/apps/*` workspaces until submodules are initialized.
