### PR TITLE
revert(alice): #141 app-training Node-safe index strip (re-exposes boot hang)

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -697,76 +697,6 @@ export function isAliceTelegramSourcePackageJsonExportPatched(packageJson) {
   );
 }
 
-const appTrainingIndexRelativePath = "plugins/app-training/src/index.ts";
-const appTrainingNodeSafeSentinel = "// [milaidy:app-training-node-safe-index]";
-const appTrainingNodeSafeBanner = `${appTrainingNodeSafeSentinel}
-// eliza/packages/app-core/src/runtime/eliza.ts loads this package via
-// \`await import("@elizaos/app-training")\` to register training runtime hooks.
-// Upstream's src/index.ts also re-exports the React UI surface
-// (\`./ui/index.js\` and \`./ui/FineTuningView.js\`), which transitively imports
-// \`@elizaos/ui\` whose src/index.ts has a top-level
-// \`import "./styles/styles.css"\` side-effect. Node ESM has no .css loader at
-// production runtime (Bun + tsx), so loading the package root in Node throws
-// "Unknown file extension '.css'" and the agent's loader catches it as
-// "@elizaos/app-training not installed, skipping runtime hooks" — which fails
-// the deploy script's startup log contract.
-//
-// This Node-safe variant drops only the two UI re-exports. Browser/SPA
-// consumers can still reach FineTuningView via the wildcard subpath
-// \`@elizaos/app-training/ui/FineTuningView\` (exposed by the source-main
-// patch's "./*" exports entry).
-`;
-const appTrainingUiReexportLines = [
-  'export * from "./ui/index.js";',
-  'export * from "./ui/FineTuningView.js";',
-];
-
-export function isAliceAppTrainingNodeSafeIndexPatched(source) {
-  return source.includes(appTrainingNodeSafeSentinel);
-}
-
-export function applyAliceAppTrainingNodeSafeIndexPatch({
-  elizaRoot,
-  log = console.log,
-} = {}) {
-  const indexPath = path.join(elizaRoot, appTrainingIndexRelativePath);
-  if (!existsSync(indexPath)) {
-    log(
-      "[alice-eliza-runtime-patches] plugins/app-training/src/index.ts absent; skipping node-safe-index patch",
-    );
-    return "skipped";
-  }
-  const source = readFileSync(indexPath, "utf8");
-  if (isAliceAppTrainingNodeSafeIndexPatched(source)) {
-    log(
-      "[alice-eliza-runtime-patches] plugins/app-training/src/index.ts node-safe-index already applied",
-    );
-    return "already-applied";
-  }
-  let next = source;
-  let removed = 0;
-  for (const line of appTrainingUiReexportLines) {
-    if (next.includes(`${line}\n`)) {
-      next = next.replace(`${line}\n`, "");
-      removed += 1;
-    } else if (next.includes(line)) {
-      next = next.replace(line, "");
-      removed += 1;
-    }
-  }
-  if (removed === 0) {
-    log(
-      "[alice-eliza-runtime-patches] no app-training UI re-exports found to strip; writing sentinel only (upstream already Node-safe?)",
-    );
-  }
-  next = `${appTrainingNodeSafeBanner}${next}`;
-  writeFileSync(indexPath, next);
-  log(
-    `[alice-eliza-runtime-patches] patched plugins/app-training/src/index.ts to remove ${removed} UI re-export(s) for Node-safe runtime load`,
-  );
-  return "applied";
-}
-
 const elizacloudIndexRelativePath = "plugins/plugin-elizacloud/src/index.ts";
 const elizacloudReexportsSentinel =
   "// [milaidy:elizacloud-agent-export-compat]";
@@ -2604,7 +2534,6 @@ export function applyAliceElizaRuntimePatches({
     applyAliceTelegramSourcePackageJsonExportPatch({ elizaRoot, log }),
     applyAliceTelegramAccountAuthResolverPatch({ elizaRoot, log }),
     applyAliceElizacloudReexportPatch({ elizaRoot, log }),
-    applyAliceAppTrainingNodeSafeIndexPatch({ elizaRoot, log }),
     // applyAliceBundledKnowledgeStartupDeferralPatch retired against upstream
     // be182cc913b3+ — `seedBundledKnowledge` no longer exists in upstream's
     // packages/agent/src/runtime/eliza.ts (removed during the 866-commit


### PR DESCRIPTION
## Why revert

PR #141 stripped \`./ui/*\` re-exports from \`eliza/plugins/app-training/src/index.ts\` to make the Node-side import succeed (no more CSS error). That worked at the import-resolution level — but unmasked a separate latent bug: **something in app-training's module-evaluation chain hangs indefinitely** once the import is allowed to complete. The deployed pod (image \`sha-89a62dd-milaidy-7a03d85\`) never bound \`:3000\`, startup probes failed for 20+ min, the rollout deadline tripped, and we lost the healthy state we had after #140.

The two failure modes were:

| state | pod | validator |
|---|---|---|
| post-#140 (before #141) | 1/1 Ready, healthy | exit-1 on \"skipping runtime hooks\" warn (false positive) |
| post-#141 (now) | 0/1, hung at boot | exit-1 on rollout deadline (real failure) |

#141 traded a cosmetic validator failure for a real boot regression. #140's state is strictly better operationally.

## Why we're not also adopting the upstream fix in this PR

Upstream eliza \`origin/develop\` has the canonical fix at \`packages/ui/src/index.ts\` — the CSS imports were moved out of the barrel to a \`./styles\` subpath, so Node-side plugin loaders can import \`@elizaos/ui\` without forcing CSS evaluation. We want that. But adopting it now would re-expose the same boot hang at the @elizaos/ui level (the CSS error was masking the underlying hang, not the cause). The hang needs to be debugged and fixed first; THEN we can adopt the upstream CSS fix safely.

## Plan after this revert

1. **(separate PR, 555stream)** Relax the deploy script's \`startup log contract\` to allow the specific \`not installed, skipping runtime hooks\` graceful-skip line. The agent's loader uses try/catch around this exact case — it's intentional behavior, not an error.
2. **(follow-up debug)** Spin up a debug pod and bisect app-training's submodule evaluation: \`core/*\`, \`routes/*\`, \`services/training-trigger\`, \`backends/{tinker,native,atropos}\`, \`optimizers/*\`. Identify which top-level evaluation hangs.
3. **(once hang is isolated)** Patch the specific module via the patcher, OR cherry-pick the relevant fix from upstream develop (where the training-side files have substantial churn that may already address it).
4. **(then)** Adopt upstream eliza's \`packages/ui/src/index.ts\` CSS-extraction fix via a patcher entry. \"Don't be behind\" alignment.

## Test plan

- [ ] CI green
- [ ] Merge → trigger commit on \`render-network-os/555-bot:alice\`
- [ ] \`alice-bot\` returns to \`1/1 Ready\` (the post-#140 healthy state, image hash will differ but behavior matches)
- [ ] Deploy script still exits with code 1 on the \"skipping runtime hooks\" warn — that's the known cosmetic issue, addressed by the 555stream PR above