### PR TITLE
[draft] chore: merge upstream/develop scripts/run-production-build.mjs (alice layered on upstream)

### DIFF
--- a/scripts/run-production-build.mjs
+++ b/scripts/run-production-build.mjs
@@ -1,25 +1,45 @@
 #!/usr/bin/env node
 /**
- * Full production build with maximal safe parallelism:
- * 1. tsdown (root dist) ∥ Capacitor plugin-build
- * 2. vite build (apps/app)
- * 3. write-build-info (dist metadata)
+ * Production build orchestrator.
  *
- * Requires prior `bun install` / postinstall (see apps/app/scripts/build.mjs).
+ * Upstream provides the mode-switching baseline:
+ *   - packages mode (isLocalElizaDisabled === true) → delegate to
+ *     scripts/run-eliza-app-core-script.mjs which runs the standard
+ *     elizaOS production build.
+ *   - local mode (default for alice's AWS deploy) → run the inline
+ *     local-mode flow with the elizaOS patch scripts + tsdown + vite.
+ *
+ * Alice layer on top of the local-mode flow:
+ *   - Capacitor plugin-build (apps/app/scripts/plugin-build.mjs) runs
+ *     in parallel with tsdown for build speed.
+ *   - Milady asset-CDN handling: resolveMiladyAssetBaseUrls() supplies
+ *     VITE_ASSET_BASE_URL so the vite build emits CDN-anchored asset
+ *     paths; prune-cdn-local-assets.mjs prunes the local copies after
+ *     the CDN upload step.
+ *   - write-build-info preferentially runs through bun when bun is on
+ *     PATH; falls back to `node --import tsx` so the script also works
+ *     from a pure-node host.
+ *   - resolveNodeExec() handles the case where this script is invoked
+ *     via `bun run`, where process.execPath is bun, not node — needed
+ *     because tsdown + vite CLIs require real node.
  */
+
 import { spawn, spawnSync } from "node:child_process";
-import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { resolveMiladyAssetBaseUrls } from "./lib/asset-cdn.mjs";
 
-const rootDir = path.resolve(
+import { resolveMiladyAssetBaseUrls } from "./lib/asset-cdn.mjs";
+import { isLocalElizaDisabled } from "./lib/eliza-package-mode.mjs";
+
+const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
 );
-const appDir = path.join(rootDir, "apps", "app");
+const appDir = path.join(repoRoot, "apps", "app");
 
