### PR TITLE
fix(alice): strip UI re-exports from app-training's Node runtime entry

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -697,6 +697,76 @@ export function isAliceTelegramSourcePackageJsonExportPatched(packageJson) {
   );
 }
 
+const appTrainingIndexRelativePath = "plugins/app-training/src/index.ts";
+const appTrainingNodeSafeSentinel = "// [milaidy:app-training-node-safe-index]";
+const appTrainingNodeSafeBanner = `${appTrainingNodeSafeSentinel}
+// eliza/packages/app-core/src/runtime/eliza.ts loads this package via
+// \`await import("@elizaos/app-training")\` to register training runtime hooks.
+// Upstream's src/index.ts also re-exports the React UI surface
+// (\`./ui/index.js\` and \`./ui/FineTuningView.js\`), which transitively imports
+// \`@elizaos/ui\` whose src/index.ts has a top-level
+// \`import "./styles/styles.css"\` side-effect. Node ESM has no .css loader at
+// production runtime (Bun + tsx), so loading the package root in Node throws
+// "Unknown file extension '.css'" and the agent's loader catches it as
+// "@elizaos/app-training not installed, skipping runtime hooks" — which fails
+// the deploy script's startup log contract.
+//
+// This Node-safe variant drops only the two UI re-exports. Browser/SPA
+// consumers can still reach FineTuningView via the wildcard subpath
+// \`@elizaos/app-training/ui/FineTuningView\` (exposed by the source-main
+// patch's "./*" exports entry).
+`;
+const appTrainingUiReexportLines = [
+  'export * from "./ui/index.js";',
+  'export * from "./ui/FineTuningView.js";',
+];
+
+export function isAliceAppTrainingNodeSafeIndexPatched(source) {
+  return source.includes(appTrainingNodeSafeSentinel);
+}
+
+export function applyAliceAppTrainingNodeSafeIndexPatch({
+  elizaRoot,
+  log = console.log,
+} = {}) {
+  const indexPath = path.join(elizaRoot, appTrainingIndexRelativePath);
+  if (!existsSync(indexPath)) {
+    log(
+      "[alice-eliza-runtime-patches] plugins/app-training/src/index.ts absent; skipping node-safe-index patch",
+    );
+    return "skipped";
+  }
+  const source = readFileSync(indexPath, "utf8");
+  if (isAliceAppTrainingNodeSafeIndexPatched(source)) {
+    log(
+      "[alice-eliza-runtime-patches] plugins/app-training/src/index.ts node-safe-index already applied",
+    );
+    return "already-applied";
+  }
+  let next = source;
+  let removed = 0;
+  for (const line of appTrainingUiReexportLines) {
+    if (next.includes(`${line}\n`)) {
+      next = next.replace(`${line}\n`, "");
+      removed += 1;
+    } else if (next.includes(line)) {
+      next = next.replace(line, "");
+      removed += 1;
+    }
+  }
+  if (removed === 0) {
+    log(
+      "[alice-eliza-runtime-patches] no app-training UI re-exports found to strip; writing sentinel only (upstream already Node-safe?)",
+    );
+  }
+  next = `${appTrainingNodeSafeBanner}${next}`;
+  writeFileSync(indexPath, next);
+  log(
+    `[alice-eliza-runtime-patches] patched plugins/app-training/src/index.ts to remove ${removed} UI re-export(s) for Node-safe runtime load`,
+  );
+  return "applied";
+}
+
 const elizacloudIndexRelativePath = "plugins/plugin-elizacloud/src/index.ts";
 const elizacloudReexportsSentinel =
   "// [milaidy:elizacloud-agent-export-compat]";
