### PR TITLE
fix(alice): bump eliza submodule to upstream develop tip + re-anchor patch chain

### DIFF
--- a/scripts/alice-eliza-runtime-patches/app-core-server-only-api-bind.patch
+++ b/scripts/alice-eliza-runtime-patches/app-core-server-only-api-bind.patch
@@ -1,8 +1,8 @@
 diff --git a/packages/app-core/src/runtime/eliza.ts b/packages/app-core/src/runtime/eliza.ts
-index 9becb337a0..b20476b87c 100644
+index 71f9f391a2..75580e284d 100644
 --- a/packages/app-core/src/runtime/eliza.ts
 +++ b/packages/app-core/src/runtime/eliza.ts
-@@ -119,6 +119,68 @@ function isAutonomyService(value: unknown): value is AutonomyServiceLike {
+@@ -113,6 +113,68 @@ function isAutonomyService(value: unknown): value is AutonomyServiceLike {
  /** Guards against registering signal handlers more than once. */
  let signalHandlersRegistered = false;
  
@@ -71,7 +71,7 @@ index 9becb337a0..b20476b87c 100644
  interface EntityLike {
    id: string;
    agentId?: string;
-@@ -1290,6 +1352,10 @@ export async function startEliza(
+@@ -1065,6 +1127,10 @@ export async function startEliza(
    options?: StartElizaOptionsExt,
  ): Promise<Awaited<ReturnType<typeof upstreamStartEliza>>> {
    syncAppEnvToEliza();
@@ -82,7 +82,7 @@ index 9becb337a0..b20476b87c 100644
    // Eliza app: load PTY / coding-swarm orchestration unless explicitly opted out.
    const orchRaw = process.env.ELIZA_AGENT_ORCHESTRATOR?.trim().toLowerCase();
    if (orchRaw !== "0" && orchRaw !== "false" && orchRaw !== "no") {
-@@ -1306,47 +1372,59 @@ export async function startEliza(
+@@ -1081,47 +1147,59 @@ export async function startEliza(
      }
  
      if (options?.serverOnly) {
@@ -181,7 +181,7 @@ index 9becb337a0..b20476b87c 100644
  
        // WHY: `startApiServer` may bind a different port than requested (busy
        // socket, upstream policy). Shells, scripts, and follow-up code reading
-@@ -1364,10 +1442,60 @@ export async function startEliza(
+@@ -1139,10 +1217,60 @@ export async function startEliza(
        } catch {}
  
        logger.info(
@@ -245,15 +245,26 @@ index 9becb337a0..b20476b87c 100644
  
        const keepAlive = setInterval(() => {}, 1 << 30);
        let isCleaningUp = false;
-@@ -1434,6 +1562,7 @@ export async function startEliza(
-         } catch {
-           /* non-critical — best effort */
+@@ -1172,6 +1300,18 @@ export async function startEliza(
+           }
+           _triggerEventBridge = null;
          }
++        // Stop the n8n sidecar if it was started during this session. The
++        // singleton is lazily constructed, so this is a no-op when n8n was
++        // never used.
++        try {
++          const { disposeN8nSidecar } = await import(
++            "../services/n8n-sidecar.js"
++          );
++          await disposeN8nSidecar();
++        } catch {
++          /* non-critical — best effort */
++        }
 +        await apiServerHandle.close().catch(() => undefined);
          process.exit(0);
        };
  
-@@ -1445,8 +1574,23 @@ export async function startEliza(
+@@ -1183,8 +1323,23 @@ export async function startEliza(
        return currentRuntime;
      }
  

--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -1994,12 +1994,38 @@ export function applyAliceElizaRuntimePatches({
     applyAliceAppCoreCodingAgentsFallbackPatch({ elizaRoot, log }),
     applyAliceAppCoreCompanionStagePatch({ elizaRoot, log }),
     applyAliceAppCoreOpenAccessPatch({ elizaRoot, log }),
-    applyAliceBundledKnowledgeStartupDeferralPatch({ elizaRoot, log }),
-    applyAliceTelegramAccountAuthResolverPatch({ elizaRoot, log }),
-    applyAlicePgliteContainerLockPatch({ elizaRoot, log }),
-    applyAliceLifeOpsCalendarActionPatch({ elizaRoot, log }),
-    applyAliceLifeOpsRuntimeImportPatch({ elizaRoot, log }),
-    applyAliceLifeOpsNativeActivityTrackerPatch({ elizaRoot, log }),
+    // applyAliceBundledKnowledgeStartupDeferralPatch retired against upstream
+    // be182cc913b3+ — `seedBundledKnowledge` no longer exists in upstream's
+    // packages/agent/src/runtime/eliza.ts (removed during the 866-commit
+    // upstream catch-up). The behaviour the patch was guarding (avoid
+    // synchronous bundled-knowledge seeding during server startup) is now
+    // moot because upstream doesn't seed bundled knowledge from the agent
+    // runtime at all. Companion contract guards in 555stream's
+    // deploy-555-bot-staging.sh have been removed in lockstep.
+    // The five patches below are retired against the upstream eliza
+    // be182cc913b3+ bump because their anchors no longer match (telegram
+    // account-auth resolver), or their target files have been deleted/moved
+    // upstream (pglite manager, lifeops native-activity-tracker), or their
+    // upstream restructure makes the original behavior moot (lifeops
+    // calendar/runtime-import). Each can be revived in a focused follow-up
+    // by re-anchoring against the new upstream source. Companion contract
+    // guards in 555stream's deploy-555-bot-staging.sh have been removed in
+    // lockstep. The behaviors most at risk:
+    //
+    //   - Telegram account-auth resolver: only matters when Alice runs the
+    //     telegram channel; staging deploy doesn't exercise that path.
+    //   - Pglite container-lock: database lockfile arbitration; on EKS we
+    //     run pgvector via the timescaledb pod, not pglite, so this is
+    //     orthogonal to the staging-alice path.
+    //   - LifeOps calendar/runtime-import/activity-tracker: feature surface
+    //     of @elizaos/app-lifeops. Upstream substantially restructured the
+    //     activity-profile area; the original patches' targets are gone.
+    //
+    // applyAliceTelegramAccountAuthResolverPatch({ elizaRoot, log }),
+    // applyAlicePgliteContainerLockPatch({ elizaRoot, log }),
+    // applyAliceLifeOpsCalendarActionPatch({ elizaRoot, log }),
+    // applyAliceLifeOpsRuntimeImportPatch({ elizaRoot, log }),
+    // applyAliceLifeOpsNativeActivityTrackerPatch({ elizaRoot, log }),
   ];
 
   return results.includes("applied")


### PR DESCRIPTION
Bumps eliza submodule pin from \`f0c6fecaa2e8\` to upstream develop tip \`be182cc913b3\` (866 commits) and re-anchors the alice-eliza-runtime-patches chain.

## Patch chain end state at the new pin

| Patch | Status |
|---|---|
| applyAliceRuntimeApiBindPatch | re-anchored — git apply 3-way merge resolved one conflict (n8n sidecar disposal in SIGINT handler), patch file regenerated and applies cleanly |
| applyAliceKubeHealthReadinessPatch | applied unchanged |
| applyAliceCoreBasicCapabilitiesBrowserSafePatch | applied unchanged |
| applyAliceCoreBuildBrowserExternalsPatch (fs-extra/graceful-fs) | applied unchanged |
| applyAliceCoreBuildBrowserExternalsMammothPatch | applied unchanged |
| applyAliceAppViteStubMammothPatch | applied unchanged |
| applyAliceAppCoreCodingAgentsFallbackPatch | applied unchanged |
| applyAliceAppCoreCompanionStagePatch | applied unchanged |
| applyAliceAppCoreOpenAccessPatch | **silent-skips** — \`packages/app-core/src/api/trusted-local-request.ts\` deleted upstream; \`isTrustedLocalRequest\` moved to \`compat-route-shared.ts\`. SPA reverts to pairing-required view; bundle still mounts (fs-extra/mammoth fixes still in effect). Revive in focused follow-up. |
| applyAliceBundledKnowledgeStartupDeferralPatch | retired — upstream removed \`seedBundledKnowledge\` from agent runtime entirely |
| applyAliceTelegramAccountAuthResolverPatch | retired — anchor drifted; Telegram channel not exercised by staging-alice |
| applyAlicePgliteContainerLockPatch | retired — upstream removed \`plugins/plugin-sql/typescript/pglite/manager.ts\`; we run pgvector via timescaledb on EKS, not pglite |
| applyAliceLifeOpsCalendarActionPatch | retired — upstream restructured app-lifeops |
| applyAliceLifeOpsRuntimeImportPatch | retired |
| applyAliceLifeOpsNativeActivityTrackerPatch | retired — target file family deleted upstream |

Each retired patch keeps its function definition, sentinel marker, and unit test for documentation and future revival; only the orchestrator-chain entry is commented out.

## Tests

\`bun test scripts/apply-alice-eliza-runtime-patches.test.ts\` → 16 pass / 0 fail / 95 expect() calls.

## Pairs with

[Render-Network-OS/stream\#probe/eliza-bump-be182cc-contract-guards](https://github.com/Render-Network-OS/stream/pull/new/probe/eliza-bump-be182cc-contract-guards) — retires the matching contract guards in deploy-555-bot-staging.sh in lockstep.

## Verification path

After both PRs merge, push the standard empty-trigger commit on \`Render-Network-OS/555-bot:alice\`. If the deploy fails or the SPA crashes, revert milaidy alice to \`7c9376ce1c48d5c07ca0c94a630f06ef9fb44351\` and stream staging to its pre-merge tip; the 555-bot deploys whatever alice points at, so a single revert + trigger restores the prior known-good.

## What stays unchanged

- All four sentinel-tagged patches survive (\`MILADY_OPEN_ACCESS\`, \`milaidy:browser-externals\`, \`milaidy:browser-externals-mammoth\`, \`milaidy:vite-stub-mammoth\`)
- \`apps/app/src/main.tsx\` direct edits (isMiladyOS definition) untouched
- Streaming/arcade/Alice-specific behaviour preserved (no patches touched those areas)
- Persistent state (alice-eliza-state, alice-milaidy-state PVCs) is volume-backed and survives the deploy unchanged