### PR TITLE
fix(alice): add ./register subpath exports to upstream app plugins

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -739,6 +739,87 @@ export function applyAliceTelegramSourcePackageJsonExportPatch({
   return "applied";
 }
 
+const aliceAppPluginRegisterExportRelativePaths = [
+  "plugins/app-wallet",
+  "plugins/app-contacts",
+  "plugins/app-phone",
+  "plugins/app-wifi",
+];
+
+export function isAliceAppPluginRegisterExportPatched(packageJson) {
+  return (
+    packageJson?.exports &&
+    typeof packageJson.exports === "object" &&
+    !Array.isArray(packageJson.exports) &&
+    packageJson.exports["./register"] !== undefined
+  );
+}
+
+export function applyAliceAppPluginRegisterExportPatch({
+  elizaRoot,
+  log = console.log,
+} = {}) {
+  let patchedFiles = 0;
+  let inspectedFiles = 0;
+  let alreadyApplied = 0;
+
+  for (const pluginRelativePath of aliceAppPluginRegisterExportRelativePaths) {
+    const packageJsonPath = path.join(
+      elizaRoot,
+      pluginRelativePath,
+      "package.json",
+    );
+    if (!existsSync(packageJsonPath)) {
+      continue;
+    }
+    inspectedFiles += 1;
+    const sourceText = readFileSync(packageJsonPath, "utf8");
+    const packageJson = JSON.parse(sourceText);
+
+    if (isAliceAppPluginRegisterExportPatched(packageJson)) {
+      alreadyApplied += 1;
+      continue;
+    }
+
+    if (
+      !packageJson.exports ||
+      typeof packageJson.exports !== "object" ||
+      Array.isArray(packageJson.exports)
+    ) {
+      packageJson.exports = { ".": packageJson.main ?? "./dist/index.js" };
+    }
+    packageJson.exports["./register"] = {
+      types: "./dist/register.d.ts",
+      import: "./dist/register.js",
+      default: "./dist/register.js",
+    };
+
+    const trailingNewline = sourceText.endsWith("\n") ? "\n" : "";
+    writeFileSync(
+      packageJsonPath,
+      `${JSON.stringify(packageJson, null, 2)}${trailingNewline}`,
+    );
+    patchedFiles += 1;
+  }
+
+  if (inspectedFiles === 0) {
+    log(
+      "[alice-eliza-runtime-patches] no app plugin packages found; skipping register exports patch",
+    );
+    return "skipped";
+  }
+  if (patchedFiles === 0) {
+    log(
+      "[alice-eliza-runtime-patches] app plugin register exports already patched",
+    );
+    return "already-applied";
+  }
+  log(
+    `[alice-eliza-runtime-patches] patched register exports on ${patchedFiles} app plugin package.json file(s)`,
+  );
+  return "applied";
+}
+
 const browserBridgeStubRelativePath = "plugins/plugin-browser-bridge";
 const browserBridgeStubMarker = "// [milaidy:browser-bridge-stub]";
 
@@ -2178,6 +2259,7 @@ export function applyAliceElizaRuntimePatches({
     applyAliceAppCoreCompanionStagePatch({ elizaRoot, log }),
     applyAliceAppCoreOpenAccessPatch({ elizaRoot, log }),
     applyAliceBrowserBridgeWorkspaceStubPatch({ elizaRoot, log }),
+    applyAliceAppPluginRegisterExportPatch({ elizaRoot, log }),
     applyAliceTelegramSourcePackageJsonExportPatch({ elizaRoot, log }),
     applyAliceTelegramAccountAuthResolverPatch({ elizaRoot, log }),
     // applyAliceBundledKnowledgeStartupDeferralPatch retired against upstream

--- a/scripts/apply-alice-eliza-runtime-patches.test.ts
+++ b/scripts/apply-alice-eliza-runtime-patches.test.ts
@@ -20,6 +20,8 @@ import {
   applyAliceAppViteStubMammothPatch,
   applyAliceCoreBuildBrowserExternalsPatch,
   applyAliceCoreBuildBrowserExternalsMammothPatch,
+  applyAliceAppPluginRegisterExportPatch,
+  isAliceAppPluginRegisterExportPatched,
   applyAliceBrowserBridgeWorkspaceStubPatch,
   isAliceBrowserBridgeWorkspaceStubPatched,
   applyAliceTelegramAccountAuthResolverPatch,
@@ -860,6 +862,77 @@ describe("Alice Eliza runtime patch contract", () => {
     try {
       expect(
         applyAliceTelegramSourcePackageJsonExportPatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("skipped");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("adds ./register exports to app-plugin package.json files for static SPA imports", () => {
+    const tempDir = mkdtempSync(
+      path.join(os.tmpdir(), "alice-app-register-exports-"),
+    );
+    try {
+      const plugins = ["app-wallet", "app-contacts", "app-phone", "app-wifi"];
+      for (const plugin of plugins) {
+        const pluginDir = path.join(tempDir, "plugins", plugin);
+        mkdirSync(pluginDir, { recursive: true });
+        writeFileSync(
+          path.join(pluginDir, "package.json"),
+          `${JSON.stringify(
+            {
+              name: `@elizaos/${plugin}`,
+              main: "./dist/index.js",
+              exports: { ".": "./dist/index.js" },
+            },
+            null,
+            2,
+          )}\n`,
+        );
+      }
+
+      expect(
+        applyAliceAppPluginRegisterExportPatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("applied");
+
+      for (const plugin of plugins) {
+        const patched = JSON.parse(
+          readFileSync(
+            path.join(tempDir, "plugins", plugin, "package.json"),
+            "utf8",
+          ),
+        );
+        expect(isAliceAppPluginRegisterExportPatched(patched)).toBe(true);
+        const registerExport = patched.exports["./register"];
+        expect(registerExport.import).toBe("./dist/register.js");
+        expect(registerExport.default).toBe("./dist/register.js");
+        expect(patched.exports["."]).toBe("./dist/index.js");
+      }
+
+      expect(
+        applyAliceAppPluginRegisterExportPatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("already-applied");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips the app-register-exports patch when no app plugins are present", () => {
+    const tempDir = mkdtempSync(
+      path.join(os.tmpdir(), "alice-app-register-absent-"),
+    );
+    try {
+      expect(
+        applyAliceAppPluginRegisterExportPatch({
           elizaRoot: tempDir,
           log: () => undefined,
         }),


### PR DESCRIPTION
## Summary

Alice's `apps/app/src/main.tsx` imports `@elizaos/app-wallet/register` (static, line 4) and `@elizaos/app-{contacts,phone,wifi}/register` (dynamic, lines 127-129). Upstream eliza `be182cc913b3+` ships these plugins' `package.json` with only `"."` (and in some cases `"./plugin"`, `"./package.json"`) in `exports` — no `"./register"` entry. Vite SPA build fails with:

```
[commonjs--resolver] Missing "./register" specifier in "@elizaos/app-wallet" package
```

## Patch

`applyAliceAppPluginRegisterExportPatch` adds:

```json
"./register": {
  "types": "./dist/register.d.ts",
  "import": "./dist/register.js",
  "default": "./dist/register.js"
}
```

to each of the four plugins' `package.json` during the `milaidy-source-prebuild-hooks` stage. The plugins' shared tsup config walks every `src/*.ts` file as an entry, so `dist/register.js` is always emitted once `bun run build` runs. Only the package.json subpath was missing.

## Tests

- 22/22 unit tests pass (2 new: apply + skip-when-absent)
- End-to-end run against bumped eliza submodule patched 4 plugin package.json files
- Idempotent (second run reports `already-applied`)

## Why this is the right shape

- The `dist/register.js` artifact is a real build output of upstream's tsup config, not a stub.
- The patch is purely additive to package.json; doesn't modify exports."." or any other entry.
- Skips silently when no app plugins exist (e.g., a future upstream that completes a pkg-restructure before milaidy bumps).