### PR TITLE
fix(alice): extend source-main to cloud-routing + sibling eliza/packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -304,7 +304,6 @@
     "@elizaos/plugin-discord": "workspace:*",
     "@elizaos/plugin-openai": "workspace:*",
     "@elizaos/plugin-streaming": "workspace:*",
-    "@elizaos/plugin-whatsapp": "workspace:*",
     "@elizaos/plugin-workflow": "workspace:*",
     "@elizaos/plugin-x402": "workspace:*",
     "@elizaos/plugin-openrouter": "2.0.0-alpha.13",

--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -740,9 +740,14 @@ export function applyAliceTelegramSourcePackageJsonExportPatch({
 }
 
 const aliceUpstreamSourceMainPackageRelativePaths = [
+  "packages/cloud-routing",
+  "packages/elizaos",
+  "packages/scenario-runner",
   "packages/shared",
+  "packages/skills",
   "packages/ui",
   "packages/vault",
+  "packages/workflows",
   // The plugins below are imported statically from eliza/packages/agent/src
   // or eliza/packages/app-core/src and survive tsdown's pluginExternal regex
   // into the bundled dist/entry.js. They MUST resolve at runtime under


### PR DESCRIPTION
Plugin-streaming's symlinked source loads but its dep `@elizaos/cloud-routing` has main: `./dist/index.js` with no dist built — same pattern shared/ui/vault hit. Extend source-main patch to cloud-routing + 4 defensive siblings (elizaos, scenario-runner, skills, workflows). Also drops a duplicate plugin-whatsapp entry from #133.