### PR TITLE
fix(alice): externalize fs-extra and graceful-fs in core browser dist

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -26,6 +26,7 @@ const appCoreTrustedLocalRequestRelativePath =
   "packages/app-core/src/api/trusted-local-request.ts";
 const coreBasicCapabilitiesRelativePath =
   "packages/core/src/features/basic-capabilities/index.ts";
+const coreBuildRelativePath = "packages/core/build.ts";
 const agentRuntimeRelativePath = "packages/agent/src/runtime/eliza.ts";
 const agentPluginResolverRelativePath =
   "packages/agent/src/runtime/plugin-resolver.ts";
@@ -1546,6 +1547,77 @@ export function applyAliceCoreBasicCapabilitiesBrowserSafePatch({
   return "applied";
 }
 
+function patchAliceCoreBuildBrowserExternalsSource(source) {
+  const safeMarker = '"fs-extra", // [milaidy:browser-externals]';
+  if (source.includes(safeMarker)) {
+    return source;
+  }
+
+  const anchor = `// Browser-specific externals (these should be provided by the host environment)
+const browserExternals = [
+\t// These will be loaded via CDN or bundled by the consuming app
+\t"sharp", // Image processing - not available in browser`;
+
+  if (!source.includes(anchor)) {
+    throw new Error(
+      "core/build.ts browserExternals anchor drifted",
+    );
+  }
+
+  /* When bun build runs without fs-extra in browserExternals, it resolves and
+   * inlines the fs-extra source code directly into dist/browser/index.browser.js
+   * (along with its graceful-fs dep). graceful-fs's gracefulify() reads
+   * fs.realpath.native at module init; in a browser where fs is stubbed empty,
+   * that lookup throws TypeError synchronously and kills SPA boot before React
+   * mounts. Marking fs-extra and graceful-fs as externals leaves bare
+   * `import "fs-extra"` / `import "graceful-fs"` in the dist, which the SPA's
+   * Vite stub plugin (apps/app/vite/native-module-stub-plugin.ts) catches and
+   * replaces with a Proxy noop stub. This is the root cause of the
+   * staging-alice white-screen crash. */
+  const replacement = `// Browser-specific externals (these should be provided by the host environment)
+const browserExternals = [
+\t// [milaidy:browser-externals] Mark fs-extra and graceful-fs as external so
+\t// they are NOT inlined into dist/browser/index.browser.js. graceful-fs's
+\t// gracefulify() reads fs.realpath.native at module init; in a browser where
+\t// fs is stubbed empty that lookup throws TypeError and kills SPA boot.
+\t// Leaving these as bare imports lets the SPA's Vite stub plugin (apps/app/
+\t// vite/native-module-stub-plugin.ts) replace them with a Proxy noop stub.
+\t"fs-extra", // [milaidy:browser-externals]
+\t"graceful-fs", // [milaidy:browser-externals]
+\t// These will be loaded via CDN or bundled by the consuming app
+\t"sharp", // Image processing - not available in browser`;
+
+  return source.replace(anchor, replacement);
+}
+
+export function applyAliceCoreBuildBrowserExternalsPatch({
+  elizaRoot,
+  log = console.log,
+} = {}) {
+  const filePath = path.join(elizaRoot, coreBuildRelativePath);
+  if (!existsSync(filePath)) {
+    log(
+      "[alice-eliza-runtime-patches] core build.ts absent; skipping browser-externals patch",
+    );
+    return "skipped";
+  }
+
+  const before = readFileSync(filePath, "utf8");
+  const after = patchAliceCoreBuildBrowserExternalsSource(before);
+  if (after === before) {
+    log(
+      "[alice-eliza-runtime-patches] core build.ts browser-externals patch already applied",
+    );
+    return "already-applied";
+  }
+
+  writeFileSync(filePath, after);
+  log(
+    "[alice-eliza-runtime-patches] patched core build.ts to externalize fs-extra and graceful-fs in the browser dist",
+  );
+  return "applied";
+}
+
 function patchAliceBundledKnowledgeStartupDeferralSource(source) {
   if (isAliceBundledKnowledgeStartupDeferralPatched(source)) {
     return source;
@@ -1795,6 +1867,7 @@ export function applyAliceElizaRuntimePatches({
     applyAliceRuntimeApiBindPatch({ rootDir, elizaRoot, runtimePath, log }),
     applyAliceKubeHealthReadinessPatch({ elizaRoot, log }),
     applyAliceCoreBasicCapabilitiesBrowserSafePatch({ elizaRoot, log }),
+    applyAliceCoreBuildBrowserExternalsPatch({ elizaRoot, log }),
     applyAliceAppCoreCodingAgentsFallbackPatch({ elizaRoot, log }),
     applyAliceAppCoreCompanionStagePatch({ elizaRoot, log }),
     applyAliceAppCoreOpenAccessPatch({ elizaRoot, log }),

--- a/scripts/apply-alice-eliza-runtime-patches.test.ts
+++ b/scripts/apply-alice-eliza-runtime-patches.test.ts
@@ -17,6 +17,7 @@ import {
   applyAliceAppCoreOpenAccessPatch,
   applyAliceBundledKnowledgeStartupDeferralPatch,
   applyAliceCoreBasicCapabilitiesBrowserSafePatch,
+  applyAliceCoreBuildBrowserExternalsPatch,
   applyAliceTelegramAccountAuthResolverPatch,
   applyAliceKubeHealthReadinessPatch,
   applyAliceLifeOpsCalendarActionPatch,
@@ -400,6 +401,51 @@ describe("Alice Eliza runtime patch contract", () => {
 
       expect(
         applyAliceCoreBasicCapabilitiesBrowserSafePatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("already-applied");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("patches core build.ts to externalize fs-extra and graceful-fs in the browser dist", () => {
+    const tempDir = mkdtempSync(
+      path.join(os.tmpdir(), "alice-core-browser-externals-"),
+    );
+    try {
+      const dir = path.join(tempDir, "packages", "core");
+      mkdirSync(dir, { recursive: true });
+      const filePath = path.join(dir, "build.ts");
+      const original = [
+        "// Browser-specific externals (these should be provided by the host environment)",
+        "const browserExternals = [",
+        "\t// These will be loaded via CDN or bundled by the consuming app",
+        '\t"sharp", // Image processing - not available in browser',
+        '\t"@hapi/shot", // Test utility - not needed in browser',
+        "];",
+      ].join("\n");
+      writeFileSync(filePath, original);
+
+      expect(
+        applyAliceCoreBuildBrowserExternalsPatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("applied");
+
+      const patched = readFileSync(filePath, "utf8");
+      expect(patched).toContain('"fs-extra", // [milaidy:browser-externals]');
+      expect(patched).toContain(
+        '"graceful-fs", // [milaidy:browser-externals]',
+      );
+      // Existing externals must remain.
+      expect(patched).toContain('"sharp", // Image processing');
+      expect(patched).toContain('"@hapi/shot", // Test utility');
+
+      expect(
+        applyAliceCoreBuildBrowserExternalsPatch({
           elizaRoot: tempDir,
           log: () => undefined,
         }),


### PR DESCRIPTION
## Summary

Adds \`applyAliceCoreBuildBrowserExternalsPatch\` to the alice-eliza-runtime-patches chain. Patches \`eliza/packages/core/build.ts\` to mark \`fs-extra\` and \`graceful-fs\` as \`browserExternals\` so bun build no longer inlines their source into \`dist/browser/index.browser.js\`.

## The actual root cause (traced via SSM into the staging pod)

The earlier basic-capabilities patch ([rndrntwrk/milaidy#116](https://github.com/rndrntwrk/milaidy/pull/116)) cut one re-export chain but the SPA bundle's \`main-*.js\` content-hash was unchanged after deploy — fs-extra was still in the bundle. Tracing via \`grep -l fs-extra-WARN0001\` across the deployed image found:

\`\`\`
/app/milaidy/eliza/packages/core/dist/browser/index.browser.js  HAS fs-extra-WARN0001
/app/milaidy/node_modules/@elizaos/core/dist/browser/index.browser.js  HAS fs-extra-WARN0001
\`\`\`

So fs-extra is inlined directly into \`@elizaos/core\`'s **own** browser dist. The SPA's Vite stub plugin (\`apps/app/vite/native-module-stub-plugin.ts\`, which has \`fs-extra\` in its \`nativePackages\` Set) never sees an \`fs-extra\` import to intercept — by the time Vite reads \`@elizaos/core/dist/browser/index.browser.js\`, fs-extra is already inlined as source code.

The inlining happens inside \`@elizaos/core\`'s [build.ts:619-628](eliza/packages/core/build.ts#L619), which marks \`sharp\`, \`@hapi/shot\`, \`@opentelemetry/context-async-hooks\`, \`async_hooks\`, and a couple node: builtins as \`browserExternals\` — but **not** \`fs-extra\` and **not** \`graceful-fs\`. bun build resolves and inlines them.

graceful-fs's \`gracefulify()\` reads \`fs.realpath.native\` at module init. In a browser where \`fs\` is stubbed empty, that lookup throws \`TypeError: Cannot read properties of undefined (reading 'native')\` synchronously and kills SPA boot before React mounts. That's the white screen the user reported.

## What this PR changes

Patches \`eliza/packages/core/build.ts\`:

\`\`\`ts
const browserExternals = [
  // [milaidy:browser-externals] Mark fs-extra and graceful-fs as external...
  "fs-extra",   // [milaidy:browser-externals]
  "graceful-fs", // [milaidy:browser-externals]
  // (existing entries...)
];
\`\`\`

After this:
- bun build emits bare \`import "fs-extra"\` / \`import "graceful-fs"\` in \`dist/browser/index.browser.js\`
- Vite's stub plugin in the SPA build catches those bare imports
- The SPA bundle ships a Proxy noop stub instead of fs-extra source
- \`fs.realpath.native\` is never read at module init
- React mounts cleanly

## Why this is the upstream-friendly fix

\`@elizaos/core\` shipping fs-extra inlined into its browser bundle is a bug in @elizaos/core itself — any consumer importing the browser dist gets a TypeError on init. The fix here is local (a milaidy patch) but the underlying issue should also be reported / contributed back to upstream eliza.

## Tests

\`\`\`
14 pass
 0 fail
83 expect() calls
\`\`\`

The new test mirrors the existing patch tests: builds a fixture \`build.ts\` with the same anchor as upstream, applies the patch, asserts both new entries with their sentinel comments are present, asserts existing entries (\`sharp\`, \`@hapi/shot\`) survived, and confirms idempotence on second application.

## Test plan post-merge

- [ ] Trigger 555-bot redeploy on \`alice\` branch
- [ ] After deploy: \`grep -c fs-extra-WARN0001 /app/milaidy/eliza/packages/core/dist/browser/index.browser.js\` should drop from 1 to 0
- [ ] After deploy: \`grep -c gracefulify /app/milaidy/apps/app/dist/assets/main-*.js\` should drop from 1 to 0
- [ ] After deploy: SPA bundle's content-hash filename will change (currently \`main-9mVt9neL.js\`)
- [ ] \`https://staging-alice.rndrntwrk.com/\` renders a React tree (not blank)
- [ ] No \`Cannot read properties of undefined (reading 'native')\` in console