### PR TITLE
chore: merge upstream/develop apps/app/tsconfig.json (local-mode TS paths)

### DIFF
--- a/apps/app/tsconfig.json
+++ b/apps/app/tsconfig.json
@@ -3,7 +3,11 @@
     "target": "ES2022",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
@@ -12,13 +16,334 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "experimentalDecorators": true,
     "useUnknownInCatchVariables": true,
-    "types": ["vite/client"]
+    "types": [
+      "vite/client",
+      "bun-types"
+    ],
+    "baseUrl": "../..",
+    "paths": {
+      "@elizaos/app-core": [
+        "./node_modules/@elizaos/app-core"
+      ],
+      "@elizaos/app-core/platform/native-plugin-entrypoints": [
+        "./node_modules/@elizaos/app-core/platform/native-plugin-entrypoints"
+      ],
+      "@elizaos/app-core/*": [
+        "./node_modules/@elizaos/app-core/*"
+      ],
+      "@elizaos/app-hyperscape": [
+        "./node_modules/@elizaos/app-hyperscape",
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-hyperscape/*": [
+        "./node_modules/@elizaos/app-hyperscape/*",
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/agent": [
+        "./node_modules/@elizaos/agent"
+      ],
+      "@elizaos/agent/*": [
+        "./node_modules/@elizaos/agent/*"
+      ],
+      "@elizaos/plugin-browser-bridge": [
+        "./node_modules/@elizaos/plugin-browser-bridge"
+      ],
+      "@elizaos/plugin-browser-bridge/*": [
+        "./node_modules/@elizaos/plugin-browser-bridge/*"
+      ],
+      "@elizaos/core": [
+        "./node_modules/@elizaos/core"
+      ],
+      "@elizaos/core/*": [
+        "./node_modules/@elizaos/core/*"
+      ],
+      "@elizaos/shared": [
+        "./node_modules/@elizaos/shared"
+      ],
+      "@elizaos/shared/*": [
+        "./node_modules/@elizaos/shared/*"
+      ],
+      "@elizaos/skills": [
+        "./node_modules/@elizaos/skills"
+      ],
+      "@elizaos/skills/*": [
+        "./node_modules/@elizaos/skills/*"
+      ],
+      "@elizaos/ui": [
+        "./node_modules/@elizaos/ui"
+      ],
+      "@elizaos/ui/*": [
+        "./node_modules/@elizaos/ui/*"
+      ],
+      "react": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "react/jsx-runtime": [
+        "./node_modules/@types/react/jsx-runtime.d.ts"
+      ],
+      "react/jsx-dev-runtime": [
+        "./node_modules/@types/react/jsx-dev-runtime.d.ts"
+      ],
+      "react-dom": [
+        "./node_modules/@types/react-dom/index.d.ts"
+      ],
+      "react-dom/client": [
+        "./node_modules/@types/react-dom/client.d.ts"
+      ],
+      "@elizaos/*": [
+        "./node_modules/@elizaos/*"
+      ],
+      "@elizaos/app-2004scape": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-2004scape/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-babylon": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-babylon/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-elizamaker": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-elizamaker/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-task-coordinator": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-task-coordinator/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-companion": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-companion/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-contacts": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-contacts/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-defense-of-the-agents": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-defense-of-the-agents/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-lifeops": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-lifeops/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-scape": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-scape/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-shopify": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-shopify/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-hyperliquid": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-hyperliquid/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-polymarket": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-polymarket/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-phone": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-phone/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-steward": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-steward/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-screenshare": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-screenshare/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-training": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-training/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-trajectory-logger": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-trajectory-logger/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-vincent": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-vincent/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-wallet": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-wallet/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-wifi": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-wifi/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-workflow-builder": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-workflow-builder/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@clawville/app-clawville": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@clawville/app-clawville/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/capacitor-agent": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-agent/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-contacts": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-contacts/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-desktop": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-desktop/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-phone": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-phone/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-wifi": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-wifi/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-llama": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-llama/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-mobile-signals": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-mobile-signals/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-appblocker": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-appblocker/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-camera": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-camera/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-canvas": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-canvas/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-gateway": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-gateway/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-location": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-location/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-messages": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-messages/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-screencapture": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-screencapture/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-swabble": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-swabble/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-system": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-system/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-talkmode": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-talkmode/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-websiteblocker": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-websiteblocker/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/native-activity-tracker": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ]
+    }
   },
   "include": [
     "src/**/*.ts",
@@ -26,5 +351,11 @@
     "../../packages/app-core/src/ambient-modules.d.ts",
     "../../packages/agent/src/external-modules.d.ts"
   ],
-  "exclude": ["node_modules", "dist", "ios", "android", "electrobun"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "ios",
+    "android",
+    "electrobun"
+  ]
 }


### PR DESCRIPTION
## Summary

Conflict resolution PR 4 of 9. Adopts upstream's `compilerOptions` (which add the local-mode TS resolution support) while keeping alice's extra `include` entries.

**File:** `apps/app/tsconfig.json` (5 → 341 lines)

## Upstream brings (we now have)

- `baseUrl: "../.."`
- `paths`: ~50 mapping entries pointing every `@elizaos/*` package at its `node_modules` location, plus stubs for optional eliza apps (`app-2004scape`, `app-babylon`, `app-elizamaker`, `app-companion`, …) and `capacitor-*` native plugins. This is the local-mode (`MILADY_ELIZA_SOURCE=local`) TS resolution support shipped by upstream's `0346182ff1 wip(milady local-mode)`. Without this, milady's apps/app vite/rollup build can't resolve workspace symlinks correctly in local mode.
- `types`: adds `"bun-types"` alongside `"vite/client"`
- `ignoreDeprecations: "6.0"` — suppresses TS 6.0 deprecation warnings during build
- `noUnusedLocals` and `noUnusedParameters` relaxed from `true` → `false`. Upstream made this change in lockstep with adding the paths block because the new optional-app/native-plugin stubs have intentional unused-param surfaces. If alice wants strict mode back, that's a separate cleanup PR.

## Alice preserves

```json
"include": [
  "src/**/*.ts",
  "src/**/*.tsx",
  "../../packages/app-core/src/ambient-modules.d.ts",   // ← alice-only
  "../../packages/agent/src/external-modules.d.ts"      // ← alice-only
]
```

Alice has extra type-reference includes upstream doesn't — the `ambient-modules.d.ts` and `external-modules.d.ts` files that declare alice's module shapes. Strictly additive; doesn't conflict with upstream structure.

## Stub files referenced by upstream's paths exist in alice

```
✓ apps/app/src/optional-eliza-app-stub.tsx
✓ apps/app/src/native-plugin-stubs.ts
```

Both are present in `origin/alice` — upstream's paths will resolve correctly.

## Test plan

- [ ] CI green (TS compilation)
- [ ] vite/rollup build of apps/app resolves @elizaos/* + capacitor-* + optional-app stubs without "Cannot find module" errors