### PR TITLE
chore(alice): surgical upstream/develop merge — 1 of 23 commits applied

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,8 +243,10 @@ These rules govern all changes. If existing code conflicts with them, fix the co
 4. **BFF is auth + proxy. Nothing else.** Validate JWT, inject `userId`, forward request, `unwrapServerResponse()`. No field additions, no calculations, no transformations.
    - Violation: shadow API contract divergence.
 
-5. **Zero polymorphism for runtime game/content type branching.** Separate classes, methods, and routes per type. No `if (gameType === ...)`, no union parameters, no union return types where separate flows should exist.
-   - Violation: runtime type checks, hidden branches.
+5. **Zero polymorphism for runtime game/content type branching — in code, not in agent surfaces.** Separate classes, methods, and routes per type. No `if (gameType === ...)`, no union parameters, no union return types where separate flows should exist.
+   - **Scope:** This is a code-pattern rule about TypeScript/runtime classes, methods, and HTTP routes. It does **not** apply to elizaOS agent surfaces — Action / Provider / Evaluator / Service definitions, planner-visible action shapes, contextual Evaluators, or any LLM-facing JSON. Those are intentionally polymorphic by design — one `BROWSER` action that dispatches across registered targets is correct; one `BROWSER_NAVIGATE` + `BROWSER_CLICK` + … action per subaction is the antipattern. Same for Providers that gather from multiple sources, Evaluators that branch on context, and Services with target/adapter registries.
+   - Violation (code): runtime type checks, hidden branches in classes/methods/routes.
+   - Not a violation: an Action with a `subaction` / `target` parameter, a Provider that aggregates across registered sources, a Service that routes a command to a registered adapter.
 
 6. **CQRS: readers read, writers write.** Separate classes. Readers return domain objects. Writers return `void` or ID only. Mappers handle all DB-to-domain translation.
    - Violation: mixed concerns, untraceable mutations.


### PR DESCRIPTION
## Summary

