### PR TITLE
fix(alice): extend source-main patch to all statically-imported eliza plugins

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -743,12 +743,24 @@ const aliceUpstreamSourceMainPackageRelativePaths = [
   "packages/shared",
   "packages/ui",
   "packages/vault",
-  // plugin-computeruse: imported statically by eliza/packages/agent/src/api
-  // (server-route-dispatch.ts, index.ts, server.ts) so it MUST resolve at
-  // runtime even though milaidy doesn't actively use the compute-use
-  // surface in staging. Added as a workspace; source-main lets bun resolve
-  // its main to ./src/index.ts directly without the dist build step.
+  // The plugins below are imported statically from eliza/packages/agent/src
+  // or eliza/packages/app-core/src and survive tsdown's pluginExternal regex
+  // into the bundled dist/entry.js. They MUST resolve at runtime under
+  // Node + tsx (the production container runtime). Each gets its main
+  // rewritten to ./src/index.ts via the source-main patch and is
+  // materialized into node_modules by stream's deploy script.
+  "plugins/plugin-aosp-local-inference",
+  "plugins/plugin-browser",
+  "plugins/plugin-capacitor-bridge",
+  "plugins/plugin-coding-tools",
   "plugins/plugin-computeruse",
+  "plugins/plugin-discord",
+  "plugins/plugin-elizacloud",
+  "plugins/plugin-local-inference",
+  "plugins/plugin-mcp",
+  "plugins/plugin-streaming",
+  "plugins/plugin-workflow",
+  "plugins/plugin-x402",
 ];
 const aliceUpstreamSourceMainSentinel = "0.0.0-milady-source-main";
 


### PR DESCRIPTION
Eliza agent/app-core statically import 16 `@elizaos/plugin-*` packages that survive tsdown's externalize and end up as required imports in `dist/entry.js`. Iteratively crashing on each was unsustainable (plugin-elizacloud, plugin-computeruse, plugin-workflow so far).

Pre-empt the rest by adding source-main rewrites for all 11 remaining missing plugins (computeruse already in list). Each gets `main: ./src/index.ts` so Node+tsx resolves without a dist build. Companion stream PR adds materialize_pkg calls so node_modules has the source.