### PR TITLE
fix(alice): point @elizaos/shared,ui,vault main+exports at TS source

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -739,6 +739,95 @@ export function applyAliceTelegramSourcePackageJsonExportPatch({
   return "applied";
 }
 
+const aliceUpstreamSourceMainPackageRelativePaths = [
+  "packages/shared",
+  "packages/ui",
+  "packages/vault",
+];
+const aliceUpstreamSourceMainSentinel = "0.0.0-milady-source-main";
+
+export function isAliceUpstreamSourceMainPatched(packageJson) {
+  return packageJson?.version === aliceUpstreamSourceMainSentinel;
+}
+
+export function applyAliceUpstreamPackageSourceMainPatch({
+  elizaRoot,
+  log = console.log,
+} = {}) {
+  let patchedFiles = 0;
+  let inspectedFiles = 0;
+  let alreadyApplied = 0;
+
+  for (const pkgRelativePath of aliceUpstreamSourceMainPackageRelativePaths) {
+    const packageJsonPath = path.join(
+      elizaRoot,
+      pkgRelativePath,
+      "package.json",
+    );
+    const srcEntryPath = path.join(elizaRoot, pkgRelativePath, "src/index.ts");
+    if (!existsSync(packageJsonPath)) continue;
+    if (!existsSync(srcEntryPath)) {
+      // Source entry missing — leave the dist-main alone and let the deploy
+      // fall back to whatever upstream ships.
+      continue;
+    }
+    inspectedFiles += 1;
+    const sourceText = readFileSync(packageJsonPath, "utf8");
+    const packageJson = JSON.parse(sourceText);
+
+    if (isAliceUpstreamSourceMainPatched(packageJson)) {
+      alreadyApplied += 1;
+      continue;
+    }
+
+    packageJson.version = aliceUpstreamSourceMainSentinel;
+    packageJson.main = "./src/index.ts";
+    packageJson.types = "./src/index.ts";
+    packageJson.exports = {
+      ".": {
+        types: "./src/index.ts",
+        bun: "./src/index.ts",
+        import: "./src/index.ts",
+        default: "./src/index.ts",
+      },
+      "./package.json": "./package.json",
+      "./*": {
+        types: "./src/*.ts",
+        bun: "./src/*.ts",
+        import: "./src/*.ts",
+        default: "./src/*.ts",
+      },
+    };
+    if (!packageJson.type) {
+      packageJson.type = "module";
+    }
+
+    const trailingNewline = sourceText.endsWith("\n") ? "\n" : "";
+    writeFileSync(
+      packageJsonPath,
+      `${JSON.stringify(packageJson, null, 2)}${trailingNewline}`,
+    );
+    patchedFiles += 1;
+  }
+
+  if (inspectedFiles === 0) {
+    log(
+      "[alice-eliza-runtime-patches] no upstream eliza source-main targets present; skipping source-main patch",
+    );
+    return "skipped";
+  }
+  if (patchedFiles === 0) {
+    log(
+      "[alice-eliza-runtime-patches] upstream eliza source-main exports already patched",
+    );
+    return "already-applied";
+  }
+  log(
+    `[alice-eliza-runtime-patches] rerouted ${patchedFiles} upstream eliza package.json file(s) to TS source (shared/ui/vault main: src/index.ts)`,
+  );
+  return "applied";
+}
+
 const aliceAppPluginRegisterExportRelativePaths = [
   "plugins/app-wallet",
   "plugins/app-contacts",
@@ -2258,6 +2347,7 @@ export function applyAliceElizaRuntimePatches({
     applyAliceAppCoreCodingAgentsFallbackPatch({ elizaRoot, log }),
     applyAliceAppCoreCompanionStagePatch({ elizaRoot, log }),
     applyAliceAppCoreOpenAccessPatch({ elizaRoot, log }),
+    applyAliceUpstreamPackageSourceMainPatch({ elizaRoot, log }),
     applyAliceBrowserBridgeWorkspaceStubPatch({ elizaRoot, log }),
     applyAliceAppPluginRegisterExportPatch({ elizaRoot, log }),
     applyAliceTelegramSourcePackageJsonExportPatch({ elizaRoot, log }),


### PR DESCRIPTION
## Summary

Upstream eliza ships `@elizaos/shared`, `@elizaos/ui`, `@elizaos/vault` (and others) with `main` pointing at `./dist/index.js`. Their `dist/` is never present in source — upstream's monorepo relies on per-package build steps or bun-conditional source exports.

Without one of those, vite (running under bun in the container build) fails with:

```
[commonjs--resolver] Failed to resolve entry for package "@elizaos/shared".
The package may have incorrect main/module/exports specified in its package.json.
```

(Same shape as the prior `@elizaos/ui` failure that stream#375 patched by adding a `bun run build` step.)

## Patch

`applyAliceUpstreamPackageSourceMainPatch` rewrites `main` and `exports` for `packages/{shared,ui,vault}` to point at TypeScript source:

```json
"main": "./src/index.ts",
"exports": {
  ".":             { "types": "./src/index.ts", "bun": "./src/index.ts", "import": "./src/index.ts", "default": "./src/index.ts" },
  "./package.json": "./package.json",
  "./*":           { "types": "./src/*.ts", "bun": "./src/*.ts", "import": "./src/*.ts", "default": "./src/*.ts" }
}
```

The container runtime is bun (oven/bun:1.3.10-slim) and so is the SPA build pipeline — both resolve TypeScript sources natively. This mirrors the structure upstream's own `@elizaos/agent` already uses.

Sentinel `version: "0.0.0-milady-source-main"` makes the patch idempotent; it self-skips when the source entry is missing.

## Why this instead of building dist for every package

- Upstream eliza's package.json mains all point at `dist/`, but their `dist/` is never shipped in git. Building each one before the SPA build is feasible but cascades: shared, then vault, then app-core, then cloud-routing, etc.
- The wildcard `./*` source export covers every subpath in one shot (12+ subpath imports across the milaidy tree), avoiding the need to enumerate each one in package.json — which is where `@elizaos/shared` was already broken (only 2 of its many subpaths were declared).
- TypeScript source loading is the path that upstream's own bun monorepo development uses, and it's what `@elizaos/agent` already relies on in the same image.