### PR TITLE
fix(alice): patch core basic-capabilities to bypass plugin-manager barrel

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -24,6 +24,8 @@ const appCoreCompatStateRelativePath =
 const appCoreKubeHealthRelativePath = "packages/app-core/src/api/kube-health.ts";
 const appCoreTrustedLocalRequestRelativePath =
   "packages/app-core/src/api/trusted-local-request.ts";
+const coreBasicCapabilitiesRelativePath =
+  "packages/core/src/features/basic-capabilities/index.ts";
 const agentRuntimeRelativePath = "packages/agent/src/runtime/eliza.ts";
 const agentPluginResolverRelativePath =
   "packages/agent/src/runtime/plugin-resolver.ts";
@@ -1458,6 +1460,92 @@ export function applyAliceAppCoreOpenAccessPatch({
   return "applied";
 }
 
+function patchAliceCoreBasicCapabilitiesBrowserSafeSource(source) {
+  const safeMarker = '} from "../plugin-manager/security.ts";';
+  if (source.includes(safeMarker)) {
+    return source;
+  }
+
+  const anchor = `// Re-export plugin-manager security helpers (used by other plugins like
+// plugin-app-control to gate owner/admin-only actions without taking a dep
+// on @elizaos/agent, which would create a layer cycle).
+export {
+\tcreatePluginAction,
+\thasAdminAccess,
+\thasOwnerAccess,
+\ttype PluginMode,
+\tpluginAction,
+\ttype SecurityDeps,
+} from "../plugin-manager/index.ts";`;
+
+  if (!source.includes(anchor)) {
+    throw new Error(
+      "core/features/basic-capabilities/index.ts plugin-manager re-export anchor drifted",
+    );
+  }
+
+  // Re-route the re-export to the leaf source file so the browser bundle
+  // never evaluates the plugin-manager barrel. The barrel statically pulls
+  // PluginManagerService and pluginAction → plugin-handlers/create.ts which
+  // does `import fs from "fs-extra"` at the top; fs-extra wraps graceful-fs,
+  // graceful-fs reads `fs.realpath.native` at module init, and in a browser
+  // where fs is stubbed empty that lookup throws TypeError synchronously,
+  // killing SPA boot before React mounts.
+  //
+  // createPluginAction / pluginAction / PluginMode were never reachable from
+  // a browser consumer (the only references were in the agent runtime barrel
+  // features/index.ts which the browser entry never imports), so dropping
+  // them here is a pure dead-export prune.
+  const replacement = `// Re-export plugin-manager security helpers (used by other plugins like
+// plugin-app-control to gate owner/admin-only actions without taking a dep
+// on @elizaos/agent, which would create a layer cycle).
+//
+// Direct import from ../plugin-manager/security.ts (NOT the barrel) so the
+// browser bundle never evaluates plugin-manager/index.ts, whose static
+// imports drag PluginManagerService and pluginAction → plugin-handlers/
+// create.ts → fs-extra → graceful-fs into the SPA. graceful-fs reads
+// fs.realpath.native at module init; in a browser where fs is stubbed
+// empty, that lookup throws TypeError and kills SPA boot before React
+// mounts. createPluginAction / pluginAction / PluginMode are server-only
+// and have no browser-reachable consumer; dropping them from this re-export
+// is a pure dead-export prune.
+export {
+\thasAdminAccess,
+\thasOwnerAccess,
+\ttype SecurityDeps,
+} from "../plugin-manager/security.ts";`;
+
+  return source.replace(anchor, replacement);
+}
+
+export function applyAliceCoreBasicCapabilitiesBrowserSafePatch({
+  elizaRoot,
+  log = console.log,
+} = {}) {
+  const filePath = path.join(elizaRoot, coreBasicCapabilitiesRelativePath);
+  if (!existsSync(filePath)) {
+    log(
+      "[alice-eliza-runtime-patches] core basic-capabilities source absent; skipping browser-safe patch",
+    );
+    return "skipped";
+  }
+
+  const before = readFileSync(filePath, "utf8");
+  const after = patchAliceCoreBasicCapabilitiesBrowserSafeSource(before);
+  if (after === before) {
+    log(
+      "[alice-eliza-runtime-patches] core basic-capabilities browser-safe patch already applied",
+    );
+    return "already-applied";
+  }
+
+  writeFileSync(filePath, after);
+  log(
+    "[alice-eliza-runtime-patches] patched core basic-capabilities to bypass plugin-manager barrel for browser safety",
+  );
+  return "applied";
+}
+
 function patchAliceBundledKnowledgeStartupDeferralSource(source) {
   if (isAliceBundledKnowledgeStartupDeferralPatched(source)) {
     return source;
@@ -1706,6 +1794,7 @@ export function applyAliceElizaRuntimePatches({
   const results = [
     applyAliceRuntimeApiBindPatch({ rootDir, elizaRoot, runtimePath, log }),
     applyAliceKubeHealthReadinessPatch({ elizaRoot, log }),
+    applyAliceCoreBasicCapabilitiesBrowserSafePatch({ elizaRoot, log }),
     applyAliceAppCoreCodingAgentsFallbackPatch({ elizaRoot, log }),
     applyAliceAppCoreCompanionStagePatch({ elizaRoot, log }),
     applyAliceAppCoreOpenAccessPatch({ elizaRoot, log }),

--- a/scripts/apply-alice-eliza-runtime-patches.test.ts
+++ b/scripts/apply-alice-eliza-runtime-patches.test.ts
@@ -16,6 +16,7 @@ import {
   applyAliceAppCoreCompanionStagePatch,
   applyAliceAppCoreOpenAccessPatch,
   applyAliceBundledKnowledgeStartupDeferralPatch,
+  applyAliceCoreBasicCapabilitiesBrowserSafePatch,
   applyAliceTelegramAccountAuthResolverPatch,
   applyAliceKubeHealthReadinessPatch,
   applyAliceLifeOpsCalendarActionPatch,
@@ -331,6 +332,74 @@ describe("Alice Eliza runtime patch contract", () => {
 
       expect(
         applyAliceAppCoreCompanionStagePatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("already-applied");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("patches core basic-capabilities to bypass the plugin-manager barrel for browser safety", () => {
+    const tempDir = mkdtempSync(
+      path.join(os.tmpdir(), "alice-basic-capabilities-browser-safe-"),
+    );
+    try {
+      const dir = path.join(
+        tempDir,
+        "packages",
+        "core",
+        "src",
+        "features",
+        "basic-capabilities",
+      );
+      mkdirSync(dir, { recursive: true });
+      const filePath = path.join(dir, "index.ts");
+      const original = [
+        "// Re-export plugin-manager security helpers (used by other plugins like",
+        "// plugin-app-control to gate owner/admin-only actions without taking a dep",
+        "// on @elizaos/agent, which would create a layer cycle).",
+        "export {",
+        "\tcreatePluginAction,",
+        "\thasAdminAccess,",
+        "\thasOwnerAccess,",
+        "\ttype PluginMode,",
+        "\tpluginAction,",
+        "\ttype SecurityDeps,",
+        '} from "../plugin-manager/index.ts";',
+      ].join("\n");
+      writeFileSync(filePath, original);
+
+      expect(
+        applyAliceCoreBasicCapabilitiesBrowserSafePatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("applied");
+
+      const patched = readFileSync(filePath, "utf8");
+      // The exact safe re-export block must be present, pointed at the leaf
+      // source file rather than the plugin-manager barrel.
+      expect(patched).toContain(
+        [
+          "export {",
+          "\thasAdminAccess,",
+          "\thasOwnerAccess,",
+          "\ttype SecurityDeps,",
+          '} from "../plugin-manager/security.ts";',
+        ].join("\n"),
+      );
+      // The original tab-indented exports of the unsafe symbols must be gone
+      // from the source. Comment-text mentions are allowed (and documented).
+      expect(patched).not.toContain("\tcreatePluginAction,");
+      expect(patched).not.toContain("\tpluginAction,");
+      expect(patched).not.toContain("\ttype PluginMode,");
+      // The barrel re-export must be gone.
+      expect(patched).not.toContain('"../plugin-manager/index.ts"');
+
+      expect(
+        applyAliceCoreBasicCapabilitiesBrowserSafePatch({
           elizaRoot: tempDir,
           log: () => undefined,
         }),


### PR DESCRIPTION
## Summary

Adds \`applyAliceCoreBasicCapabilitiesBrowserSafePatch\` to the existing alice-eliza-runtime-patches chain. Re-routes \`features/basic-capabilities/index.ts\` to import security helpers directly from \`../plugin-manager/security.ts\` instead of the plugin-manager barrel.

## The bug

\`https://staging-alice.rndrntwrk.com/\` rendered a white blank page. Live pod inspection (kubectl + bundle grep on the deployed image \`sha-bb06f50-milaidy-41ce76a-build-38c8c272\`) found a TypeError thrown synchronously during module init of the bundled SPA JS:

\`\`\`
Uncaught TypeError: Cannot read properties of undefined (reading 'native')
    at main-9mVt9neL.js:7442:5934   (= graceful-fs reading fs.realpath.native)
    at main-9mVt9neL.js:2144:20332
    at main-9mVt9neL.js:7447:3629
    at main-9mVt9neL.js:2144:20332
    at main-9mVt9neL.js:8613:2470
\`\`\`

graceful-fs is in the browser bundle through this chain:

\`\`\`
index.browser.ts:17  →  features/basic-capabilities/index.ts:114
                     →  ../plugin-manager/index.ts (BARREL — side-effecting)
                     →  PluginManagerService + pluginAction
                     →  plugin-handlers/create.ts ('import fs from "fs-extra"')
                     →  fs-extra → graceful-fs
\`\`\`

graceful-fs's gracefulify() runs at module init and reads \`fs.realpath.native\`. In a browser where \`fs\` is stubbed empty, that lookup throws TypeError, the SPA dies before React mounts, and the user sees a blank page.

## What this changes

\`features/basic-capabilities/index.ts:114-121\` re-exports six symbols:

| symbol | safe? |
|---|---|
| \`hasOwnerAccess\`, \`hasAdminAccess\`, \`SecurityDeps\` | yes — \`security.ts\` only imports logger + types |
| \`createPluginAction\`, \`pluginAction\`, \`PluginMode\` | no — pulled via barrel; \`pluginAction = createPluginAction()\` runs at module init and statically imports \`plugin-handlers/create.ts\` → fs-extra |

The patch rewrites the re-export to:

\`\`\`ts
export {
	hasAdminAccess,
	hasOwnerAccess,
	type SecurityDeps,
} from "../plugin-manager/security.ts";
\`\`\`

dropping the three unsafe symbols from the basic-capabilities surface and routing the safe ones at the leaf source file (which has no side-effecting imports).

## Why dropping those three is safe

Audit across milaidy + the SPA tree found zero browser-reachable consumers of \`createPluginAction\` / \`pluginAction\` / \`PluginMode\`. The only references are:
- \`features/basic-capabilities/index.ts:115-119\` — the re-export this PR removes
- \`features/index.ts:149,161\` — agent runtime barrel, server-only, never imported by \`index.browser.ts\`

Server-side consumers continue to import these symbols from the plugin-manager barrel directly; nothing changes for them.

## Tests

\`\`\`
13 pass
 0 fail
77 expect() calls
\`\`\`

The new test mirrors the existing companion-stage and open-access patch tests: builds a fixture, applies the patch, asserts the exact safe re-export block is emitted, asserts the barrel reference and tab-indented unsafe-symbol export lines are gone, and confirms idempotence on second application.

## Contract guards (separate PR)

The companion 555stream PR adds source + compiled-bundle contract guards to \`deploy-555-bot-staging.sh\` so any future regression that re-introduces \`fs-extra\` / \`graceful-fs\` / \`pluginManagerService\` into the SPA bundle fails the deploy before the image gets pushed. Both PRs are needed to fully close the loop, but this one is the actual fix.

## Test plan post-merge

- [ ] 555-bot redeploy with milaidy at this commit
- [ ] \`grep -c GFS4 apps/app/dist/assets/main-*.js\` → 0 (currently 2)
- [ ] \`grep -c registryPluginsProvider apps/app/dist/assets/main-*.js\` → 0 (currently 1)
- [ ] \`https://staging-alice.rndrntwrk.com/\` renders a React tree (not blank)
- [ ] No \`Cannot read properties of undefined (reading 'native')\` in console