### PR TITLE
fix(alice): add plugin-signal to source-main patch list

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -767,6 +767,7 @@ const aliceUpstreamSourceMainPackageRelativePaths = [
   "plugins/plugin-imessage",
   "plugins/plugin-local-inference",
   "plugins/plugin-mcp",
+  "plugins/plugin-signal",
   "plugins/plugin-streaming",
   "plugins/plugin-whatsapp",
   "plugins/plugin-workflow",


### PR DESCRIPTION
Companion to stream#388 which switches plugin-signal's materialize source from the older milaidy submodule to upstream eliza. Adds plugin-signal to source-main so its main rewrites to ./src/index.ts under Node+tsx.