### PR TITLE
fix(alice): re-export AppCoreRuntimeHooks surface from packages/app-core/src/index.ts

### DIFF
--- a/packages/app-core/src/index.ts
+++ b/packages/app-core/src/index.ts
@@ -12,3 +12,19 @@ export {
   requestRestart,
   setRestartHandler,
 } from "@miladyai/shared/restart";
+
+// AppCoreRuntimeHooks surface — eliza/packages/agent/src/runtime/eliza.ts
+// destructures these names from `await import("@elizaos/app-core")` at runtime.
+// In our deploy layout, that dynamic import resolves to this package (the
+// milaidy `packages/app-core`, mounted at node_modules/@elizaos/app-core),
+// not to eliza/packages/app-core. Without these re-exports, the destructure
+// yields undefined and the agent crashes in runtime-boot with
+// `TypeError: runVaultBootstrap is not a function`.
+export { runVaultBootstrap } from "./services/vault-bootstrap";
+export { sharedVault } from "./services/vault-mirror";
+export {
+  applyAccountPoolApiCredentials,
+  getDefaultAccountPool,
+  startAccountPoolKeepAlive,
+} from "./services/account-pool";
+export { hydrateWalletKeysFromNodePlatformSecureStore } from "./security/hydrate-wallet-keys-from-platform-store";


### PR DESCRIPTION
## Summary

Even after milaidy#139 landed and the staging deploy of `bc6a6b5` ran the source-main patcher successfully (30 packages rerouted), the alice-bot pod still CrashLoops with:

```
[milady][startup] runtime-boot:error error="runVaultBootstrap is not a function"
TypeError: runVaultBootstrap is not a function
```

## Root cause (confirmed via debug pod)

The agent at `eliza/packages/agent/src/runtime/eliza.ts:127` does:

```ts
async function importAppCoreRuntime(): Promise<AppCoreRuntimeModule> {
  return import("@elizaos/app-core") as Promise<AppCoreRuntimeModule>;
}
```

Then destructures `{ runVaultBootstrap, hydrateWalletKeysFromNodePlatformSecureStore, ... }` (the AppCoreRuntimeHooks shape from `eliza/packages/core/src/app-core-runtime-hooks.ts:9`).

At runtime, the dynamic import walks `node_modules` and resolves to **`/app/milaidy/node_modules/@elizaos/app-core/`** — which is a copy of **this** package (milaidy `packages/app-core`, internally named `@miladyai/app-core`), **NOT** the upstream `eliza/packages/app-core`. milaidy#139 patched the upstream eliza app-core's package.json but had zero effect on this resolution path.

This package's `src/index.ts` was 14 lines and only re-exported `@miladyai/shared/config` and `@miladyai/shared/restart`. None of the AppCoreRuntimeHooks symbols were exposed at the public surface — the destructure yielded `undefined` for each.

## What's in this PR

All six AppCoreRuntimeHooks symbols already exist in milaidy. Just re-exporting them:

| symbol | source |
|---|---|
| `runVaultBootstrap` | `services/vault-bootstrap.ts:219` |
| `sharedVault` | `services/vault-mirror.ts:24` |
| `getDefaultAccountPool` | `services/account-pool.ts:720` |
| `applyAccountPoolApiCredentials` | `services/account-pool.ts:734` |
| `startAccountPoolKeepAlive` | `services/account-pool.ts:865` |
| `hydrateWalletKeysFromNodePlatformSecureStore` | `security/hydrate-wallet-keys-from-platform-store.ts:23` |

Added an inline comment explaining the resolution-chain trap so the next person doesn't fall into it.

## Verified

- Debug pod against image `sha-bc6a6b5-milaidy-0baef2f-build-6fc46162` confirmed that `/app/milaidy/node_modules/@elizaos/app-core/package.json` has `name: @miladyai/app-core` and `main: src/index.ts`, and the file is the 14-line stub.
- All six symbols confirmed to exist as named exports in the corresponding milaidy source files.

## Test plan

- [ ] CI green
- [ ] Merge → trigger commit on `render-network-os/555-bot:alice` → staging deploy
- [ ] Verify `alice-bot` pod reaches `Ready 1/1` in `staging` ns of `rndr-stream-staging`
- [ ] Confirm `runtime-boot` reaches completion (no `runVaultBootstrap is not a function` crash, no `hydrateWalletKeysFromNodePlatformSecureStore` warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)