### PR TITLE
fix(alice): define isMiladyOS — unblock SPA boot ReferenceError

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -96,6 +96,31 @@ const isNative = Capacitor.isNativePlatform();
 const isIOS = platform === "ios";
 const isAndroid = platform === "android";
 
+/**
+ * Detect MiladyOS — a custom AOSP product distribution that appends
+ * `MiladyOS/<tag>` to its user agent and is only built for Android.
+ * Returns false on every other platform (iOS, desktop, stock Android,
+ * server-rendered SPA bundles served to plain browsers).
+ *
+ * The user-agent suffix is set by `MainActivity` when
+ * `ro.miladyos.product` is configured by the AOSP product config; the
+ * regex matches the same `\bMiladyOS\/` pattern as
+ * `hasMiladyOSMarker` in
+ * `eliza/packages/app-core/src/components/apps/overlay-app-registry.ts`,
+ * keeping detection consistent across the SPA's two call sites and the
+ * overlay-app registry.
+ */
+function isMiladyOS(): boolean {
+  if (!isAndroid) return false;
+  if (
+    typeof navigator === "undefined" ||
+    typeof navigator.userAgent !== "string"
+  ) {
+    return false;
+  }
+  return /\bMiladyOS\//.test(navigator.userAgent);
+}
+
 async function registerMiladyOsSystemApps(): Promise<void> {
   if (!isMiladyOS()) return;
   await Promise.all([


### PR DESCRIPTION
## Summary

\`apps/app/src/main.tsx\` references \`isMiladyOS()\` at two call sites (line 100 inside \`registerMiladyOsSystemApps\` and line 593 in the boot-time MiladyOS pre-seed) but the function was never imported or defined anywhere in the codebase. \`git blame\` shows the references were added across two upstream commits in early May without the companion definition landing, leaving SPA boot with a dangling \`ReferenceError\`.

In the deployed bundle this surfaces as:

\`\`\`
main-3xHjPCr_.js:8753 Uncaught (in promise) ReferenceError: isMiladyOS is not defined
    at Dya (main-3xHjPCr_.js:8753:386540)
\`\`\`

This is the next-layer crash, surfaced because the earlier fs-extra ([rndrntwrk/milaidy#117](https://github.com/rndrntwrk/milaidy/pull/117)) and mammoth ([rndrntwrk/milaidy#118](https://github.com/rndrntwrk/milaidy/pull/118), [rndrntwrk/milaidy#119](https://github.com/rndrntwrk/milaidy/pull/119)) fixes let SPA boot reach far enough to actually hit the missing-function reference. Not a regression.

## Fix

Inline definition next to the call sites. Logic mirrors \`hasMiladyOSMarker\` in [eliza/packages/app-core/src/components/apps/overlay-app-registry.ts:117](eliza/packages/app-core/src/components/apps/overlay-app-registry.ts#L117) — same \`\\bMiladyOS\\/\` regex against the user-agent — and gates on \`isAndroid\` (the existing platform constant at line 97) so it returns false on every other surface.

For the **staging-alice** deploy specifically: \`Capacitor.getPlatform()\` is \`"web"\` → \`isAndroid\` is false → \`isMiladyOS()\` returns false → the \`registerMiladyOsSystemApps\` guard short-circuits and the boot-time pre-seed is skipped. Correct behaviour: staging-alice is a server-deployed Linux EKS pod, not a MiladyOS device.

## Why inline rather than imported

\`hasMiladyOSMarker\` is a private helper inside \`overlay-app-registry.ts\` — not exported on a stable public path. The regex is one line. Keeping the definition next to its two call sites in the same file makes future maintenance obvious; importing would require also touching the app-core barrel.

## Test plan post-merge

- [ ] Trigger 555-bot redeploy
- [ ] After deploy: SPA bundle \`main-*.js\` content-hash filename will change again
- [ ] \`https://staging-alice.rndrntwrk.com/\` mounts a React tree, no \`isMiladyOS is not defined\` in console
- [ ] If a NEW error surfaces, file the next as a separate follow-up using the same shape

## Why this is a milaidy direct edit (not an eliza patch)

\`apps/app/src/main.tsx\` is **milaidy-owned source** (apps/app, not eliza/packages/app). The alice-eliza-runtime-patches chain is for vendored eliza files we can't touch directly; this file isn't in that bucket — direct edit is the right shape.