### PR TITLE
fix(alice): externalize mammoth in core browser dist + add to vite stub

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -27,6 +27,8 @@ const appCoreTrustedLocalRequestRelativePath =
 const coreBasicCapabilitiesRelativePath =
   "packages/core/src/features/basic-capabilities/index.ts";
 const coreBuildRelativePath = "packages/core/build.ts";
+const appViteNativeStubRelativePath =
+  "packages/app/vite/native-module-stub-plugin.ts";
 const agentRuntimeRelativePath = "packages/agent/src/runtime/eliza.ts";
 const agentPluginResolverRelativePath =
   "packages/agent/src/runtime/plugin-resolver.ts";
@@ -1618,6 +1620,125 @@ export function applyAliceCoreBuildBrowserExternalsPatch({
   return "applied";
 }
 
+function patchAliceCoreBuildBrowserExternalsMammothSource(source) {
+  const safeMarker = '"mammoth", // [milaidy:browser-externals-mammoth]';
+  if (source.includes(safeMarker)) {
+    return source;
+  }
+
+  /* The browser-externals patch (apply order #4 in this chain) inserted
+   * fs-extra and graceful-fs into browserExternals already. Anchor against
+   * THAT post-state so this patch composes after it. */
+  const anchor = `\t"fs-extra", // [milaidy:browser-externals]
+\t"graceful-fs", // [milaidy:browser-externals]`;
+
+  if (!source.includes(anchor)) {
+    throw new Error(
+      "core/build.ts post-fs-extra browserExternals anchor drifted; the prior browser-externals patch must run first",
+    );
+  }
+
+  /* features/knowledge/utils.ts statically imports mammoth at line 3.
+   * mammoth is a Node-only docx parser that calls fs.readFile.bind at
+   * module init (its DocumentXmlReader factory). When bundled into the
+   * browser dist via index.browser.ts -> features/knowledge/index ->
+   * utils, the .bind on undefined fs.readFile throws TypeError and kills
+   * SPA boot the same way fs-extra/graceful-fs did. Externalizing mammoth
+   * leaves a bare `import "mammoth"` in the dist; a paired Vite stub
+   * patch adds mammoth to nativePackages so the SPA build replaces it
+   * with a Proxy noop. */
+  const replacement = `\t"fs-extra", // [milaidy:browser-externals]
+\t"graceful-fs", // [milaidy:browser-externals]
+\t"mammoth", // [milaidy:browser-externals-mammoth]`;
+
+  return source.replace(anchor, replacement);
+}
+
+export function applyAliceCoreBuildBrowserExternalsMammothPatch({
+  elizaRoot,
+  log = console.log,
+} = {}) {
+  const filePath = path.join(elizaRoot, coreBuildRelativePath);
+  if (!existsSync(filePath)) {
+    log(
+      "[alice-eliza-runtime-patches] core build.ts absent; skipping mammoth-externals patch",
+    );
+    return "skipped";
+  }
+
+  const before = readFileSync(filePath, "utf8");
+  const after = patchAliceCoreBuildBrowserExternalsMammothSource(before);
+  if (after === before) {
+    log(
+      "[alice-eliza-runtime-patches] core build.ts mammoth-externals patch already applied",
+    );
+    return "already-applied";
+  }
+
+  writeFileSync(filePath, after);
+  log(
+    "[alice-eliza-runtime-patches] patched core build.ts to externalize mammoth in the browser dist",
+  );
+  return "applied";
+}
+
+function patchAliceAppViteStubMammothSource(source) {
+  const safeMarker = '"mammoth", // [milaidy:vite-stub-mammoth]';
+  if (source.includes(safeMarker)) {
+    return source;
+  }
+
+  const anchor = `    "node-llama-cpp",
+    "fs-extra",`;
+
+  if (!source.includes(anchor)) {
+    throw new Error(
+      "app/vite/native-module-stub-plugin.ts nativePackages anchor drifted",
+    );
+  }
+
+  /* Add mammoth to the SPA's Vite stub plugin so the bare `import "mammoth"`
+   * left in @elizaos/core's browser dist (after the paired core/build.ts
+   * mammoth-externals patch) gets replaced with a Proxy noop stub instead
+   * of being resolved and bundled by Vite. The default load() branch
+   * returns a generic noop Proxy for any nativePackages entry that
+   * doesn't have a specific stub generator, which is the right shape for
+   * mammoth (consumers only call its API, never inspect its export shape). */
+  const replacement = `    "node-llama-cpp",
+    "fs-extra",
+    "mammoth", // [milaidy:vite-stub-mammoth]`;
+
+  return source.replace(anchor, replacement);
+}
+
+export function applyAliceAppViteStubMammothPatch({
+  elizaRoot,
+  log = console.log,
+} = {}) {
+  const filePath = path.join(elizaRoot, appViteNativeStubRelativePath);
+  if (!existsSync(filePath)) {
+    log(
+      "[alice-eliza-runtime-patches] app vite native-module-stub-plugin absent; skipping mammoth stub patch",
+    );
+    return "skipped";
+  }
+
+  const before = readFileSync(filePath, "utf8");
+  const after = patchAliceAppViteStubMammothSource(before);
+  if (after === before) {
+    log(
+      "[alice-eliza-runtime-patches] app vite mammoth stub patch already applied",
+    );
+    return "already-applied";
+  }
+
+  writeFileSync(filePath, after);
+  log(
+    "[alice-eliza-runtime-patches] patched app vite native-module-stub-plugin to stub mammoth",
+  );
+  return "applied";
+}
+
 function patchAliceBundledKnowledgeStartupDeferralSource(source) {
   if (isAliceBundledKnowledgeStartupDeferralPatched(source)) {
     return source;
@@ -1868,6 +1989,8 @@ export function applyAliceElizaRuntimePatches({
     applyAliceKubeHealthReadinessPatch({ elizaRoot, log }),
     applyAliceCoreBasicCapabilitiesBrowserSafePatch({ elizaRoot, log }),
     applyAliceCoreBuildBrowserExternalsPatch({ elizaRoot, log }),
+    applyAliceCoreBuildBrowserExternalsMammothPatch({ elizaRoot, log }),
+    applyAliceAppViteStubMammothPatch({ elizaRoot, log }),
     applyAliceAppCoreCodingAgentsFallbackPatch({ elizaRoot, log }),
     applyAliceAppCoreCompanionStagePatch({ elizaRoot, log }),
     applyAliceAppCoreOpenAccessPatch({ elizaRoot, log }),

--- a/scripts/apply-alice-eliza-runtime-patches.test.ts
+++ b/scripts/apply-alice-eliza-runtime-patches.test.ts
@@ -17,7 +17,9 @@ import {
   applyAliceAppCoreOpenAccessPatch,
   applyAliceBundledKnowledgeStartupDeferralPatch,
   applyAliceCoreBasicCapabilitiesBrowserSafePatch,
+  applyAliceAppViteStubMammothPatch,
   applyAliceCoreBuildBrowserExternalsPatch,
+  applyAliceCoreBuildBrowserExternalsMammothPatch,
   applyAliceTelegramAccountAuthResolverPatch,
   applyAliceKubeHealthReadinessPatch,
   applyAliceLifeOpsCalendarActionPatch,
@@ -446,6 +448,99 @@ describe("Alice Eliza runtime patch contract", () => {
 
       expect(
         applyAliceCoreBuildBrowserExternalsPatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("already-applied");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("patches core build.ts to also externalize mammoth in the browser dist (composes after the fs-extra externalization)", () => {
+    const tempDir = mkdtempSync(
+      path.join(os.tmpdir(), "alice-core-mammoth-externals-"),
+    );
+    try {
+      const dir = path.join(tempDir, "packages", "core");
+      mkdirSync(dir, { recursive: true });
+      const filePath = path.join(dir, "build.ts");
+      // Simulate the post-fs-extra-patch state.
+      const original = [
+        "// Browser-specific externals (these should be provided by the host environment)",
+        "const browserExternals = [",
+        "\t// [milaidy:browser-externals] Mark fs-extra and graceful-fs as external...",
+        '\t"fs-extra", // [milaidy:browser-externals]',
+        '\t"graceful-fs", // [milaidy:browser-externals]',
+        "\t// These will be loaded via CDN or bundled by the consuming app",
+        '\t"sharp", // Image processing - not available in browser',
+        "];",
+      ].join("\n");
+      writeFileSync(filePath, original);
+
+      expect(
+        applyAliceCoreBuildBrowserExternalsMammothPatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("applied");
+
+      const patched = readFileSync(filePath, "utf8");
+      expect(patched).toContain(
+        '"mammoth", // [milaidy:browser-externals-mammoth]',
+      );
+      // The fs-extra/graceful-fs sentinels must remain.
+      expect(patched).toContain('"fs-extra", // [milaidy:browser-externals]');
+      expect(patched).toContain(
+        '"graceful-fs", // [milaidy:browser-externals]',
+      );
+      // sharp must remain.
+      expect(patched).toContain('"sharp", // Image processing');
+
+      expect(
+        applyAliceCoreBuildBrowserExternalsMammothPatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("already-applied");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("patches the app vite native-module-stub-plugin to stub mammoth", () => {
+    const tempDir = mkdtempSync(
+      path.join(os.tmpdir(), "alice-vite-stub-mammoth-"),
+    );
+    try {
+      const dir = path.join(tempDir, "packages", "app", "vite");
+      mkdirSync(dir, { recursive: true });
+      const filePath = path.join(dir, "native-module-stub-plugin.ts");
+      const original = [
+        "  const nativePackages = new Set([",
+        '    "node-llama-cpp",',
+        '    "fs-extra",',
+        '    "pty-state-capture",',
+        "  ]);",
+      ].join("\n");
+      writeFileSync(filePath, original);
+
+      expect(
+        applyAliceAppViteStubMammothPatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("applied");
+
+      const patched = readFileSync(filePath, "utf8");
+      expect(patched).toContain('"mammoth", // [milaidy:vite-stub-mammoth]');
+      // Existing entries must remain in order.
+      expect(patched).toContain('"node-llama-cpp",');
+      expect(patched).toContain('"fs-extra",');
+      expect(patched).toContain('"pty-state-capture",');
+
+      expect(
+        applyAliceAppViteStubMammothPatch({
           elizaRoot: tempDir,
           log: () => undefined,
         }),


### PR DESCRIPTION
## Summary

Follow-up to [rndrntwrk/milaidy#117](https://github.com/rndrntwrk/milaidy/pull/117). After the fs-extra/graceful-fs externalization landed and the SPA bundle hash flipped, the next module-init crash surfaced:

\`\`\`
Uncaught TypeError: Cannot read properties of undefined (reading 'bind')
    at main-cFbyyzZR.js:7863:249
\`\`\`

Same class of bug, different package — this time **mammoth** (the docx parser).

## Trace

\`eliza/packages/core/src/features/knowledge/utils.ts\` line 3 statically imports \`mammoth\`. \`index.browser.ts\` re-exports \`fetchKnowledgeFromUrl\` and \`isYouTubeUrl\` from \`features/knowledge/index\`, which transitively loads \`utils.ts\`. mammoth is also a direct dep in core's package.json (line 136), so bun build resolves and inlines its source into \`dist/browser/index.browser.js\`.

mammoth's \`DocumentXmlReader\` factory promisifies \`fs.readFile\` via \`o.promisify(e.readFile.bind(e))\` at module init. In a browser where \`fs\` is stubbed empty, \`e.readFile\` is undefined and \`.bind\` throws.

## What this PR adds

Two paired patches to the alice-eliza-runtime-patches chain:

1. **\`applyAliceCoreBuildBrowserExternalsMammothPatch\`** — anchors against the post-fs-extra-patch state and inserts \`"mammoth"\` after the existing \`fs-extra\`/\`graceful-fs\` lines in \`browserExternals\`. Sentinel \`[milaidy:browser-externals-mammoth]\`.
2. **\`applyAliceAppViteStubMammothPatch\`** — adds \`"mammoth"\` to the SPA's Vite stub plugin \`nativePackages\` Set. Sentinel \`[milaidy:vite-stub-mammoth]\`.

After both apply:
- bun build emits bare \`import "mammoth"\` in core's \`dist/browser/index.browser.js\`
- Vite catches the bare import via \`nativePackages\` and substitutes a Proxy noop
- mammoth's \`e.readFile.bind\` never executes at module init
- SPA boots past the previous crash point

## Tests

\`\`\`
16 pass
 0 fail
95 expect() calls
\`\`\`

Both new tests mirror the existing pattern: build a fixture matching the post-prior-patch state, apply, assert sentinel + existing entries, confirm idempotence.

## Long-term note

The fs-extra and mammoth fixes share the same shape. If the next deploy surfaces yet another Node-only inlined package, the same pattern (externalize in core/build.ts + add to apps/app/vite/native-module-stub-plugin.ts) applies. **The right long-term fix is upstream**: \`@elizaos/core\`'s \`build.ts\` should externalize all Node-only deps, since shipping them inlined in \`dist/browser\` breaks every browser consumer. Worth filing an issue at elizaOS/eliza.

## Test plan post-merge

- [ ] Trigger 555-bot redeploy on \`alice\`
- [ ] After deploy: \`grep -c -F mammoth /app/milaidy/eliza/packages/core/dist/browser/index.browser.js\` should drop substantially (only bare-import remains)
- [ ] After deploy: SPA bundle's \`main-*.js\` content-hash filename will change (currently \`main-cFbyyzZR.js\`)
- [ ] After deploy: \`grep -c -F DocumentXmlReader main-*.js\` should be 0
- [ ] \`https://staging-alice.rndrntwrk.com/\` mounts a React tree, no \`Cannot read properties of undefined (reading 'bind')\` in console
- [ ] If a NEW TypeError surfaces, file the next package as a separate follow-up using this same pattern