### PR TITLE
fix(alice): add mammoth to apps/app vite stub nativePackages

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -904,6 +904,16 @@ function nativeModuleStubPlugin(): Plugin {
     "electron",
     "undici",
     "@elizaos/plugin-local-embedding",
+    // mammoth (statically imported from @elizaos/core/src/features/knowledge/
+    // utils.ts) calls fs.readFile.bind(fs) inside its DocumentXmlReader factory
+    // at module init. In a browser where fs is stubbed empty that lookup throws
+    // TypeError and kills SPA boot. The paired core/build.ts patch externalizes
+    // mammoth in the dist; this entry stubs it in the SPA build so the bare
+    // import emitted by core gets replaced with a Proxy noop instead of being
+    // resolved and bundled by Vite. The shared eliza/packages/app stub plugin
+    // has the same entry; both are needed because each Vite config runs its
+    // own copy of nativeModuleStubPlugin.
+    "mammoth",
   ]);
   const nativeScopeRe = /^@node-llama-cpp\//;
 


### PR DESCRIPTION
## Summary

Direct addition of \`"mammoth"\` to the \`nativePackages\` Set inside \`apps/app/vite.config.ts\`'s inline \`nativeModuleStubPlugin\`. Companion to [rndrntwrk/milaidy#118](https://github.com/rndrntwrk/milaidy/pull/118), which patched the same Set in the eliza-vendored stub plugin (\`eliza/packages/app/vite/native-module-stub-plugin.ts\`).

## Why two files

Both vite configs run **their own copy** of \`nativeModuleStubPlugin\`. The actual SPA build for staging-alice runs from \`apps/app/\` (the milaidy top-level config), not \`eliza/packages/app/\` (the eliza standalone-app config). #118 patched the latter; this PR patches the former. Without both, mammoth survives the SPA build via whichever stub doesn't have it.

## Verification trace

After #118 merged + the bot redeployed (image tag \`sha-2796ba8-milaidy-89fca9d-build-e9092733\`), SSM into the pod confirmed:

- \`eliza/packages/core/build.ts\` carried the \`[milaidy:browser-externals-mammoth]\` sentinel ✓
- \`eliza/packages/app/vite/native-module-stub-plugin.ts\` carried the \`[milaidy:vite-stub-mammoth]\` sentinel ✓
- \`@elizaos/core/dist/browser/index.browser.js\` had **0** occurrences of \`DocumentXmlReader\`, \`mammoth\`, \`fs-extra-WARN0001\`, \`gracefulify\` — core's build externalized everything correctly ✓
- BUT the SPA bundle \`apps/app/dist/assets/main-D6Z3iPEe.js\` still had \`DocumentXmlReader: 2\`, \`convertElementToRawText: 2\`, \`readXmlFromZipFile: 2\` ✗

The discrepancy: Vite's \`@elizaos/core\` alias [resolves to \`packages/core/src/index.browser.ts\`](eliza/packages/app/vite.config.ts#L430-L432) (the TS source) when present, **bypassing the compiled dist**. So my \`build.ts\` patch never ran in this code path; the SPA build read \`utils.ts\` directly, hit \`import * as mammoth from "mammoth"\`, and resolved/bundled mammoth via the inline stub plugin in \`apps/app/vite.config.ts\` — which doesn't have mammoth in its set.

## What this PR adds

\`\`\`ts
const nativePackages = new Set([
  "node-llama-cpp",
  "fs-extra",
  // ...
  "@elizaos/plugin-local-embedding",
  "mammoth",  // <- new
]);
\`\`\`

After merge:
- The bare \`import "mammoth"\` from utils.ts hits the inline stub plugin
- nativePackages.has("mammoth") returns true
- The plugin substitutes a Proxy noop module
- mammoth's source never enters the bundle
- \`DocumentXmlReader\` count drops to 0

## Why this is a direct edit (not a patch)

\`apps/app/vite.config.ts\` is **milaidy-owned source**, not a vendored eliza file. The alice-eliza-runtime-patches chain exists for files we can't touch directly because they live inside the eliza submodule. This file isn't in that bucket — direct edit is the right shape.

## Test plan post-merge

- [ ] Trigger 555-bot redeploy
- [ ] After deploy: SPA bundle \`main-*.js\` content-hash filename will change again
- [ ] After deploy: \`grep -c -F DocumentXmlReader main-*.js\` should drop from 2 to 0
- [ ] After deploy: \`grep -c -F readXmlFromZipFile main-*.js\` should drop from 2 to 0
- [ ] \`https://staging-alice.rndrntwrk.com/\` mounts a React tree, no \`Cannot read properties of undefined (reading 'bind')\` in console