### PR TITLE
fix(alice): restore telegram account-auth source export patch for eliza be182cc913b3

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -622,8 +622,7 @@ export default { TelegramAccountAuthSession, loadTelegramAccountSessionString, d
     packageRoot: params.packageRoot,
     stagedPackageRoot,
   });
-
-  return stagedPackageRoot;
+  const shouldLinkHoistedWorkspaceDeps =
 `;
   const stagedImportPatch = `  await ensureStagedPackageDependencies({
     installRoot: params.installRoot,
@@ -632,8 +631,7 @@ export default { TelegramAccountAuthSession, loadTelegramAccountSessionString, d
     stagedPackageRoot,
   });
   await ensureTelegramAccountAuthExportCompat(stagedInstallRoot);
-
-  return stagedPackageRoot;
+  const shouldLinkHoistedWorkspaceDeps =
 `;
   if (!next.includes(stagedImportAnchor)) {
     throw new Error("plugin-resolver staged import anchor drifted");
@@ -680,6 +678,63 @@ export function applyAliceTelegramAccountAuthResolverPatch({
   writeFileSync(resolverPath, after);
   log(
     "[alice-eliza-runtime-patches] patched telegram account-auth resolver compatibility",
+  );
+  return "applied";
+}
+
+const telegramSourcePackageRelativePath =
+  "plugins/plugin-telegram/package.json";
+const telegramSourceAccountAuthExport = "./account-auth-service";
+const telegramSourceAccountAuthTarget = "./dist/account-auth-service.js";
+
+export function isAliceTelegramSourcePackageJsonExportPatched(packageJson) {
+  return (
+    packageJson?.exports &&
+    typeof packageJson.exports === "object" &&
+    !Array.isArray(packageJson.exports) &&
+    packageJson.exports[telegramSourceAccountAuthExport] ===
+      telegramSourceAccountAuthTarget
+  );
+}
+
+export function applyAliceTelegramSourcePackageJsonExportPatch({
+  elizaRoot,
+  log = console.log,
+} = {}) {
+  const packageJsonPath = path.join(
+    elizaRoot,
+    telegramSourcePackageRelativePath,
+  );
+  if (!existsSync(packageJsonPath)) {
+    log(
+      "[alice-eliza-runtime-patches] telegram source package.json absent; skipping source export patch",
+    );
+    return "skipped";
+  }
+
+  const sourceText = readFileSync(packageJsonPath, "utf8");
+  const packageJson = JSON.parse(sourceText);
+
+  if (isAliceTelegramSourcePackageJsonExportPatched(packageJson)) {
+    log(
+      "[alice-eliza-runtime-patches] telegram source package.json account-auth-service export already present",
+    );
+    return "already-applied";
+  }
+
+  if (!packageJson.exports || typeof packageJson.exports !== "object" || Array.isArray(packageJson.exports)) {
+    packageJson.exports = { ".": packageJson.main ?? "./dist/index.js" };
+  }
+  packageJson.exports[telegramSourceAccountAuthExport] =
+    telegramSourceAccountAuthTarget;
+
+  const trailingNewline = sourceText.endsWith("\n") ? "\n" : "";
+  writeFileSync(
+    packageJsonPath,
+    `${JSON.stringify(packageJson, null, 2)}${trailingNewline}`,
+  );
+  log(
+    "[alice-eliza-runtime-patches] patched telegram source package.json to expose account-auth-service",
   );
   return "applied";
 }
@@ -1994,6 +2049,8 @@ export function applyAliceElizaRuntimePatches({
     applyAliceAppCoreCodingAgentsFallbackPatch({ elizaRoot, log }),
     applyAliceAppCoreCompanionStagePatch({ elizaRoot, log }),
     applyAliceAppCoreOpenAccessPatch({ elizaRoot, log }),
+    applyAliceTelegramSourcePackageJsonExportPatch({ elizaRoot, log }),
+    applyAliceTelegramAccountAuthResolverPatch({ elizaRoot, log }),
     // applyAliceBundledKnowledgeStartupDeferralPatch retired against upstream
     // be182cc913b3+ — `seedBundledKnowledge` no longer exists in upstream's
     // packages/agent/src/runtime/eliza.ts (removed during the 866-commit
@@ -2002,18 +2059,14 @@ export function applyAliceElizaRuntimePatches({
     // moot because upstream doesn't seed bundled knowledge from the agent
     // runtime at all. Companion contract guards in 555stream's
     // deploy-555-bot-staging.sh have been removed in lockstep.
-    // The five patches below are retired against the upstream eliza
-    // be182cc913b3+ bump because their anchors no longer match (telegram
-    // account-auth resolver), or their target files have been deleted/moved
-    // upstream (pglite manager, lifeops native-activity-tracker), or their
-    // upstream restructure makes the original behavior moot (lifeops
+    // The four patches below are retired against the upstream eliza
+    // be182cc913b3+ bump because their target files have been deleted/moved
+    // upstream (pglite manager, lifeops native-activity-tracker), or because
+    // the upstream restructure makes the original behavior moot (lifeops
     // calendar/runtime-import). Each can be revived in a focused follow-up
-    // by re-anchoring against the new upstream source. Companion contract
-    // guards in 555stream's deploy-555-bot-staging.sh have been removed in
-    // lockstep. The behaviors most at risk:
+    // by re-anchoring against the new upstream source. The behaviors most
+    // at risk:
     //
-    //   - Telegram account-auth resolver: only matters when Alice runs the
-    //     telegram channel; staging deploy doesn't exercise that path.
     //   - Pglite container-lock: database lockfile arbitration; on EKS we
     //     run pgvector via the timescaledb pod, not pglite, so this is
     //     orthogonal to the staging-alice path.
@@ -2021,7 +2074,6 @@ export function applyAliceElizaRuntimePatches({
     //     of @elizaos/app-lifeops. Upstream substantially restructured the
     //     activity-profile area; the original patches' targets are gone.
     //
-    // applyAliceTelegramAccountAuthResolverPatch({ elizaRoot, log }),
     // applyAlicePgliteContainerLockPatch({ elizaRoot, log }),
     // applyAliceLifeOpsCalendarActionPatch({ elizaRoot, log }),
     // applyAliceLifeOpsRuntimeImportPatch({ elizaRoot, log }),

--- a/scripts/apply-alice-eliza-runtime-patches.test.ts
+++ b/scripts/apply-alice-eliza-runtime-patches.test.ts
@@ -21,6 +21,8 @@ import {
   applyAliceCoreBuildBrowserExternalsPatch,
   applyAliceCoreBuildBrowserExternalsMammothPatch,
   applyAliceTelegramAccountAuthResolverPatch,
+  applyAliceTelegramSourcePackageJsonExportPatch,
+  isAliceTelegramSourcePackageJsonExportPatched,
   applyAliceKubeHealthReadinessPatch,
   applyAliceLifeOpsCalendarActionPatch,
   applyAliceLifeOpsNativeActivityTrackerPatch,
@@ -751,6 +753,12 @@ describe("Alice Eliza runtime patch contract", () => {
           "    packageRoot: params.packageRoot,",
           "    stagedPackageRoot,",
           "  });",
+          "  const shouldLinkHoistedWorkspaceDeps =",
+          '    stageAllHoistedNodeModulesEnabled() ||',
+          '    params.packageName.startsWith("@elizaos/app-");',
+          "  if (shouldLinkHoistedWorkspaceDeps) {",
+          "    // hoist links",
+          "  }",
           "",
           "  return stagedPackageRoot;",
           "}",
@@ -788,6 +796,72 @@ describe("Alice Eliza runtime patch contract", () => {
           log: () => undefined,
         }),
       ).toBe("already-applied");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("adds the account-auth-service export to the telegram source package.json", () => {
+    const tempDir = mkdtempSync(
+      path.join(os.tmpdir(), "alice-telegram-source-pkgjson-"),
+    );
+    try {
+      const pluginDir = path.join(tempDir, "plugins", "plugin-telegram");
+      mkdirSync(pluginDir, { recursive: true });
+      const packageJsonPath = path.join(pluginDir, "package.json");
+      writeFileSync(
+        packageJsonPath,
+        `${JSON.stringify(
+          {
+            name: "@elizaos/plugin-telegram",
+            main: "./dist/index.js",
+            exports: {
+              ".": "./dist/index.js",
+              "./package.json": "./package.json",
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      expect(
+        applyAliceTelegramSourcePackageJsonExportPatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("applied");
+
+      const patched = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+      expect(isAliceTelegramSourcePackageJsonExportPatched(patched)).toBe(true);
+      expect(patched.exports["./account-auth-service"]).toBe(
+        "./dist/account-auth-service.js",
+      );
+      expect(patched.exports["."]).toBe("./dist/index.js");
+      expect(patched.exports["./package.json"]).toBe("./package.json");
+
+      expect(
+        applyAliceTelegramSourcePackageJsonExportPatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("already-applied");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips the telegram source package.json patch when the file is absent", () => {
+    const tempDir = mkdtempSync(
+      path.join(os.tmpdir(), "alice-telegram-source-pkgjson-absent-"),
+    );
+    try {
+      expect(
+        applyAliceTelegramSourcePackageJsonExportPatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("skipped");
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

The eliza submodule bump (#123) retired `applyAliceTelegramAccountAuthResolverPatch` and there was no patch for the telegram source `package.json`. Both are required by 555stream's `deploy-555-bot-staging.sh` source contracts:

- Line 1051: `eliza/plugins/plugin-telegram/package.json` must expose `./account-auth-service`
- Line 1060: `eliza/packages/agent/src/runtime/plugin-resolver.ts` must contain `ensureTelegramAccountAuthExportCompat(...)` call sites

The deploy that ran against `f782d13` failed at the source contract (line 1051). This PR restores both behaviours and re-anchors the resolver patch's `stagedImportAnchor` for upstream's new `const shouldLinkHoistedWorkspaceDeps` continuation.

## Patches

- `applyAliceTelegramSourcePackageJsonExportPatch` (new): writes `./account-auth-service` export into `eliza/plugins/plugin-telegram/package.json`. Idempotent. Skips if file absent.
- `applyAliceTelegramAccountAuthResolverPatch` (un-retired + re-anchored): adds the runtime fallback function to `plugin-resolver.ts`.

## Tests

- 16 existing patch-script tests still pass
- 2 new tests for the source package.json patch (apply + skip-when-absent)
- Test fixture for resolver patch updated to mirror new upstream pattern (`const shouldLinkHoistedWorkspaceDeps =` after `ensureStagedPackageDependencies(...)`)

Total: 18/18 unit tests pass

## Verification

Patch chain end-to-end run against the bumped eliza submodule:
```
[alice-eliza-runtime-patches] applied app-core API bind patch
[alice-eliza-runtime-patches] patched app-core kube /health readiness gate
[alice-eliza-runtime-patches] patched core basic-capabilities to bypass plugin-manager barrel for browser safety
[alice-eliza-runtime-patches] patched core build.ts to externalize fs-extra and graceful-fs in the browser dist
[alice-eliza-runtime-patches] patched core build.ts to externalize mammoth in the browser dist
[alice-eliza-runtime-patches] patched app vite native-module-stub-plugin to stub mammoth
[alice-eliza-runtime-patches] patched app-core coding agents fallback
[alice-eliza-runtime-patches] patched app-core companion stage routes
[alice-eliza-runtime-patches] app-core trusted-local-request source absent; skipping open-access patch
[alice-eliza-runtime-patches] patched telegram source package.json to expose account-auth-service
[alice-eliza-runtime-patches] patched telegram account-auth resolver compatibility
```

Both source contracts in deploy-555-bot-staging.sh now satisfied.