### PR TITLE
fix(alice): add plugin-imessage + plugin-whatsapp to source-main patch list

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -756,9 +756,11 @@ const aliceUpstreamSourceMainPackageRelativePaths = [
   "plugins/plugin-computeruse",
   "plugins/plugin-discord",
   "plugins/plugin-elizacloud",
+  "plugins/plugin-imessage",
   "plugins/plugin-local-inference",
   "plugins/plugin-mcp",
   "plugins/plugin-streaming",
+  "plugins/plugin-whatsapp",
   "plugins/plugin-workflow",
   "plugins/plugin-x402",
 ];


### PR DESCRIPTION
Both are statically imported from the eliza agent runtime source and need to resolve at runtime. Companion stream PR switches their materialize call to use the upstream eliza source instead of the empty milaidy submodule slot.