Surgical bring-in of upstream \`milady-ai/milady@develop\` commits onto \`alice\`. Of the 23 upstream commits not on alice, **only 1 was genuinely applicable** (a docs touch). The remaining 22 are categorized below with reasoning.

This PR adds 1 commit (\`a1c328889\` — AGENTS.md doc clarification). Everything we've built (basic-capabilities patch, fs-extra externalization, mammoth externalization, vite stubs in both apps/app and eliza/packages/app, open-access env gate, contract guards) is preserved.

**Do not merge to alice without reading the categorization below — confirm you agree the skipped commits are non-applicable.** If any of the SKIP categorizations look wrong, push back and I'll re-evaluate.

## Categorization of all 23 commits

### ✅ Applied (1)

- \`a1c328889\` **docs(AGENTS.md): scope rule #5 to code patterns, not LLM action surfaces** — pure docs change to \`AGENTS.md\` clarifying that the "no polymorphism" rule applies to TS classes/methods, not Action/Provider/Evaluator/Service. Cherry-pick clean (auto-merged \`CLAUDE.md\`).

### ⏭ Skipped — release-pipeline (does not apply to our deploy chain) (12)

Our staging deploys via \`bot-aws-staging-webhook-deployer.service\` → \`deploy-555-bot-staging.sh\`, NOT through \`.github/workflows/*.yml\`. These commits modify upstream's electrobun/desktop release pipeline:

- \`b9e4118cd\` chore: point eliza upstream to elizaOS (changes URL in release workflow YAMLs we don't use)
- \`8cb1fc379\` fix(release): reuse windows smoke launcher for renderer check
- \`9a8852b2a\` fix(ci): run tsdown through checked-in node wrapper
- \`4131077dc\` fix(ci): avoid tsdown unrun loader in release builds
- \`02d3d0cdf\` fix(build): use esm tsdown config in release jobs
- \`1d67a9059\` fix(release): link elizacloud source for windows renderer checks
- \`151815400\` fix(release): prefer eliza source plugins in renderer checks
- \`f6062f45e\` fix(test): probe packaged renderer api bootstrap
- \`bba0c112c\` fix(release): define publish body cap
- \`fb3ec822b\` fix(ci): make eliza Bun postinstall hydration conditional
- \`64c895a36\` fix(ci): generate protobuf types in Build Agent Image before docker build
- \`303b4a3db\` fix(ci): tighten Build Agent Image proto-gen guard to v1 subdir

### ⏭ Skipped — desktop/Windows-only (3)

We deploy to Linux EKS, not Windows desktop:

- \`8fdf0f176\` fix(desktop): preserve elizaos boot api base
- (Windows smoke test commits already covered above)
- \`f6062f45e\` already-listed packaged-renderer test

### ⏭ Skipped — mobile/llama (3)

Mobile-only; we don't ship mobile from this stack:

- \`7e66cac0f\` Sync mobile llama patch
- \`7283b456a\` fix(patches): llama-cpp-capacitor exposes getNativeKernels
- \`44cb9cddd\` fix(patches): repair llama-cpp-capacitor patch after merge conflict

### ⏭ Skipped — WIP / merge / housekeeping (3)

Not safe to cherry-pick onto alice:

- \`f83399628\` chore(wip): snapshot in-progress local develop changes — WIP snapshot, half-finished
- \`a40455e11\` merge(develop): bring origin/develop's 39 CI/release fixes — merge commit, cherry-picking those is messy and brings in nothing alice needs
- \`f0b81ca5d\` fix(build,test): add missing stub subpaths, gitignore CI scratch dirs, drop dead var — explicitly described in commit message as "revert WIP refactors superseded by origin/develop's tested fixes". Picking this onto alice would actively undo our customizations

### ⏭ Skipped — script/upstream-prompt formatting (2)

- \`e7478bfef\` fix(scripts): align prompts setup-upstreams step with current package
- \`305306572\` fix(scripts): biome format setup-upstreams.mjs prompts step

### ⏭ Skipped — script unrelated (1)

- \`4b0756547\` fix(scripts): make eliza:local mode use local app-core scripts for everything (#2122) — touches \`scripts/run-eliza-app-core-script.mjs\` only; alice doesn't use this script in its deploy path

## Important separate finding: eliza submodule is 866 commits behind

\`milaidy/eliza\` submodule pin is \`f0c6fecaa2e8\`; \`elizaOS/eliza@develop\` is at \`be182cc913b3\`. **Eliza is 866 commits behind**, with 0 alice-side customizations to the submodule itself (all our eliza customizations are applied at deploy time via \`scripts/apply-alice-eliza-runtime-patches.mjs\`).

**Updating the eliza submodule is significantly more impactful than this milaidy-level merge** — it would bring in real bug fixes, security patches, and feature work. But it is also significantly riskier:

- Our patch chain anchors against exact source-text patterns in the eliza submodule. If upstream changed those files (very likely across 866 commits), the patches throw "anchor drifted" and the deploy fails.
- 866 commits is too large to evaluate commit-by-commit in a single session.

**Recommended approach for the eliza submodule update** (as a separate, scheduled effort, not in this PR):

1. Pick a stable upstream eliza tag (e.g., latest published v2.0.0-alpha.X release) to pin to, rather than a moving \`develop\` tip.
2. Bump the submodule pin in a dedicated branch.
3. Run \`bun test scripts/apply-alice-eliza-runtime-patches.test.ts\` — failures point at every patch whose anchor drifted.
4. Re-anchor each broken patch to match the new upstream source.
5. Trigger a staging deploy from that branch. Watch the deployer healthz, then SSM-verify the new SPA bundle.
6. If the SPA still mounts cleanly, open a PR.

I would NOT do this autonomously — it needs your judgment on which upstream eliza pin to target.

## Verification this PR doesn't break anything

\`\`\`
$ git log update/upstream-develop-2026-05-10 -10 --oneline
ae553d619 docs(AGENTS.md): scope rule #5 to code patterns, not LLM action surfaces  ← this PR
60ccfe54b add mammoth to apps/app vite stub nativePackages (#119)                   ← preserved
89fca9d11 externalize mammoth in core browser dist + add to vite stub (#118)        ← preserved
553709f37 externalize fs-extra and graceful-fs in core browser dist (#117)          ← preserved
60286799e patch core basic-capabilities to bypass plugin-manager barrel (#116)      ← preserved
20d1d2659 patch alice app-core open access env gate                                 ← preserved
41ce76a48 mount alice companion stage routes in source mode                         ← preserved
b0716be08 add alice coding agents fallback route                                    ← preserved
52563a093 make alice bundled knowledge seed opt in                                  ← preserved
6408ce03b fix alice source-mode knowledge startup deferral                          ← preserved
\`\`\`

All four sentinel-tagged patches present:
- \`MILADY_OPEN_ACCESS\` — open-access env gate
- \`milaidy:browser-externals\` — fs-extra/graceful-fs externalization
- \`milaidy:browser-externals-mammoth\` — mammoth externalization (eliza-side)
- \`milaidy:vite-stub-mammoth\` — mammoth Vite stub (both eliza-side and apps/app-side)

## Test plan if/when merged

This PR doesn't change any deploy-affecting code (only AGENTS.md). If merged onto alice, the next 555-bot deploy should:

- Build identically to the current alice tip
- SPA bundle hash unchanged from the post-mammoth-fix \`main-3xHjPCr_.js\`
- All forbidden markers remain at 0
- API routes still 200