### PR TITLE
fix: harden Alice prod runtime serving paths

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -6372,6 +6372,8 @@ async function handleRequest(
       method === "GET" && pathname === "/api/coding-agents/coordinator/status";
     const isPreflightRoute =
       method === "GET" && pathname === "/api/coding-agents/preflight";
+    const isCodingAgentsRootRoute =
+      method === "GET" && pathname === "/api/coding-agents";
 
     // Try to dynamically load the route handler from the local plugin first
     let handled = false;
@@ -6402,6 +6404,7 @@ async function handleRequest(
     // PTY/coordinator services are not ready yet, prefer the built-in graceful
     // fallback response over the plugin's hard 503.
     if (
+      (isCodingAgentsRootRoute && !ptyService) ||
       (isCoordinatorStatusRoute && !coordinator) ||
       (isPreflightRoute && !ptyService)
     ) {

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -174,23 +174,23 @@ import {
 } from "./chat-routes.js";
 import { handleCloudBillingRoute } from "./cloud-billing-routes.js";
 import { handleCloudCompatRoute } from "./cloud-compat-routes.js";
-import { isCloudflareAccessAuthenticated } from "./cloudflare-access-auth.js";
 import { isCloudProvisionedContainer } from "./cloud-provisioning.js";
 import { handleCloudRelayRoute } from "./cloud-relay-routes.js";
 import { type CloudRouteState, handleCloudRoute } from "./cloud-routes.js";
 import { handleCloudStatusRoutes } from "./cloud-status-routes.js";
+import { isCloudflareAccessAuthenticated } from "./cloudflare-access-auth.js";
 import { extractCompatTextContent } from "./compat-utils.js";
 import { handleConfigRoutes } from "./config-routes.js";
 import { ConnectorHealthMonitor } from "./connector-health.js";
 import { handleConnectorRoutes } from "./connector-routes.js";
 import { handleConversationRoutes } from "./conversation-routes.js";
-import { handleCrossChannelIngestRoutes } from "./cross-channel-ingest-routes.js";
 import type {
   SwarmEvent,
   TaskCompletionSummary,
   TaskContext,
 } from "./coordinator-types.js";
 import { wireCoordinatorBridgesWhenReady } from "./coordinator-wiring.js";
+import { handleCrossChannelIngestRoutes } from "./cross-channel-ingest-routes.js";
 import { handleDatabaseRoute } from "./database.js";
 import { handleDiagnosticsRoutes } from "./diagnostics-routes.js";
 import { handleDiscordLocalRoute } from "./discord-local-routes.js";
@@ -717,7 +717,9 @@ export interface ServerState {
     import("../services/signal-pairing.js").SignalPairingSnapshot
   >;
   /** Active Telegram account auth session (user-account login flow). */
-  telegramAccountAuthSession?: import("../services/telegram-account-auth.js").TelegramAccountAuthSessionLike | null;
+  telegramAccountAuthSession?:
+    | import("../services/telegram-account-auth.js").TelegramAccountAuthSessionLike
+    | null;
 }
 
 export interface ShareIngestItem {
@@ -5817,8 +5819,7 @@ async function handleRequest(
       routeState,
       { json, error, readJsonBody },
       {
-        createAuthSession: (options) =>
-          new TelegramAccountAuthSession(options),
+        createAuthSession: (options) => new TelegramAccountAuthSession(options),
         authStateExists: telegramAccountAuthStateExists,
         sessionExists: telegramAccountSessionExists,
         clearAuthState: clearTelegramAccountAuthState,

--- a/packages/app-core/src/api/__tests__/client-coding-agent-fallback.test.ts
+++ b/packages/app-core/src/api/__tests__/client-coding-agent-fallback.test.ts
@@ -148,6 +148,33 @@ describe("MiladyClient.listCodingAgentScratchWorkspaces", () => {
   });
 });
 
+describe("MiladyClient.getCodingAgentStatus", () => {
+  it("does not poll /api/coding-agents when coordinator returns an empty tasks array", async () => {
+    const client = new MiladyClient("http://127.0.0.1:31337");
+    const fetchSpy = vi.spyOn(
+      client as unknown as {
+        fetch: (path: string, init?: RequestInit) => Promise<unknown>;
+      },
+      "fetch",
+    );
+    fetchSpy.mockResolvedValueOnce({
+      supervisionLevel: "autonomous",
+      taskCount: 0,
+      tasks: [],
+      pendingConfirmations: 0,
+    });
+
+    await expect(client.getCodingAgentStatus()).resolves.toMatchObject({
+      taskCount: 0,
+      tasks: [],
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/coding-agents/coordinator/status",
+    );
+  });
+});
+
 describe("MiladyClient task thread APIs", () => {
   it("propagates persisted task thread list failures instead of masking them", async () => {
     const client = new MiladyClient("http://127.0.0.1:31337");

--- a/packages/app-core/src/api/__tests__/client-coding-agent-fallback.test.ts
+++ b/packages/app-core/src/api/__tests__/client-coding-agent-fallback.test.ts
@@ -7,9 +7,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   MiladyClient,
-  type RawPtySession,
   mapPtySessionsToCodingAgentSessions,
   mapTaskThreadsToCodingAgentSessions,
+  type RawPtySession,
 } from "../client";
 
 describe("mapPtySessionsToCodingAgentSessions", () => {

--- a/packages/app-core/src/api/client.ts
+++ b/packages/app-core/src/api/client.ts
@@ -1531,6 +1531,8 @@ export interface CodingAgentStatus {
   taskCount: number;
   tasks: CodingAgentSession[];
   pendingConfirmations: number;
+  taskThreadCount?: number;
+  taskThreads?: CodingAgentTaskThread[];
 }
 
 /** Raw PTY session shape returned by /api/coding-agents. */
@@ -1570,6 +1572,37 @@ export function mapPtySessionsToCodingAgentSessions(
             : ("active" as const),
     decisionCount: 0,
     autoResolvedCount: 0,
+  }));
+}
+
+export function mapTaskThreadsToCodingAgentSessions(
+  taskThreads: CodingAgentTaskThread[],
+): CodingAgentSession[] {
+  return taskThreads.map((thread) => ({
+    sessionId: thread.latestSessionId ?? thread.id,
+    agentType: "task-thread",
+    label: thread.title || thread.latestSessionLabel || "Task",
+    originalTask: thread.originalRequest,
+    workdir: thread.latestWorkdir ?? thread.latestRepo ?? "",
+    status:
+      thread.status === "failed"
+        ? ("error" as const)
+        : thread.status === "done"
+          ? ("completed" as const)
+          : thread.status === "interrupted"
+            ? ("stopped" as const)
+            : thread.status === "validating"
+              ? ("tool_running" as const)
+              : thread.status === "blocked" ||
+                  thread.status === "waiting_on_user"
+                ? ("blocked" as const)
+                : ("active" as const),
+    decisionCount: thread.decisionCount,
+    autoResolvedCount: 0,
+    lastActivity:
+      thread.status === "interrupted"
+        ? "Interrupted - reopen or resume this task"
+        : thread.summary || thread.latestSessionLabel || thread.status,
   }));
 }
 
@@ -6048,10 +6081,19 @@ export class MiladyClient {
       const status = await this.fetch<CodingAgentStatus>(
         "/api/coding-agents/coordinator/status",
       );
-      // If coordinator returned but tasks is empty, fall back to ptyService
-      // session list so the UI shows active PTY sessions even when the
-      // coordinator hasn't registered them yet.
-      if (status && (!status.tasks || status.tasks.length === 0)) {
+      if (
+        status &&
+        (!status.tasks || status.tasks.length === 0) &&
+        Array.isArray(status.taskThreads) &&
+        status.taskThreads.length > 0
+      ) {
+        status.tasks = mapTaskThreadsToCodingAgentSessions(status.taskThreads);
+        status.taskCount = status.tasks.length;
+      }
+      // Only fall back to the legacy root list when the coordinator omitted
+      // tasks entirely. An explicit empty array is authoritative; polling the
+      // old plugin root in that state causes production console 503 storms.
+      if (status && !status.tasks) {
         try {
           const ptySessions =
             await this.fetch<RawPtySession[]>("/api/coding-agents");

--- a/packages/app-core/src/api/client.ts
+++ b/packages/app-core/src/api/client.ts
@@ -81,11 +81,6 @@ import type {
   WalletTradingProfileSourceFilter,
   WalletTradingProfileWindow,
 } from "@miladyai/agent/contracts/wallet";
-import type { AvatarSpeechManifest } from "@miladyai/shared/contracts";
-import type {
-  CaptureLifeOpsActivitySignalRequest,
-  LifeOpsActivitySignal,
-} from "@miladyai/shared/contracts/lifeops";
 import {
   DEFAULT_WALLET_RPC_SELECTIONS,
   normalizeWalletRpcProviderId,
@@ -97,6 +92,11 @@ import {
   sanitizeForSettingsDebug,
   settingsDebugCloudSummary,
 } from "@miladyai/shared";
+import type { AvatarSpeechManifest } from "@miladyai/shared/contracts";
+import type {
+  CaptureLifeOpsActivitySignalRequest,
+  LifeOpsActivitySignal,
+} from "@miladyai/shared/contracts/lifeops";
 import type {
   CompanionStageState,
   PartialCompanionStageState,
@@ -2363,7 +2363,8 @@ export class MiladyClient {
     // Session storage can survive a prior local runtime; it must not beat the
     // boot config injected by the current shell/server process.
     const bootBase = getBootConfig().apiBase;
-    this._baseUrl = baseUrl ?? bootBase ?? getElizaApiBase() ?? storedBase ?? "";
+    this._baseUrl =
+      baseUrl ?? bootBase ?? getElizaApiBase() ?? storedBase ?? "";
   }
 
   /**
@@ -2573,13 +2574,17 @@ export class MiladyClient {
     init?: RequestInit,
     options?: { allowNonOk?: boolean; timeoutMs?: number },
   ): Promise<T> {
-    const res = await this.rawRequest(path, {
-      ...init,
-      headers: {
-        "Content-Type": "application/json",
-        ...init?.headers,
+    const res = await this.rawRequest(
+      path,
+      {
+        ...init,
+        headers: {
+          "Content-Type": "application/json",
+          ...init?.headers,
+        },
       },
-    }, options);
+      options,
+    );
     return res.json() as Promise<T>;
   }
 
@@ -3944,9 +3949,7 @@ export class MiladyClient {
     return this.fetch("/api/wallet/steward-pending-approvals");
   }
 
-  async approveStewardTx(
-    txId: string,
-  ): Promise<StewardApprovalActionResponse> {
+  async approveStewardTx(txId: string): Promise<StewardApprovalActionResponse> {
     return this.fetch("/api/wallet/steward-approve-tx", {
       method: "POST",
       body: JSON.stringify({ txId }),
@@ -4231,9 +4234,7 @@ export class MiladyClient {
     }
 
     try {
-      const stored = localStorage
-        .getItem("milady.arcade555.sessionId")
-        ?.trim();
+      const stored = localStorage.getItem("milady.arcade555.sessionId")?.trim();
       if (stored) return stored;
       localStorage.setItem("milady.arcade555.sessionId", fallback);
     } catch {

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -47,7 +47,7 @@ import {
   getConfiguredCompatAgentName,
   hasCompatPersistedOnboardingState,
   isLoopbackRemoteAddress,
-  readCompatJsonBody,
+  readCompatJsonBody as readCompatJsonBodyShared,
   type CompatRuntimeState,
 } from "./compat-route-shared";
 
@@ -631,7 +631,7 @@ async function handleCompatMiscRoutes(
       sendJsonErrorResponse(targetRes, status, message);
     },
     readJsonBody: async <T extends object>(targetReq, targetRes) =>
-      (await readCompatJsonBody(targetReq, targetRes)) as T | null,
+      (await readCompatJsonBodyShared(targetReq, targetRes)) as T | null,
     AGENT_EVENT_ALLOWED_STREAMS,
     resolveTerminalRunRejection,
     resolveTerminalRunClientId,

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -38,19 +38,27 @@ import {
   getCompatApiToken,
 } from "./auth";
 import {
-  sendJsonError as sendJsonErrorResponse,
-  sendJson as sendJsonResponse,
-} from "./response";
-import {
-  DATABASE_UNAVAILABLE_MESSAGE,
+  type CompatRuntimeState,
   clearCompatRuntimeRestart,
+  DATABASE_UNAVAILABLE_MESSAGE,
   getConfiguredCompatAgentName,
   hasCompatPersistedOnboardingState,
   isLoopbackRemoteAddress,
   readCompatJsonBody as readCompatJsonBodyShared,
-  type CompatRuntimeState,
 } from "./compat-route-shared";
+import {
+  sendJsonError as sendJsonErrorResponse,
+  sendJson as sendJsonResponse,
+} from "./response";
 
+export {
+  type CompatRuntimeState,
+  DATABASE_UNAVAILABLE_MESSAGE,
+  getConfiguredCompatAgentName,
+  hasCompatPersistedOnboardingState,
+  isLoopbackRemoteAddress,
+  readCompatJsonBody,
+} from "./compat-route-shared";
 export {
   __resetCloudBaseUrlCache,
   ensureCloudTtsApiKeyAlias,
@@ -61,12 +69,12 @@ export {
   filterConfigEnvForResponse,
   SENSITIVE_ENV_RESPONSE_KEYS,
 } from "./server-config-filter";
-export { injectApiBaseIntoHtml } from "./server-html";
 export {
   buildCorsAllowedPorts,
   invalidateCorsAllowedPorts,
   isAllowedLocalOrigin,
 } from "./server-cors";
+export { injectApiBaseIntoHtml } from "./server-html";
 // Re-export helpers from split-out modules so tests can import from "./server"
 export {
   ensureApiTokenForBindHost,
@@ -100,14 +108,6 @@ export {
   streamResponseBodyWithByteLimit,
   validateMcpServerConfig,
 };
-export {
-  DATABASE_UNAVAILABLE_MESSAGE,
-  getConfiguredCompatAgentName,
-  hasCompatPersistedOnboardingState,
-  isLoopbackRemoteAddress,
-  readCompatJsonBody,
-  type CompatRuntimeState,
-} from "./compat-route-shared";
 
 import { initStewardWalletCache } from "@miladyai/agent/api/wallet";
 import {
@@ -116,13 +116,13 @@ import {
   saveElizaConfig,
 } from "@miladyai/agent/config/config";
 import { resolveUserPath } from "@miladyai/agent/config/paths";
-import { buildCharacterFromConfig } from "../runtime/eliza";
 import { resolveDefaultAgentWorkspaceDir } from "@miladyai/agent/providers/workspace";
 import {
   isMiladySettingsDebugEnabled,
   sanitizeForSettingsDebug,
   settingsDebugCloudSummary,
 } from "@miladyai/shared";
+import { buildCharacterFromConfig } from "../runtime/eliza";
 import {
   ensureRuntimeSqlCompatibility,
   executeRawSql,
@@ -130,35 +130,35 @@ import {
   sanitizeIdentifier,
   sqlLiteral,
 } from "../utils/sql-compat";
+import { handleAuthPairingCompatRoutes } from "./auth-pairing-compat-routes";
 import { handleCloudRoute } from "./cloud-routes";
 import { handleCloudStatusRoutes } from "./cloud-status-routes";
+import { handleDatabaseRowsCompatRoute } from "./database-rows-compat-routes";
+import { handleDevCompatRoutes } from "./dev-compat-routes";
+import {
+  isAllowedDevConsoleLogPath,
+  readDevConsoleLogTail,
+} from "./dev-console-log";
+import { resolveDevStackFromEnv } from "./dev-stack";
+import { handleOnboardingCompatRoute } from "./onboarding-compat-routes";
+import { handlePluginsCompatRoutes } from "./plugins-compat-routes";
 import {
   buildCorsAllowedPorts,
   getCorsAllowedPorts,
   isAllowedLocalOrigin,
 } from "./server-cors";
-import { handleShopifyRoute } from "./shopify-routes";
-import { handleVincentRoute } from "./vincent-routes";
-import {
-  isAllowedDevConsoleLogPath,
-  readDevConsoleLogTail,
-} from "./dev-console-log";
-import { handleAuthPairingCompatRoutes } from "./auth-pairing-compat-routes";
 import { isCloudProvisioned as _isCloudProvisioned } from "./server-onboarding-compat";
-import { handleDatabaseRowsCompatRoute } from "./database-rows-compat-routes";
-import { handleDevCompatRoutes } from "./dev-compat-routes";
-import { handleOnboardingCompatRoute } from "./onboarding-compat-routes";
-import { handlePluginsCompatRoutes } from "./plugins-compat-routes";
-import { handleWalletBrowserCompatRoutes } from "./wallet-browser-compat-routes";
-import { handleWalletTradeCompatRoutes } from "./wallet-trade-compat-routes";
+import { handleShopifyRoute } from "./shopify-routes";
 import { handleStewardCompatRoutes } from "./steward-compat-routes";
-import { handleWorkbenchCompatRoutes } from "./workbench-compat-routes";
+import { handleVincentRoute } from "./vincent-routes";
+import { handleWalletBrowserCompatRoutes } from "./wallet-browser-compat-routes";
 import { handleWalletCompatRoutes } from "./wallet-compat-routes";
-import { resolveDevStackFromEnv } from "./dev-stack";
+import { handleWalletTradeCompatRoutes } from "./wallet-trade-compat-routes";
+import { handleWorkbenchCompatRoutes } from "./workbench-compat-routes";
 
 const require = createRequire(import.meta.url);
 
-import { syncMiladyEnvToEliza, syncElizaEnvToMilady } from "../utils/env.js";
+import { syncElizaEnvToMilady, syncMiladyEnvToEliza } from "../utils/env.js";
 
 // Lazy-imported to avoid circular dependency with runtime/eliza.ts
 const lazyEnsureTTS = () =>
@@ -180,6 +180,7 @@ import {
   mirrorCompatHeaders,
 } from "./server-cloud-tts";
 import { filterConfigEnvForResponse as _filterConfigEnvForResponse } from "./server-config-filter";
+
 // ---------------------------------------------------------------------------
 // Module-level constants and types that stay in server.ts
 // ---------------------------------------------------------------------------
@@ -1211,16 +1212,12 @@ export function patchHttpCreateServerForMiladyCompat(
       ) {
         const ready = Boolean(state?.current);
         const isReadyRoute = pathname === "/health/ready";
-        sendJsonResponse(
-          res,
-          isReadyRoute && !ready ? 503 : 200,
-          {
-            ok: isReadyRoute ? ready : true,
-            ready,
-            agentState: ready ? "running" : "starting",
-            uptime: Math.floor(process.uptime()),
-          },
-        );
+        sendJsonResponse(res, isReadyRoute && !ready ? 503 : 200, {
+          ok: isReadyRoute ? ready : true,
+          ready,
+          agentState: ready ? "running" : "starting",
+          uptime: Math.floor(process.uptime()),
+        });
         return;
       }
 

--- a/packages/app-core/src/components/shell/ShellOverlays.test.tsx
+++ b/packages/app-core/src/components/shell/ShellOverlays.test.tsx
@@ -47,6 +47,9 @@ describe("ShellOverlays", () => {
     const className = String(status.props.className);
 
     expect(className).toContain("bg-accent text-accent-fg");
+    expect(className).toContain(
+      "bottom-[calc(var(--safe-area-bottom,0px)+6.5rem)]",
+    );
     expect(className).not.toContain("text-white");
   });
 

--- a/packages/app-core/src/components/shell/ShellOverlays.tsx
+++ b/packages/app-core/src/components/shell/ShellOverlays.tsx
@@ -1,8 +1,8 @@
 import { Spinner, Z_SHELL_OVERLAY } from "@miladyai/ui";
 import type { ActionNotice } from "../../state/types";
+import { GlobalEmoteOverlay } from "../companion/GlobalEmoteOverlay";
 import { BugReportModal } from "./BugReportModal";
 import { CommandPalette } from "./CommandPalette";
-import { GlobalEmoteOverlay } from "../companion/GlobalEmoteOverlay";
 import { RestartBanner } from "./RestartBanner";
 import { ShortcutsOverlay } from "./ShortcutsOverlay";
 

--- a/packages/app-core/src/components/shell/ShellOverlays.tsx
+++ b/packages/app-core/src/components/shell/ShellOverlays.tsx
@@ -20,7 +20,7 @@ export function ShellOverlays({
       <GlobalEmoteOverlay />
       {actionNotice && (
         <div
-          className={`fixed bottom-6 left-1/2 -translate-x-1/2 px-5 py-2.5 rounded-lg text-[13px] font-medium z-[${Z_SHELL_OVERLAY}] flex items-center gap-2.5 max-w-[min(92vw,28rem)] ${
+          className={`fixed bottom-[calc(var(--safe-area-bottom,0px)+6.5rem)] left-1/2 -translate-x-1/2 px-5 py-2.5 rounded-lg text-[13px] font-medium z-[${Z_SHELL_OVERLAY}] flex items-center gap-2.5 max-w-[min(92vw,28rem)] ${
             actionNotice.tone === "error"
               ? "bg-danger text-white"
               : actionNotice.tone === "success"

--- a/scripts/release-check.test.ts
+++ b/scripts/release-check.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   bundlesDependency,
   findFloatingDependencySpecs,
+  findAliceRuntimeDistIssues,
   findLocalPackHotspots,
   findMismatchedSharedAgentDependencySpecs,
   findMissingPatchedElectrobunCliSnippets,
@@ -66,6 +67,45 @@ describe("release-check local pack behavior", () => {
 });
 
 describe("release-check package guards", () => {
+  it("flags Alice production runtime dist that can reproduce the prod API breakage", () => {
+    expect(
+      findAliceRuntimeDistIssues({
+        appCoreServer:
+          'import { readCompatJsonBody as readCompatJsonBody$1 } from "./compat-route-shared.js";\nawait readCompatJsonBody(req, res);',
+        agentConversationRoutes:
+          'if (pathname === "/api/conversations/:id/messages") return true;',
+        agentServer:
+          'if (pathname === "/api/coding-agents") error(res, "Coding agent task service unavailable", 503);',
+      }),
+    ).toEqual([
+      {
+        id: "app-core-unbound-readCompatJsonBody",
+        path: "dist/api/server.js",
+      },
+      {
+        id: "agent-conversation-operator-action-missing",
+        path: "dist/agent/src/api/conversation-routes.js",
+      },
+      {
+        id: "agent-coding-agents-graceful-empty-missing",
+        path: "dist/agent/src/api/server.js",
+      },
+    ]);
+  });
+
+  it("accepts Alice production runtime dist with bound compat body calls and graceful API routes", () => {
+    expect(
+      findAliceRuntimeDistIssues({
+        appCoreServer:
+          'import { readCompatJsonBody as readCompatJsonBody$1 } from "./compat-route-shared.js";\nawait readCompatJsonBody$1(req, res);',
+        agentConversationRoutes:
+          'method === "POST" && /^\\/api\\/conversations\\/[^/]+\\/operator-action$/.test(pathname)',
+        agentServer:
+          'if (pathname === "/api/coding-agents") { json(res, []); return true; }',
+      }),
+    ).toEqual([]);
+  });
+
   it("treats parent directory file entries as covering required publish files", () => {
     expect(
       isPackPathCoveredByFilesList("dist/index.js", [

--- a/scripts/release-check.test.ts
+++ b/scripts/release-check.test.ts
@@ -4,8 +4,8 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   bundlesDependency,
-  findFloatingDependencySpecs,
   findAliceRuntimeDistIssues,
+  findFloatingDependencySpecs,
   findLocalPackHotspots,
   findMismatchedSharedAgentDependencySpecs,
   findMissingPatchedElectrobunCliSnippets,

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -39,6 +39,11 @@ const autonomousElizaPathCandidates = [
 const homepageReleaseDataPathCandidates = [
   "apps/web/src/generated/release-data.ts",
 ] as const;
+const aliceRuntimeDistPaths = {
+  appCoreServer: "dist/api/server.js",
+  agentConversationRoutes: "dist/agent/src/api/conversation-routes.js",
+  agentServer: "dist/agent/src/api/server.js",
+} as const;
 const requiredWorkflowSnippets = [
   'BUN_VERSION: "1.3.9"',
   "workflow_call:",
@@ -187,6 +192,57 @@ export function findMissingRequiredSnippets(
   snippets: readonly string[],
 ): string[] {
   return snippets.filter((snippet) => !content.includes(snippet));
+}
+
+export type AliceRuntimeDistSources = {
+  appCoreServer: string;
+  agentConversationRoutes: string;
+  agentServer: string;
+};
+
+export type AliceRuntimeDistIssue = {
+  id:
+    | "app-core-unbound-readCompatJsonBody"
+    | "agent-conversation-operator-action-missing"
+    | "agent-coding-agents-graceful-empty-missing";
+  path: string;
+};
+
+export function findAliceRuntimeDistIssues(
+  sources: AliceRuntimeDistSources,
+): AliceRuntimeDistIssue[] {
+  const issues: AliceRuntimeDistIssue[] = [];
+  const exactUnboundCompatReaderCall =
+    /(^|[^\w$])readCompatJsonBody\s*\(/m.test(sources.appCoreServer);
+
+  if (exactUnboundCompatReaderCall) {
+    issues.push({
+      id: "app-core-unbound-readCompatJsonBody",
+      path: aliceRuntimeDistPaths.appCoreServer,
+    });
+  }
+
+  if (!sources.agentConversationRoutes.includes("operator-action")) {
+    issues.push({
+      id: "agent-conversation-operator-action-missing",
+      path: aliceRuntimeDistPaths.agentConversationRoutes,
+    });
+  }
+
+  const hasCodingAgentsRootRoute = sources.agentServer.includes(
+    'pathname === "/api/coding-agents"',
+  );
+  const hasGracefulEmptyResponse =
+    sources.agentServer.includes("json(res, [])") ||
+    sources.agentServer.includes("json(res,[])");
+  if (!hasCodingAgentsRootRoute || !hasGracefulEmptyResponse) {
+    issues.push({
+      id: "agent-coding-agents-graceful-empty-missing",
+      path: aliceRuntimeDistPaths.agentServer,
+    });
+  }
+
+  return issues;
 }
 
 const forbiddenWorkflowSnippets = [
@@ -1211,6 +1267,42 @@ function assertStaticAssetManifestIsCurrent() {
   process.exit(1);
 }
 
+function assertAliceRuntimeDistLooksCurrent() {
+  const missing = Object.values(aliceRuntimeDistPaths).filter(
+    (path) => !existsSync(path),
+  );
+  if (missing.length > 0) {
+    console.error(
+      "release-check: Alice runtime root dist is missing required serving files. Run bun run build before pushing a runtime image.",
+    );
+    for (const path of missing) {
+      console.error(`  - ${path}`);
+    }
+    process.exit(1);
+  }
+
+  const sources: AliceRuntimeDistSources = {
+    appCoreServer: readFileSync(aliceRuntimeDistPaths.appCoreServer, "utf8"),
+    agentConversationRoutes: readFileSync(
+      aliceRuntimeDistPaths.agentConversationRoutes,
+      "utf8",
+    ),
+    agentServer: readFileSync(aliceRuntimeDistPaths.agentServer, "utf8"),
+  };
+  const issues = findAliceRuntimeDistIssues(sources);
+  if (issues.length === 0) {
+    return;
+  }
+
+  console.error(
+    "release-check: Alice runtime root dist is stale or unsafe for production:",
+  );
+  for (const issue of issues) {
+    console.error(`  - ${issue.id}: ${issue.path}`);
+  }
+  process.exit(1);
+}
+
 function assertHomepageReleaseDataUsesCurrentAssetRoot() {
   const releaseDataSource = readExistingReleaseCheckFile(
     "generated homepage release data",
@@ -1252,6 +1344,7 @@ function main() {
   assertServerDynamicHyperscapeImport();
   assertStartApiServerCatchBlockSafety();
   assertStaticAssetManifestIsCurrent();
+  assertAliceRuntimeDistLooksCurrent();
   assertHomepageReleaseDataUsesCurrentAssetRoot();
   maybeValidateCdnAssets();
   assertBundledAgentOrchestratorInstallFix();


### PR DESCRIPTION
## Summary
- Fixes the app-core compat body reader alias so generated root dist cannot call an unbound readCompatJsonBody symbol.
- Adds graceful root GET /api/coding-agents fallback before old plugin fallback when PTY is unavailable.
- Stops the monolithic client from polling /api/coding-agents when coordinator status already returns an explicit empty tasks array.
- Adds release checks for stale top-level Alice runtime dist: operator-action route, root coding-agent empty response, and unbound readCompatJsonBody.
- Moves action notices above the chat composer so action-log failures are visible.

## Verification
- bunx vitest run scripts/release-check.test.ts
- git diff --check

## Notes
- App-core client and ShellOverlays component tests are blocked in the clean worktree before execution because this checkout does not have the full workspace/submodule dependencies linked (missing @miladyai/agent/contracts/wallet and react).