### PR TITLE
fix(alice): add plugin-computeruse workspace + source-main

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "eliza/plugins/plugin-app-control",
     "eliza/plugins/plugin-browser-bridge",
     "eliza/plugins/plugin-commands",
+    "eliza/plugins/plugin-computeruse",
     "eliza/plugins/plugin-discord",
     "eliza/plugins/plugin-edge-tts",
     "eliza/plugins/plugin-elizacloud",

--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -743,6 +743,12 @@ const aliceUpstreamSourceMainPackageRelativePaths = [
   "packages/shared",
   "packages/ui",
   "packages/vault",
+  // plugin-computeruse: imported statically by eliza/packages/agent/src/api
+  // (server-route-dispatch.ts, index.ts, server.ts) so it MUST resolve at
+  // runtime even though milaidy doesn't actively use the compute-use
+  // surface in staging. Added as a workspace; source-main lets bun resolve
+  // its main to ./src/index.ts directly without the dist build step.
+  "plugins/plugin-computeruse",
 ];
 const aliceUpstreamSourceMainSentinel = "0.0.0-milady-source-main";
 


### PR DESCRIPTION
Pod crashes at startup:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@elizaos/plugin-computeruse' imported from /app/milaidy/dist/entry.js
```

`eliza/packages/agent/src/api/{server-route-dispatch,index,server}.ts` statically import `@elizaos/plugin-computeruse`. tsdown's `pluginExternal` regex keeps the imports out of the bundle, so they end up as externals in dist/entry.js — and Node has to resolve them at runtime.

milaidy's workspaces array didn't list `eliza/plugins/plugin-computeruse`, so bun install never linked it into node_modules. Adding it as a workspace + including it in the source-main patch list (same pattern as shared/ui/vault) lets the plugin resolve via TS source under bun without requiring a dist build.

The compute-use functional surface is not exercised at staging startup — only the package boundary is resolved. Adding the workspace satisfies that resolution.