### PR TITLE
fix(alice): extend source-main to eliza/cloud/packages/{sdk,billing,ui}

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -740,6 +740,9 @@ export function applyAliceTelegramSourcePackageJsonExportPatch({
 }
 
 const aliceUpstreamSourceMainPackageRelativePaths = [
+  "cloud/packages/billing",
+  "cloud/packages/sdk",
+  "cloud/packages/ui",
   "packages/cloud-routing",
   "packages/elizaos",
   "packages/scenario-runner",


### PR DESCRIPTION
plugin-elizacloud imports `@elizaos/cloud-sdk` which is staged at the plugin's local node_modules with main: ./dist/index.js and no dist built. Same fix shape as #134 (cloud-routing). Adds 3 cloud/packages/* to source-main.