-/** Real Node binary — when the script is started via `bun run`, process.execPath is Bun. */
+// ── alice: real Node binary even when started via `bun run` ────────────────
 function resolveNodeExec() {
   if (!process.versions.bun) {
     return process.execPath;
@@ -27,9 +47,7 @@ function resolveNodeExec() {
   const probe = spawnSync(
     "node",
     ["-e", "process.stdout.write(process.execPath)"],
-    {
-      encoding: "utf8",
-    },
+    { encoding: "utf8" },
   );
   const out = probe.stdout?.trim();
   if (probe.status === 0 && out) {
@@ -40,8 +58,6 @@ function resolveNodeExec() {
   );
 }
 
-const node = resolveNodeExec();
-
 function resolveBunForScripts() {
   if (process.versions.bun) {
     return process.execPath;
@@ -50,7 +66,10 @@ function resolveBunForScripts() {
   return probe.status === 0 ? "bun" : null;
 }
 
-function run(executable, args, cwd) {
+const node = resolveNodeExec();
+const { appAssetBaseUrl } = resolveMiladyAssetBaseUrls();
+
+function run(command, args, cwd = repoRoot) {
   const env = {
     ...process.env,
     ...(appAssetBaseUrl
@@ -63,19 +82,22 @@ function run(executable, args, cwd) {
       : {}),
   };
   return new Promise((resolve, reject) => {
-    const child = spawn(executable, args, {
+    const child = spawn(command, args, {
       cwd,
-      stdio: "inherit",
       env,
+      stdio: "inherit",
       shell: false,
+    });
+    child.on("error", (error) => {
+      reject(new Error(`${command} failed to start: ${error.message}`));
     });
     child.on("exit", (code, signal) => {
       if (signal) {
-        reject(new Error(`process exited with signal ${signal}`));
+        reject(new Error(`${command} exited due to signal ${signal}`));
         return;
       }
       if ((code ?? 1) !== 0) {
-        reject(new Error(`process exited with code ${code ?? 1}`));
+        reject(new Error(`${command} exited with code ${code ?? 1}`));
         return;
       }
       resolve();
@@ -83,55 +105,62 @@ function run(executable, args, cwd) {
   });
 }
 
-function resolveTsdownCli() {
-  const p = path.join(rootDir, "node_modules", "tsdown", "dist", "run.mjs");
-  if (!fs.existsSync(p)) {
-    throw new Error("tsdown not found under node_modules; run bun install");
-  }
-  return p;
-}
+if (!isLocalElizaDisabled()) {
+  // Upstream: packages-mode path — delegate to the elizaOS app-core script
+  await run(node, [
+    "scripts/run-eliza-app-core-script.mjs",
+    "run-production-build.mjs",
+  ]);
+} else {
+  // Local-mode (alice's deploy): upstream's patch+build flow + alice layer
+  const tsdownCli = require.resolve("tsdown/run");
+  const vitePackageRoot = path.dirname(require.resolve("vite/package.json"));
+  const viteCli = path.join(vitePackageRoot, "bin", "vite.js");
+  const pluginBuildScript = path.join(appDir, "scripts", "plugin-build.mjs");
+  const writeBuildInfoScript = path.join(
+    repoRoot,
+    "scripts",
+    "write-build-info.ts",
+  );
+  const pruneCdnAssetsScript = path.join(
+    repoRoot,
+    "scripts",
+    "prune-cdn-local-assets.mjs",
+  );
+  const bunForScripts = resolveBunForScripts();
 
-function resolveViteCli() {
-  for (const base of [appDir, rootDir]) {
-    const p = path.join(base, "node_modules", "vite", "bin", "vite.js");
-    if (fs.existsSync(p)) {
-      return p;
-    }
-  }
-  throw new Error("vite CLI not found; run bun install");
-}
+  // Upstream: elizaOS patch scripts that prepare the workspace for build
+  await run(node, ["scripts/ensure-elizaos-optional-app-stubs.mjs"]);
+  await run(node, ["scripts/patch-elizaos-package-styles.mjs"]);
+  await run(node, ["scripts/patch-elizaos-plugin-browser-bridge-package.mjs"]);
 
-const tsdownCli = resolveTsdownCli();
-const viteCli = resolveViteCli();
-const pluginBuildScript = path.join(appDir, "scripts", "plugin-build.mjs");
-const writeBuildInfoScript = path.join(
-  rootDir,
-  "scripts",
-  "write-build-info.ts",
-);
-const bunForScripts = resolveBunForScripts();
-const pruneCdnAssetsScript = path.join(
-  rootDir,
-  "scripts",
-  "prune-cdn-local-assets.mjs",
-);
-const { appAssetBaseUrl } = resolveMiladyAssetBaseUrls();
+  // Alice + upstream: tsdown ∥ Capacitor plugin-build (parallel)
+  await Promise.all([
+    run(node, [
+      tsdownCli,
+      "--config-loader",
+      "native",
+      "--fail-on-warn",
+      "false",
+    ]),
+    run(node, [pluginBuildScript], appDir),
+  ]);
 
-await Promise.all([
-  run(node, [tsdownCli], rootDir),
-  run(node, [pluginBuildScript], appDir),
-]);
+  // Upstream: post-tsdown patch for native browser package
+  await run(node, ["scripts/patch-elizaos-app-core-native-browser-package.mjs"]);
 
-async function runWriteBuildInfo() {
+  // Vite SPA build
+  await run(node, [viteCli, "build"], appDir);
+
+  // Alice: write-build-info — prefer bun if available
   if (bunForScripts) {
-    await run(bunForScripts, [writeBuildInfoScript], rootDir);
-    return;
+    await run(bunForScripts, [writeBuildInfoScript], repoRoot);
+  } else {
+    await run(node, ["--import", "tsx", writeBuildInfoScript], repoRoot);
   }
-  await run(node, ["--import", "tsx", writeBuildInfoScript], rootDir);
-}
 
-await run(node, [viteCli, "build"], appDir);
-await runWriteBuildInfo();
-if (appAssetBaseUrl) {
-  await run(node, [pruneCdnAssetsScript], rootDir);
+  // Alice: CDN asset pruning (only when MILADY_ASSET_BASE_URL is set)
+  if (appAssetBaseUrl) {
+    await run(node, [pruneCdnAssetsScript], repoRoot);
+  }
 }


### PR DESCRIPTION
## Summary

Draft PR — please review function-by-function before merge.

Conflict resolution PR 7 of 9. Adopts upstream's mode-switching structure as the baseline, re-applies alice's milaidy-specific build layer on top.

**File:** `scripts/run-production-build.mjs` (137 → ~155 lines, structural rewrite)

## Upstream baseline (newly adopted)

- `isLocalElizaDisabled()` gate — in packages mode (`MILADY_ELIZA_SOURCE=packages`), delegate to `scripts/run-eliza-app-core-script.mjs`. Alice's deploy uses local mode so the inline branch runs, but the packages-mode path is now there for completeness.
- Pre-build patch scripts (run in local mode):
  - `ensure-elizaos-optional-app-stubs.mjs`
  - `patch-elizaos-package-styles.mjs`
  - `patch-elizaos-plugin-browser-bridge-package.mjs`
- tsdown args: `--config-loader native --fail-on-warn false`
- Post-tsdown patch: `patch-elizaos-app-core-native-browser-package.mjs`
- `require.resolve` for tsdown + vite (cleaner than alice's fs.existsSync probes)

## Alice layer preserved

| Alice-specific element | Why it must stay |
|---|---|
| `resolveNodeExec()` | When script is started via `bun run`, `process.execPath` is bun. tsdown + vite CLIs need real node. |
| `resolveBunForScripts()` | bun-prefer for write-build-info |
| `resolveMiladyAssetBaseUrls()` import + `VITE_ASSET_BASE_URL` env injection | CDN-anchored asset paths for milaidy's SPA |
| Parallel `tsdown ∥ apps/app/scripts/plugin-build.mjs` | Capacitor plugin build runs concurrently with tsdown |
| `prune-cdn-local-assets.mjs` step | Cleanup after CDN upload, guarded by `if (appAssetBaseUrl)` |
| `write-build-info` dispatch (`bun` if available, else `node --import tsx`) | Works on hosts without bun |

## Verification

- `node --check scripts/run-production-build.mjs` → ✓ syntax OK
- Alice helpers grep'd in result: all present
- Upstream pieces grep'd in result: all present

## What to look at when reviewing

- The parallel `Promise.all([tsdown, plugin-build])` placement — is this safe with the patch-elizaos-app-core-native-browser-package step running AFTER tsdown? In alice's previous flow plugin-build also ran before that patch step.
- Whether the `VITE_ASSET_BASE_URL` env injection should apply to ALL spawned commands (current behavior) or only the vite build.
- Whether bun is the right preference for write-build-info on AWS staging.

If anything looks off, point it at me and I'll iterate.