@@ -2534,6 +2604,7 @@ export function applyAliceElizaRuntimePatches({
     applyAliceTelegramSourcePackageJsonExportPatch({ elizaRoot, log }),
     applyAliceTelegramAccountAuthResolverPatch({ elizaRoot, log }),
     applyAliceElizacloudReexportPatch({ elizaRoot, log }),
+    applyAliceAppTrainingNodeSafeIndexPatch({ elizaRoot, log }),
     // applyAliceBundledKnowledgeStartupDeferralPatch retired against upstream
     // be182cc913b3+ — `seedBundledKnowledge` no longer exists in upstream's
     // packages/agent/src/runtime/eliza.ts (removed during the 866-commit


### PR DESCRIPTION
## Summary

After milaidy#140 unblocked the `runVaultBootstrap` crash, the bot deploy of `83ae7eff` reached `1/1 Ready` (pod healthy, runtime-boot:done in 13.5s). The deploy script then failed its post-startup log contract on this warning:

```
[eliza] @elizaos/app-training not installed, skipping runtime hooks:
  Unknown file extension ".css" for /app/milaidy/eliza/packages/ui/src/styles/styles.css
```

## Root cause

1. `eliza/packages/app-core/src/runtime/eliza.ts:412` loads training hooks via `await import("@elizaos/app-training")`.
2. After milaidy#139's source-main patch, `@elizaos/app-training` resolves to `plugins/app-training/src/index.ts`.
3. `src/index.ts` re-exports `./ui/index.js` and `./ui/FineTuningView.js`, both of which import from `@elizaos/ui`.
4. `eliza/packages/ui/src/index.ts:1` is `import "./styles/styles.css"` — a top-level side-effect CSS import.
5. Node ESM at runtime (Bun + tsx) has no `.css` loader → import throws → loader catches and logs `not installed`.

## Upstream comparison

Diff against `origin/develop`: only a version bump and the atropos export removal. The UI re-exports + CSS chain are identical on develop. No fix coming from rebase.

## Why this didn't fail pre-#139

The same load attempt was happening, but the warning was `Cannot find module .../dist/index.js` (dist-missing) instead of the CSS error. **Same warning shape, same validator behavior** — we just never got far enough to see it, because every prior deploy CrashLoop'd on `runVaultBootstrap` before the post-startup validator could run. This is the first deploy where the pod actually came up.

## Why this is a fix, not a delete

- Server-side runtime entry has no business pulling React + CSS — that's a defect in the upstream entry, not an intentional contract.
- All server-side exports remain: `core`, `routes`, `services`, `setup-routes`, `register-runtime`, `cli`, `privacy-filter`, `skill-scoring-cron`, `train`, `backends/{tinker,native,atropos}`, `optimizers`.
- Only the two `./ui/*` lines are removed.
- The single consumer of `FineTuningView` from the package root (`eliza/packages/app/src/main.tsx`) is the upstream eliza SPA; that package is NOT in milaidy's workspaces and is NOT built by the bot deploy. Verified via `grep` across the workspace.
- Browser/SPA consumers that DO want the UI still have a path: `@elizaos/app-training/ui/FineTuningView` via the source-main patch's `./*` exports wildcard.

## What the PR adds

A single new patch function `applyAliceAppTrainingNodeSafeIndexPatch` in `scripts/apply-alice-eliza-runtime-patches.mjs`:

- Sentinel-guarded (`// [milaidy:app-training-node-safe-index]`).
- Idempotent on re-run (verified locally — second invocation reports `already-applied`).
- No-op if upstream eventually ships a Node-safe entry (sentinel survives).
- Banner comment in the patched file documents *why* the lines were stripped, so the next person reading `plugins/app-training/src/index.ts` understands.

Registered in `applyAliceElizaRuntimePatches` alongside the existing patch chain.

## Verified locally

```
$ node scripts/apply-alice-eliza-runtime-patches.mjs
...
[alice-eliza-runtime-patches] patched plugins/app-training/src/index.ts to remove 2 UI re-export(s) for Node-safe runtime load

$ node scripts/apply-alice-eliza-runtime-patches.mjs
...
[alice-eliza-runtime-patches] plugins/app-training/src/index.ts node-safe-index already applied
```

The resulting `src/index.ts` keeps every server-side export and only strips the two `./ui/*` lines.

## Test plan

- [ ] CI green
- [ ] Merge → trigger commit on `render-network-os/555-bot:alice` → staging deploy
- [ ] `alice-bot` pod reaches `Ready 1/1`
- [ ] Pod logs no longer show `@elizaos/app-training not installed, skipping runtime hooks`
- [ ] Deploy script's startup log contract passes → `deploy finished successfully` instead of exit-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)