### PR TITLE
fix(alice): write workspace stub for removed upstream plugin-browser-bridge

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -739,6 +739,134 @@ export function applyAliceTelegramSourcePackageJsonExportPatch({
   return "applied";
 }
 
+const browserBridgeStubRelativePath = "plugins/plugin-browser-bridge";
+const browserBridgeStubMarker = "// [milaidy:browser-bridge-stub]";
+
+const browserBridgeStubModuleSource = `${browserBridgeStubMarker}
+const action = Object.freeze({
+  name: "BROWSER_BRIDGE_UNAVAILABLE",
+  description: "Agent Browser Bridge is unavailable in this build.",
+  validate: async () => false,
+  handler: async () => ({
+    text: "Agent Browser Bridge is unavailable in this build.",
+    success: false,
+    values: { success: false, error: "BROWSER_BRIDGE_UNAVAILABLE" },
+    data: { error: "BROWSER_BRIDGE_UNAVAILABLE" },
+  }),
+  parameters: [],
+  examples: [],
+});
+
+export const BROWSER_BRIDGE_ROUTE_SERVICE_TYPE = "browser-bridge-route-service";
+export const browserBridgeActions = [];
+export const browserBridgeInstallAction = action;
+export const browserBridgeOpenManagerAction = action;
+export const browserBridgePlugin = Object.freeze({
+  name: "@elizaos/plugin-browser-bridge",
+  description: "Agent Browser Bridge stub for builds without upstream plugin source.",
+  actions: [],
+  routes: [],
+});
+export const browserBridgeRefreshAction = action;
+export const browserBridgeRevealFolderAction = action;
+export const browserBridgeSchema = {};
+
+export async function buildBrowserBridgeCompanionPackage() { return {}; }
+export function getBrowserBridgeCompanionPackageStatus() { return {}; }
+export async function handleBrowserBridgeRoutes() { return false; }
+export async function openBrowserBridgeCompanionManager() { return false; }
+export async function openBrowserBridgeCompanionPackagePath() { return { path: "" }; }
+
+export default browserBridgePlugin;
+`;
+
+const browserBridgeStubContractsSource = `${browserBridgeStubMarker}
+export const browserBridgeContracts = Object.freeze({});
+export default browserBridgeContracts;
+`;
+
+const browserBridgeStubSchemaSource = `${browserBridgeStubMarker}
+export const browserBridgeSchema = Object.freeze({});
+export default browserBridgeSchema;
+`;
+
+const browserBridgeStubPackageJson = {
+  name: "@elizaos/plugin-browser-bridge",
+  version: "0.0.0-milady-stub",
+  type: "module",
+  main: "./dist/index.js",
+  types: "./dist/index.d.ts",
+  exports: {
+    "./package.json": "./package.json",
+    ".": "./dist/index.js",
+    "./contracts": "./dist/contracts.js",
+    "./schema": "./dist/schema.js",
+  },
+  private: true,
+};
+
+export function isAliceBrowserBridgeWorkspaceStubPatched(elizaRoot) {
+  const distIndex = path.join(
+    elizaRoot,
+    browserBridgeStubRelativePath,
+    "dist",
+    "index.js",
+  );
+  if (!existsSync(distIndex)) return false;
+  return readFileSync(distIndex, "utf8").includes(browserBridgeStubMarker);
+}
+
+export function applyAliceBrowserBridgeWorkspaceStubPatch({
+  elizaRoot,
+  log = console.log,
+} = {}) {
+  const stubDir = path.join(elizaRoot, browserBridgeStubRelativePath);
+  const packageJsonPath = path.join(stubDir, "package.json");
+
+  if (existsSync(packageJsonPath) && !isAliceBrowserBridgeWorkspaceStubPatched(elizaRoot)) {
+    log(
+      "[alice-eliza-runtime-patches] browser-bridge plugin source already present from upstream; skipping stub",
+    );
+    return "skipped";
+  }
+
+  if (isAliceBrowserBridgeWorkspaceStubPatched(elizaRoot)) {
+    log(
+      "[alice-eliza-runtime-patches] browser-bridge workspace stub already in place",
+    );
+    return "already-applied";
+  }
+
+  const srcDir = path.join(stubDir, "src");
+  const distDir = path.join(stubDir, "dist");
+  mkdirSync(srcDir, { recursive: true });
+  mkdirSync(distDir, { recursive: true });
+
+  writeFileSync(
+    packageJsonPath,
+    `${JSON.stringify(browserBridgeStubPackageJson, null, 2)}\n`,
+  );
+  writeFileSync(path.join(srcDir, "index.js"), browserBridgeStubModuleSource);
+  writeFileSync(path.join(distDir, "index.js"), browserBridgeStubModuleSource);
+  writeFileSync(
+    path.join(distDir, "contracts.js"),
+    browserBridgeStubContractsSource,
+  );
+  writeFileSync(
+    path.join(distDir, "schema.js"),
+    browserBridgeStubSchemaSource,
+  );
+  writeFileSync(
+    path.join(distDir, "index.d.ts"),
+    `${browserBridgeStubMarker}\nexport {};\n`,
+  );
+
+  log(
+    "[alice-eliza-runtime-patches] wrote browser-bridge workspace stub (upstream plugins/plugin-browser-bridge was removed)",
+  );
+  return "applied";
+}
+
 export function applyAliceLifeOpsCalendarActionPatch({
   elizaRoot,
   log = console.log,
@@ -2049,6 +2177,7 @@ export function applyAliceElizaRuntimePatches({
     applyAliceAppCoreCodingAgentsFallbackPatch({ elizaRoot, log }),
     applyAliceAppCoreCompanionStagePatch({ elizaRoot, log }),
     applyAliceAppCoreOpenAccessPatch({ elizaRoot, log }),
+    applyAliceBrowserBridgeWorkspaceStubPatch({ elizaRoot, log }),
     applyAliceTelegramSourcePackageJsonExportPatch({ elizaRoot, log }),
     applyAliceTelegramAccountAuthResolverPatch({ elizaRoot, log }),
     // applyAliceBundledKnowledgeStartupDeferralPatch retired against upstream

--- a/scripts/apply-alice-eliza-runtime-patches.test.ts
+++ b/scripts/apply-alice-eliza-runtime-patches.test.ts
@@ -20,6 +20,8 @@ import {
   applyAliceAppViteStubMammothPatch,
   applyAliceCoreBuildBrowserExternalsPatch,
   applyAliceCoreBuildBrowserExternalsMammothPatch,
+  applyAliceBrowserBridgeWorkspaceStubPatch,
+  isAliceBrowserBridgeWorkspaceStubPatched,
   applyAliceTelegramAccountAuthResolverPatch,
   applyAliceTelegramSourcePackageJsonExportPatch,
   isAliceTelegramSourcePackageJsonExportPatched,
@@ -858,6 +860,77 @@ describe("Alice Eliza runtime patch contract", () => {
     try {
       expect(
         applyAliceTelegramSourcePackageJsonExportPatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("skipped");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates a workspace stub for the removed upstream plugin-browser-bridge plugin", () => {
+    const tempDir = mkdtempSync(
+      path.join(os.tmpdir(), "alice-browser-bridge-stub-"),
+    );
+    try {
+      expect(
+        applyAliceBrowserBridgeWorkspaceStubPatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("applied");
+
+      expect(isAliceBrowserBridgeWorkspaceStubPatched(tempDir)).toBe(true);
+
+      const stubDir = path.join(tempDir, "plugins", "plugin-browser-bridge");
+      const packageJson = JSON.parse(
+        readFileSync(path.join(stubDir, "package.json"), "utf8"),
+      );
+      expect(packageJson.name).toBe("@elizaos/plugin-browser-bridge");
+      expect(packageJson.main).toBe("./dist/index.js");
+      expect(packageJson.exports["."]).toBe("./dist/index.js");
+      expect(packageJson.exports["./contracts"]).toBe("./dist/contracts.js");
+      expect(packageJson.exports["./schema"]).toBe("./dist/schema.js");
+
+      // Required by deploy-555-bot-staging.sh container build's
+      // `test -f /src/milaidy/eliza/plugins/plugin-browser-bridge/src/index.js`.
+      expect(
+        readFileSync(path.join(stubDir, "src", "index.js"), "utf8"),
+      ).toContain("[milaidy:browser-bridge-stub]");
+
+      // Required entries for materialize_pkg + post-materialize contracts.
+      for (const entry of ["dist/index.js", "dist/contracts.js", "dist/schema.js"]) {
+        expect(
+          readFileSync(path.join(stubDir, entry), "utf8"),
+        ).toContain("[milaidy:browser-bridge-stub]");
+      }
+
+      expect(
+        applyAliceBrowserBridgeWorkspaceStubPatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("already-applied");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips the browser-bridge workspace stub when upstream source is present", () => {
+    const tempDir = mkdtempSync(
+      path.join(os.tmpdir(), "alice-browser-bridge-present-"),
+    );
+    try {
+      const stubDir = path.join(tempDir, "plugins", "plugin-browser-bridge");
+      mkdirSync(stubDir, { recursive: true });
+      writeFileSync(
+        path.join(stubDir, "package.json"),
+        `${JSON.stringify({ name: "@elizaos/plugin-browser-bridge", version: "1.0.0" }, null, 2)}\n`,
+      );
+
+      expect(
+        applyAliceBrowserBridgeWorkspaceStubPatch({
           elizaRoot: tempDir,
           log: () => undefined,
         }),


### PR DESCRIPTION
## Summary

Upstream eliza eliminated `eliza/plugins/plugin-browser-bridge` entirely during the be182cc913b3+ catch-up. milaidy/555stream still reference the workspace heavily — the deploy-555-bot-staging container build fails at `bun install` with:

```
error: Workspace not found "eliza/plugins/plugin-browser-bridge"
    at /src/milaidy/package.json:55:5
```

## Patch

Adds `applyAliceBrowserBridgeWorkspaceStubPatch` to the alice-eliza-runtime-patches chain. During the `milaidy-source-prebuild-hooks` stage (before the container build copies milaidy/), this writes a stub workspace at `eliza/plugins/plugin-browser-bridge/` with:

- `package.json` — name, exports map, required entries
- `src/index.js` — satisfies `test -f /src/milaidy/.../src/index.js`
- `dist/index.js`, `dist/contracts.js`, `dist/schema.js` — satisfy `materialize_pkg` expected entries and post-materialize contracts

All stub modules carry the `[milaidy:browser-bridge-stub]` sentinel so the patch can detect itself for idempotency and tell stub-vs-upstream apart.

## Verification

- 18 existing patch-script tests still pass
- 2 new tests: stub-creation + idempotency, and skip-when-upstream-present
- 20/20 unit tests pass

End-to-end run against the bumped eliza submodule:
```
[alice-eliza-runtime-patches] applied app-core API bind patch
... (8 prior patches)
[alice-eliza-runtime-patches] wrote browser-bridge workspace stub (upstream plugins/plugin-browser-bridge was removed)
[alice-eliza-runtime-patches] patched telegram source package.json to expose account-auth-service
[alice-eliza-runtime-patches] patched telegram account-auth resolver compatibility
```

`bun install --no-verify --no-progress` (matching container conditions) now exits 0 against the patched tree.

## Tradeoff

The stub returns `BROWSER_BRIDGE_UNAVAILABLE` for all action handlers. Browser Bridge functionality is unavailable in builds that hit this stub — same trade as the existing post-install stub script `scripts/patch-elizaos-plugin-browser-bridge-package.mjs`. Restoring the upstream plugin (or vendoring it locally outside the eliza submodule) is a separate follow-up.