### PR TITLE
chore: upstream-sync integration — eliza 30c595e1 + 7 surgical merges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,20 @@
 node_modules
+/eliza/
+.eliza-repo-setup.lock
 **/node_modules/
 .env
 .env.worktree
+**/.env
+**/.env.*
+**/.env.local
+**/.env.*.local
+**/.env.development
+**/.env.production
+**/.env.preview
+**/.env.dev
+!**/.env.example
+**/.vercel
+**/.vercel/
 dist
 storybook-static
 coverage
@@ -17,22 +30,28 @@ apps/app/electrobun/build/
 *.bun-build
 **/*.bun-build
 *.tsbuildinfo
+eliza/packages/elizaos/templates/
+eliza/packages/elizaos/templates-manifest.json
 apps/app/electron/tsc-out/
 # Android build output (capacitor plugins, main app)
 **/android/build/
 
 # TypeScript declaration build outputs inside source dirs
-packages/*/src/**/*.d.ts
-!packages/app-core/src/ambient-modules.d.ts
-packages/*/src/**/*.d.ts.map
+eliza/packages/*/src/**/*.d.ts
+!eliza/packages/app-core/src/ambient-modules.d.ts
+# Ambient declaration shims for `@elizaos/core/roles` — the published
+# alpha dist-tag doesn't ship the subpath exports field, so each
+# package that imports it needs its own per-package .d.ts.
+!eliza/packages/shared/src/elizaos-core-roles.d.ts
+eliza/packages/*/src/**/*.d.ts.map
 # Local ./eliza checkout — only @elizaos/core typescript sources had stray emit (see eliza/.gitignore)
 eliza/packages/core/src/**/*.d.ts
 eliza/packages/core/src/**/*.d.ts.map
 src/plugins/**/*.d.ts
 src/plugins/**/*.d.ts.map
 
-# Compiled JS build outputs inside source dirs (packages/ui uses tsx source directly)
-packages/ui/src/**/*.js
+# Compiled JS build outputs inside source dirs (app-core/ui uses tsx source directly)
+eliza/packages/app-core/src/ui/**/*.js
 
 # Lock files (managed at repo root)
 package-lock.json
@@ -42,19 +61,34 @@ pnpm-lock.yaml
 
 # Docker overrides
 docker-compose.extra.yml
+# Copied from deploy/.dockerignore.ci for local `docker build` (context root)
+.dockerignore
 
 # UI test artifacts
 apps/ui/src/ui/__screenshots__/
 apps/ui/playwright-report/
 apps/ui/test-results/
+eliza/packages/app-core/src/ui/test-results/
+eliza/packages/app-core/src/ui/e2e/visual-regression.spec.ts-snapshots/
 
 # Vendored repos (clone separately if needed)
 vendor/
+# MiladyOS AOSP product layer (tracked); exception to `vendor/` above.
+!os/android/vendor/
+# Built elsewhere — run `bun run build:android:system` before sync/validate.
+os/android/vendor/milady/apps/Milady/Milady.apk
+os/android/vendor/milady/apps/Milady/*.apk.idsig
+os/android/vendor/eliza/apps/Eliza/Eliza.apk
+os/android/vendor/eliza/apps/Eliza/*.apk.idsig
+
+# Local scratch / backup patches and tarballs.
+.preserve/
 
 # Local untracked files
 .local/
 .vscode/
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 .claude/skills/
 .git-workspace/
 IDENTITY.md
@@ -64,6 +98,13 @@ USER.md
 .eliza.broken.*/
 .milady-repo-setup.lock
 .milady/desktop-dev-console.log
+.milady/*.png
+.milady/gmail-fixtures/
+.milady/avd-signed/
+reports/avd-smoke/
+reports/aosp-cuttlefish/
+reports/e2e-*/
+test/mocks/fixtures/*.raw.json
 .turbo/
 skills/.cache/
 apps/app/electron/.eliza
@@ -86,6 +127,11 @@ biome-report.json
 # Local audit outputs
 report/
 
+# Action benchmark reports (local eval output; never committed)
+/action-benchmark-report/
+/action-benchmark-report-*/
+/action-benchmark-report*.md
+
 # Agent learning docs & knowledge base
 knowledge/
 !src/knowledge/
@@ -93,15 +139,12 @@ src/knowledge/*
 !src/knowledge/history.ts
 !src/knowledge/history.md
 scripts/knowledge-loop.mjs
-# Foundry build artifacts (keep source .sol, foundry.toml, lib/)
-test/contracts/out/
-test/contracts/cache/
 **/__pycache__/
 apps/app/test-results/
 # WhatsApp session files (Baileys auth state)
 /auth/
 :memory:/
-benchmarks/results/
+eliza/packages/benchmarks/app-eval/results/
 !docs/plugins/
 
 # Electrobun compiled native binaries (built locally, not committed)
@@ -110,6 +153,7 @@ apps/app/electrobun/src/libMacWindowEffects.dylib
 apps/app/electrobun/src/preload.js
 # Electrobun build artifacts (created by `electrobun build`)
 apps/app/electrobun/artifacts/
+**/electrobun/artifacts/*.tar.zst
 
 # Electron build directories
 apps/app/electron/app-build/
@@ -135,31 +179,74 @@ e2e-screenshots/
 data/
 .avatar-clone-tmp
 
+# Plugin repos owned by the embedded eliza checkout. These are registered in
+# eliza/.gitmodules and should not be added to the outer milady index.
+eliza/plugins/plugin-agent-skills/
+eliza/plugins/plugin-anthropic/
+eliza/plugins/plugin-cli/
+eliza/plugins/plugin-commands/
+eliza/plugins/plugin-cron/
+eliza/plugins/plugin-discord/
+eliza/plugins/plugin-edge-tts/
+eliza/plugins/plugin-elizacloud/
+eliza/plugins/plugin-evm/
+eliza/plugins/plugin-google-genai/
+eliza/plugins/plugin-groq/
+eliza/plugins/plugin-imessage/
+eliza/plugins/plugin-local-ai/
+eliza/plugins/plugin-local-embedding/
+eliza/plugins/plugin-music-library/
+eliza/plugins/plugin-music-player/
+eliza/plugins/plugin-ollama/
+eliza/plugins/plugin-openai/
+eliza/plugins/plugin-openrouter/
+eliza/plugins/plugin-pdf/
+eliza/plugins/plugin-shell/
+eliza/plugins/plugin-shopify/
+eliza/plugins/plugin-solana/
+eliza/plugins/plugin-sql/
+eliza/plugins/plugin-telegram/
+eliza/plugins/plugin-whatsapp/
+
 # Debug PTY captures from plugin-agent-orchestrator (PARALLAX_DEBUG_CAPTURE=1)
 .parallax/
 .worktrees/
 .claude/worktrees/
 
 # Generated raw avatar/animation assets from local setup hooks (non-source)
-apps/app/public/animations/**/*.fbx
-apps/app/public/animations/**/*.glb
-apps/app/public/animations/*.fbx
-apps/app/public/animations/*.glb
-apps/app/public/vrms/**/*.vrm
-apps/app/public/vrms/*.vrm
-apps/app/public/vrms/imported-avatars.json
-apps/app/public/vrms/backgrounds/*.png
-apps/app/public/vrms/previews/*.png
-apps/app/public/vrms/backgrounds/*.jpg
-apps/app/public/vrms/previews/*.jpg
-apps/app/public/vrms/*.jpg
-apps/app/ios/App/build*/
+# Companion plugin owns these assets; ensure-avatars.mjs populates them.
+eliza/apps/app-companion/public/animations/**/*.fbx
+eliza/apps/app-companion/public/animations/**/*.fbx.gz
+eliza/apps/app-companion/public/animations/**/*.glb
+eliza/apps/app-companion/public/animations/**/*.glb.gz
+eliza/apps/app-companion/public/animations/*.fbx
+eliza/apps/app-companion/public/animations/*.fbx.gz
+eliza/apps/app-companion/public/animations/*.glb
+eliza/apps/app-companion/public/animations/*.glb.gz
+eliza/apps/app-companion/public/vrms/**/*.vrm
+eliza/apps/app-companion/public/vrms/**/*.vrm.gz
+eliza/apps/app-companion/public/vrms/*.vrm
+eliza/apps/app-companion/public/vrms/*.vrm.gz
+eliza/apps/app-companion/public/vrms/imported-avatars.json
+eliza/apps/app-companion/public/vrms/backgrounds/*.png
+eliza/apps/app-companion/public/vrms/previews/*.png
+eliza/apps/app-companion/public/vrms/backgrounds/*.jpg
+eliza/apps/app-companion/public/vrms/previews/*.jpg
+eliza/apps/app-companion/public/vrms/*.jpg
+# Capacitor native platform scaffolds — generated by `npx cap add` and
+# `cap sync`. Canonical platform configs live in eliza/packages/app-core/platforms/;
+# run-mobile-build.mjs copies them into these dirs at build time.
+apps/app/ios/
+apps/app/android/
 
 # Ignored caches
 .ruff_cache/
-cache/audio/
-cache/voice/
-cache/audio/
+cache/
+
+# Runtime workspace placeholders (regenerated by agent runtime)
+
+# Docker build artifacts
+.docker-home/
 apps/app/.vite/
 
 # Local tool binaries (e.g. yt-dlp); PATH may prepend this dir in dev
@@ -191,3 +278,51 @@ scripts/bin/yt-dlp_*
 # because it's a developer tool, not product code.
 scripts/codex-sniff.ts
 .tmp-live/
+signal-auth/
+whatsapp-auth/
+test-results/
+# Training pipeline lives entirely outside this repo — both the scripts and
+# the data are mirrored to HuggingFace, NOT to milady's git history. Reasons:
+#   - Datasets + checkpoints (10s of GB to TBs) bloat the repo.
+#   - Trajectory exports may contain user data; gitignoring the whole tree
+#     defends against accidental `git add` of unfiltered records.
+#   - HF Hub is the canonical artifact store: dataset →
+#     elizaos/eliza-toon-v1-sft, models → elizaos/eliza-1-{2b,9b,27b}, the
+#     training pipeline itself → elizaos/eliza-training-pipeline.
+# Sync via training/scripts/push_to_hf.py (dataset),
+# training/scripts/push_model_to_hf.py (models), and
+# training/scripts/push_pipeline_to_hf.py (pipeline source).
+training/
+.milady/
+eliza-beta-prep/
+# Local CI fix scratch checkouts (not part of the project)
+eliza-ci-fix/
+eliza-ci-followup/
+eliza-ci-clean/
+package.json.pre-disable-backup
+
+# ── alice-specific patterns (preserved across upstream merges) ──
+packages/*/src/**/*.d.ts
+!packages/app-core/src/ambient-modules.d.ts
+packages/*/src/**/*.d.ts.map
+# Compiled JS build outputs inside source dirs (packages/ui uses tsx source directly)
+packages/ui/src/**/*.js
+# Foundry build artifacts (keep source .sol, foundry.toml, lib/)
+test/contracts/out/
+test/contracts/cache/
+benchmarks/results/
+apps/app/public/animations/**/*.fbx
+apps/app/public/animations/**/*.glb
+apps/app/public/animations/*.fbx
+apps/app/public/animations/*.glb
+apps/app/public/vrms/**/*.vrm
+apps/app/public/vrms/*.vrm
+apps/app/public/vrms/imported-avatars.json
+apps/app/public/vrms/backgrounds/*.png
+apps/app/public/vrms/previews/*.png
+apps/app/public/vrms/backgrounds/*.jpg
+apps/app/public/vrms/previews/*.jpg
+apps/app/public/vrms/*.jpg
+apps/app/ios/App/build*/
+cache/audio/
+cache/voice/

--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -1,72 +1,212 @@
-import { ErrorBoundary } from "@miladyai/app-core/components";
-import "@miladyai/app-core/styles/styles.css";
-import "@miladyai/app-core/styles/brand-gold.css";
-import "@elizaos/app-wallet/register";
-
-import "./native-plugin-entrypoints";
+import { App, ErrorBoundary } from "@elizaos/app-core";
+import "@elizaos/app-core/styles/styles.css";
+import "@elizaos/app-core/styles/brand-gold.css";
 
 import { App as CapacitorApp } from "@capacitor/app";
 import { Capacitor } from "@capacitor/core";
-import { Keyboard } from "@capacitor/keyboard";
-import { StatusBar, Style } from "@capacitor/status-bar";
-import { App } from "@miladyai/app-core/App";
-import { client } from "@miladyai/app-core/api";
+import { Keyboard, KeyboardResize } from "@capacitor/keyboard";
+import { Preferences } from "@capacitor/preferences";
+import { client } from "@elizaos/app-core";
 import {
   initializeCapacitorBridge,
   subscribeDesktopBridgeEvent,
   initializeStorageBridge,
   isElectrobunRuntime,
-} from "@miladyai/app-core/bridge";
-import { CharacterEditor } from "@miladyai/app-core/components";
-import type { BrandingConfig } from "@miladyai/app-core/config";
+} from "@elizaos/app-core";
+import type { BrandingConfig } from "@elizaos/app-core";
+import { MILADY_DEFAULT_THEME } from "@elizaos/shared";
 import {
   type AppBootConfig,
   getBootConfig,
+  ANDROID_LOCAL_AGENT_API_BASE,
+  MOBILE_RUNTIME_MODE_STORAGE_KEY,
+  normalizeMobileRuntimeMode,
+  preSeedAndroidLocalRuntimeIfFresh,
   setBootConfig,
-} from "@miladyai/app-core/config";
+} from "@elizaos/app-core";
 import {
   AGENT_READY_EVENT,
   APP_PAUSE_EVENT,
   APP_RESUME_EVENT,
   COMMAND_PALETTE_EVENT,
   CONNECT_EVENT,
-  dispatchMiladyEvent,
+  dispatchAppEvent,
+  MOBILE_RUNTIME_MODE_CHANGED_EVENT,
   SHARE_TARGET_EVENT,
   TRAY_ACTION_EVENT,
-} from "@miladyai/app-core/events";
+} from "@elizaos/app-core";
 import {
   applyForceFreshOnboardingReset,
   applyLaunchConnectionFromUrl,
-  dispatchQueuedLifeOpsGithubCallbackFromUrl,
-  getBroadcastChannel,
-  getBroadcastMode,
+  applyLaunchConnection,
   installDesktopPermissionsClientPatch,
   installForceFreshOnboardingClientPatch,
   installLocalProviderCloudPreferencePatch,
-  isBroadcastWindow as isBroadcastWindowShared,
+  isAppWindowRoute,
   isDetachedWindowShell,
+  getWindowNavigationPath,
   resolveWindowShellRoute,
   shouldInstallMainWindowOnboardingPatches,
   syncDetachedShellLocation,
-} from "@miladyai/app-core/platform";
+} from "@elizaos/app-core";
+import { AppWindowRenderer } from "@elizaos/app-core";
+import { dispatchQueuedLifeOpsGithubCallbackFromUrl } from "@elizaos/app-lifeops/platform";
+import type { ShareTargetPayload } from "@elizaos/app-core/platform";
 import {
   DESKTOP_TRAY_MENU_ITEMS,
   DesktopOnboardingRuntime,
   DesktopSurfaceNavigationRuntime,
   DesktopTrayRuntime,
   DetachedShellRoot,
-} from "@miladyai/app-core/shell";
-import { AppProvider } from "@miladyai/app-core/state";
-import { applyUiTheme, loadUiTheme } from "@miladyai/app-core/state";
-import { Agent } from "@miladyai/capacitor-agent";
-import { Desktop } from "@miladyai/capacitor-desktop";
+} from "@elizaos/app-core";
+import { AppProvider } from "@elizaos/app-core";
+import { applyUiTheme, loadUiTheme } from "@elizaos/app-core";
+import { Agent } from "@elizaos/capacitor-agent";
+import { Desktop } from "@elizaos/capacitor-desktop";
+import {
+  startDeviceBridgeClient,
+  type DeviceBridgeClient,
+} from "@elizaos/capacitor-llama";
 import { StrictMode } from "react";
-import { createRoot, type Root } from "react-dom/client";
-import { MILADY_ENV_ALIASES } from "./brand-env";
-import { MILADY_CHARACTER_CATALOG } from "./character-catalog";
-import { shouldUseCloudOnlyBranding } from "./cloud-only";
+import { createRoot } from "react-dom/client";
+import { CompanionShell } from "@elizaos/app-companion/ui";
+import {
+  createVectorBrowserRenderer,
+  GlobalEmoteOverlay,
+  InferenceCloudAlertButton,
+  resolveCompanionInferenceNotice,
+  THREE,
+  useCompanionSceneStatus,
+} from "@elizaos/app-companion";
+import "@elizaos/app-companion/register";
+// Side-effect: register LifeOps sidebar widgets + client methods on ElizaClient.
+import "@elizaos/app-lifeops/widgets";
+// Side-effect: register coding-agent (task-coordinator) slots so app-core
+// slot wrappers (CodingAgentControlChip, PtyConsoleBase, etc.) render the
+// real components instead of nulls.
+import "@elizaos/app-task-coordinator/register-slots";
+// Side-effect: register game operator surfaces + detail extensions.
+import "@elizaos/app-babylon/ui";
+import "@elizaos/app-scape/ui";
+import "@elizaos/app-hyperscape/ui";
+import "@elizaos/app-2004scape/ui";
+import "@elizaos/app-defense-of-the-agents/ui";
+import "@elizaos/app-screenshare/ui";
+import "@clawville/app-clawville/ui";
+import {
+  AppBlockerSettingsCard,
+  LifeOpsBrowserSetupPanel as BrowserBridgeSetupPanel,
+  LifeOpsPageView,
+  WebsiteBlockerSettingsCard,
+} from "@elizaos/app-lifeops/ui";
+import { LifeOpsActivitySignalsEffect } from "@elizaos/app-lifeops/components/LifeOpsActivitySignalsEffect";
+import {
+  ApprovalQueue,
+  StewardLogo,
+  TransactionHistory,
+} from "@elizaos/app-steward/ui";
+import {
+  CodingAgentControlChip,
+  CodingAgentSettingsSection,
+  CodingAgentTasksPanel,
+  PtyConsoleDrawer,
+} from "@elizaos/app-task-coordinator";
+import { FineTuningView } from "@elizaos/app-training/ui";
+import "@elizaos/app-shopify/register";
+import "@elizaos/app-hyperliquid/client";
+import "@elizaos/app-hyperliquid/register";
+import "@elizaos/app-polymarket/client";
+import "@elizaos/app-polymarket/register";
+import "@elizaos/app-vincent/client";
+import { useVincentState } from "@elizaos/app-vincent/ui";
+import "@elizaos/app-vincent/register";
+import "@elizaos/app-wallet/register";
+import "@elizaos/app-workflow-builder/register";
+import { shouldUseCloudOnlyBranding } from "@elizaos/app-core";
+import {
+  APP_BRANDING_BASE,
+  APP_CONFIG,
+  APP_LOG_PREFIX,
+  APP_NAMESPACE,
+  APP_URL_SCHEME,
+} from "./app-config";
+import { APP_ENV_ALIASES, APP_ENV_PREFIX } from "./brand-env";
+import { APP_CHARACTER_CATALOG } from "./character-catalog";
+import {
+  apiBaseToDeviceBridgeUrl,
+  type IosRuntimeConfig,
+  type IosRuntimeMode,
+  resolveIosRuntimeConfig,
+} from "@elizaos/app-core";
 
-const MILADY_BRANDING: Partial<BrandingConfig> = {
+// CharacterEditor is statically re-exported by `@elizaos/app-core/browser`,
+// so the previous `lazy()` wrapper here was eagerly merged back into the
+// main chunk by Rollup. Static import keeps the load path honest.
+import { CharacterEditor } from "@elizaos/app-core/components/character/CharacterEditor";
+
+declare global {
+  interface Window {
+    __ELIZA_APP_SHARE_QUEUE__?: ShareTargetPayload[];
+    __ELIZA_APP_CHARACTER_EDITOR__?: typeof CharacterEditor;
+    __ELIZA_APP_API_BASE__?: string;
+    __ELIZA_API_BASE__?: string;
+    __ELIZAOS_APP_BOOT_CONFIG__?: AppBootConfig;
+    __ELIZA_APP_BOOT_CONFIG__?: AppBootConfig;
+  }
+}
+
+const BRANDED_WINDOW_KEYS = {
+  apiBase: `__${APP_ENV_PREFIX}_API_BASE__`,
+  characterEditor: `__${APP_ENV_PREFIX}_CHARACTER_EDITOR__`,
+  shareQueue: `__${APP_ENV_PREFIX}_SHARE_QUEUE__`,
+} as const;
+
+type AppCompatWindow = Window &
+  Record<string, unknown> & {
+    __ELIZA_APP_SHARE_QUEUE__?: ShareTargetPayload[];
+    __ELIZA_APP_CHARACTER_EDITOR__?: typeof CharacterEditor;
+    __ELIZA_APP_API_BASE__?: string;
+    __ELIZA_API_BASE__?: string;
+    __ELIZAOS_APP_BOOT_CONFIG__?: AppBootConfig;
+    __ELIZA_APP_BOOT_CONFIG__?: AppBootConfig;
+  };
+
+function getAppWindow(): AppCompatWindow {
+  return window as unknown as AppCompatWindow;
+}
+
+// True when the APK is running on the AOSP MiladyOS variant. Detection:
+// MainActivity.applyMiladyOSUserAgentSuffix appends `MiladyOS/<tag>` to the
+// WebView user-agent when `ro.miladyos.product` is set by the AOSP product
+// config. The upstream elizaOS layer reads its own `ElizaOS/<tag>` marker
+// from the same place; this helper only cares about the Milady-brand layer.
+function isMiladyOS(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /\bMiladyOS\//.test(navigator.userAgent ?? "");
+}
+
+function getInjectedAppApiBase(): string | undefined {
+  const appWindow = getAppWindow();
+  const brandedApiBase = appWindow[BRANDED_WINDOW_KEYS.apiBase];
+  const bootConfig =
+    appWindow.__ELIZAOS_APP_BOOT_CONFIG__ ??
+    appWindow.__ELIZA_APP_BOOT_CONFIG__;
+  return (
+    appWindow.__ELIZA_APP_API_BASE__ ??
+    (typeof brandedApiBase === "string" ? brandedApiBase : undefined) ??
+    bootConfig?.apiBase ??
+    appWindow.__ELIZA_API_BASE__
+  );
+}
+
+const APP_BRANDING: Partial<BrandingConfig> = {
+  ...APP_BRANDING_BASE,
+  theme: MILADY_DEFAULT_THEME,
+  // ── alice: milady-ai branding (preserved from MILADY_BRANDING) ──
+  // Upstream has been migrating org refs from milady-ai/* → elizaOS/*; alice
+  // keeps the milady-ai naming for the consumer-facing brand surface. If/when
+  // the brand is officially renamed, drop these overrides and rely entirely
+  // on APP_BRANDING_BASE.
   appName: "Milady",
   orgName: "milady-ai",
   repoName: "milady",
@@ -81,9 +221,9 @@ const MILADY_BRANDING: Partial<BrandingConfig> = {
   // other hosts inject an explicit API base before React boots, and that host
   // backend should control onboarding capabilities instead.
   cloudOnly: shouldUseCloudOnlyBranding({
-    isDev: import.meta.env.DEV,
+    isDev: import.meta.env.DEV ?? false,
     injectedApiBase:
-      typeof window === "undefined" ? undefined : window.__MILADY_API_BASE__,
+      typeof window === "undefined" ? undefined : getInjectedAppApiBase(),
     isNativePlatform: Capacitor.isNativePlatform(),
   }),
 };
@@ -95,31 +235,12 @@ const platform = Capacitor.getPlatform();
 const isNative = Capacitor.isNativePlatform();
 const isIOS = platform === "ios";
 const isAndroid = platform === "android";
+const IOS_RUNTIME_ENV_CONFIG = resolveIosRuntimeConfig(import.meta.env);
+const DEVICE_BRIDGE_ID_KEY = "milady_device_bridge_id";
 
-/**
- * Detect MiladyOS — a custom AOSP product distribution that appends
- * `MiladyOS/<tag>` to its user agent and is only built for Android.
- * Returns false on every other platform (iOS, desktop, stock Android,
- * server-rendered SPA bundles served to plain browsers).
- *
- * The user-agent suffix is set by `MainActivity` when
- * `ro.miladyos.product` is configured by the AOSP product config; the
- * regex matches the same `\bMiladyOS\/` pattern as
- * `hasMiladyOSMarker` in
- * `eliza/packages/app-core/src/components/apps/overlay-app-registry.ts`,
- * keeping detection consistent across the SPA's two call sites and the
- * overlay-app registry.
- */
-function isMiladyOS(): boolean {
-  if (!isAndroid) return false;
-  if (
-    typeof navigator === "undefined" ||
-    typeof navigator.userAgent !== "string"
-  ) {
-    return false;
-  }
-  return /\bMiladyOS\//.test(navigator.userAgent);
-}
+let mobileDeviceBridgeClient: DeviceBridgeClient | null = null;
+let mobileDeviceBridgeStartPromise: Promise<void> | null = null;
+let mobileRuntimeModeListenerInstalled = false;
 
 async function registerMiladyOsSystemApps(): Promise<void> {
   if (!isMiladyOS()) return;
@@ -134,37 +255,10 @@ function isDesktopPlatform(): boolean {
   return isElectrobunRuntime();
 }
 
-function isWebPlatform(): boolean {
-  return platform === "web" && !isElectrobunRuntime();
-}
-
-interface ShareTargetFile {
-  name: string;
-  path?: string;
-}
-
-interface ShareTargetPayload {
-  source?: string;
-  title?: string;
-  text?: string;
-  url?: string;
-  files?: ShareTargetFile[];
-}
-
-declare global {
-  interface Window {
-    __MILADY_SHARE_QUEUE__?: ShareTargetPayload[];
-    __MILADY_CHARACTER_EDITOR__?: typeof CharacterEditor;
-    __MILADY_API_BASE__?: string;
-    __MILADY_REACT_ROOT__?: Root;
-    __MILADY_APP_BOOT_PROMISE__?: Promise<void>;
-  }
-}
-
 const windowShellRoute = resolveWindowShellRoute();
 
 /**
- * Adds `milady-electrobun-frameless` for CSS `-webkit-app-region` (Chromium/CEF).
+ * Adds `eliza-electrobun-frameless` for CSS `-webkit-app-region` (Chromium/CEF).
  * macOS WKWebView move/resize are still driven by native overlays in
  * window-effects.mm; this class mainly marks the shell and helps non-WK engines.
  */
@@ -177,71 +271,66 @@ function shouldEnableElectrobunMacWindowDrag(): boolean {
 }
 
 if (shouldEnableElectrobunMacWindowDrag()) {
-  document.documentElement.classList.add("milady-electrobun-frameless");
+  document.documentElement.classList.add("eliza-electrobun-frameless");
 }
 
 // Dev escape hatch: ?reset forces a truly fresh onboarding session by clearing
 // persisted state and temporarily suppressing stale backend resume config.
 if (shouldInstallMainWindowOnboardingPatches(windowShellRoute)) {
   applyForceFreshOnboardingReset();
-  installForceFreshOnboardingClientPatch(client as never);
+  installForceFreshOnboardingClientPatch(client);
 }
-installLocalProviderCloudPreferencePatch(client as never);
-installDesktopPermissionsClientPatch(client as never);
+installLocalProviderCloudPreferencePatch(client);
+installDesktopPermissionsClientPatch(client);
 
 // Register custom character editor for app-core's ViewRouter to pick up
-window.__MILADY_CHARACTER_EDITOR__ = CharacterEditor;
+window.__ELIZA_APP_CHARACTER_EDITOR__ = CharacterEditor;
+getAppWindow()[BRANDED_WINDOW_KEYS.characterEditor] = CharacterEditor;
 
-import { getStylePresets } from "@miladyai/shared/onboarding-presets";
-import { resolveDefaultSpeechCapabilitiesForAvatarIndex } from "@miladyai/shared/onboarding-presets";
+import { getStylePresets } from "@elizaos/shared/onboarding-presets";
 
 // Derive VRM roster from STYLE_PRESETS so character names stay in one place.
-const MILADY_STYLE_PRESETS = getStylePresets();
+const APP_STYLE_PRESETS = getStylePresets();
 
-const MILADY_VRM_ASSETS = MILADY_STYLE_PRESETS.slice()
+const APP_VRM_ASSETS = APP_STYLE_PRESETS.slice()
   .sort((a, b) => a.avatarIndex - b.avatarIndex)
-  .map((p) => ({
-    title: p.name,
-    slug: `milady-${p.avatarIndex}`,
-    speechCapabilities: resolveDefaultSpeechCapabilitiesForAvatarIndex(
-      p.avatarIndex,
-    ),
-    ...(p.avatarIndex === 9 ? { cameraDistanceScale: 1.3 } : {}),
-  }));
+  .map((p) => ({ title: p.name, slug: `${APP_NAMESPACE}-${p.avatarIndex}` }));
 
-// When the SPA is served at `/broadcast/:channel` (no trailing slash), the
-// document base URL is `<origin>/broadcast/`, and `resolveAppAssetUrl()`'s
-// runtime fallback would build asset URLs like
-// `<origin>/broadcast/vrm-decoders/draco/...` — which 404 because public
-// assets live at `<origin>/<asset>`. Pin the asset base to the document
-// root so DRACO / Meshopt decoders, fonts, VRMs, and any other
-// `resolveAppAssetUrl()` consumer load from `/<asset>` instead of
-// `/broadcast/<asset>`. The companion `<base href="/">` injection in
-// static-file-server only fixes HTML-level relative URLs (script src,
-// link href); JS code that resolves relative paths against
-// `window.location.href` (e.g. via `import.meta.env.BASE_URL`, which is
-// `"./"` for this Vite build) bypasses `<base>` and needs this override.
-// Same SPA bundle ships across desktop / mobile / web, so this only
-// kicks in for the web broadcast surface.
-const broadcastAssetBaseOverride =
-  typeof window !== "undefined" &&
-  window.location.pathname.startsWith("/broadcast/")
-    ? `${window.location.origin}/`
-    : undefined;
-
-const miladyBootConfig: AppBootConfig = {
-  branding: MILADY_BRANDING,
+const appBootConfig: AppBootConfig = {
+  ...getBootConfig(),
+  branding: APP_BRANDING,
+  defaultApps: APP_CONFIG.defaultApps,
   assetBaseUrl:
-    broadcastAssetBaseOverride ||
     (import.meta.env.VITE_ASSET_BASE_URL as string | undefined)?.trim() ||
     undefined,
-  cloudApiBase:
-    (import.meta.env.VITE_CLOUD_BASE as string) ?? "https://www.elizacloud.ai",
-  vrmAssets: MILADY_VRM_ASSETS,
-  onboardingStyles: MILADY_STYLE_PRESETS,
+  cloudApiBase: IOS_RUNTIME_ENV_CONFIG.cloudApiBase,
+  vrmAssets: APP_VRM_ASSETS,
+  onboardingStyles: APP_STYLE_PRESETS,
   characterEditor: CharacterEditor,
-  characterCatalog: MILADY_CHARACTER_CATALOG,
-  envAliases: MILADY_ENV_ALIASES,
+  companionShell: CompanionShell,
+  resolveCompanionInferenceNotice,
+  companionInferenceAlertButton: InferenceCloudAlertButton,
+  companionGlobalOverlay: GlobalEmoteOverlay,
+  useCompanionSceneStatus,
+  companionVectorBrowser: {
+    THREE,
+    createVectorBrowserRenderer,
+  },
+  codingAgentTasksPanel: CodingAgentTasksPanel,
+  codingAgentSettingsSection: CodingAgentSettingsSection,
+  codingAgentControlChip: CodingAgentControlChip,
+  ptyConsoleDrawer: PtyConsoleDrawer,
+  fineTuningView: FineTuningView,
+  useVincentState,
+  stewardLogo: StewardLogo,
+  stewardApprovalQueue: ApprovalQueue,
+  stewardTransactionHistory: TransactionHistory,
+  characterCatalog: APP_CHARACTER_CATALOG,
+  envAliases: APP_ENV_ALIASES,
+  lifeOpsPageView: LifeOpsPageView,
+  lifeOpsBrowserSetupPanel: BrowserBridgeSetupPanel,
+  appBlockerSettingsCard: AppBlockerSettingsCard,
+  websiteBlockerSettingsCard: WebsiteBlockerSettingsCard,
   clientMiddleware: {
     forceFreshOnboarding:
       shouldInstallMainWindowOnboardingPatches(windowShellRoute),
@@ -250,23 +339,95 @@ const miladyBootConfig: AppBootConfig = {
   },
 };
 
-setBootConfig(miladyBootConfig);
+// Self-hosted bot bootstrap. The token is read from the URL fragment
+// (#token=...), so it never reaches the server, access log, or Referer
+// headers. Once read, it persists in localStorage scoped to this origin.
+const SELF_HOSTED_TOKEN_KEY = "milady:self-hosted-api-token";
+const STALE_BOOTSTRAP_KEYS = [
+  "elizaos:agent-profiles",
+  "elizaos:active-server",
+  MOBILE_RUNTIME_MODE_STORAGE_KEY,
+] as const;
+try {
+  const url = new URL(window.location.href);
+  const hash = url.hash.startsWith("#") ? url.hash.slice(1) : url.hash;
+  const fragmentToken = new URLSearchParams(hash).get("token")?.trim() ?? null;
+  const hasQueryToken = url.searchParams.has("token");
+  if (hasQueryToken) {
+    console.error(
+      "[milady] Refusing insecure ?token=... bootstrap. Use #token=... instead.",
+    );
+  }
+  let bootstrapToken: string | null = fragmentToken;
+  if (fragmentToken) {
+    for (const key of STALE_BOOTSTRAP_KEYS) {
+      try {
+        window.localStorage.removeItem(key);
+      } catch {}
+    }
+    try {
+      window.localStorage.setItem(SELF_HOSTED_TOKEN_KEY, fragmentToken);
+    } catch {}
+  }
+  if (fragmentToken || hasQueryToken) {
+    url.hash = "";
+    url.searchParams.delete("token");
+    window.history.replaceState({}, "", url.toString());
+  }
+  if (!bootstrapToken) {
+    try {
+      const saved = window.localStorage.getItem(SELF_HOSTED_TOKEN_KEY)?.trim();
+      if (saved) bootstrapToken = saved;
+    } catch {}
+  }
+  if (bootstrapToken) {
+    appBootConfig.apiToken = bootstrapToken;
+    appBootConfig.apiBase ??= window.location.origin;
+    try {
+      client.setToken(bootstrapToken);
+    } catch {}
+  }
+} catch {}
+setBootConfig(appBootConfig);
+
+function getShareQueue(): ShareTargetPayload[] {
+  const appWindow = getAppWindow();
+  const brandedQueue = appWindow[BRANDED_WINDOW_KEYS.shareQueue];
+  const existing =
+    appWindow.__ELIZA_APP_SHARE_QUEUE__ ??
+    (Array.isArray(brandedQueue)
+      ? (brandedQueue as ShareTargetPayload[])
+      : undefined);
+  if (existing) {
+    appWindow.__ELIZA_APP_SHARE_QUEUE__ = existing;
+    appWindow[BRANDED_WINDOW_KEYS.shareQueue] = existing;
+    return existing;
+  }
+  const queue: ShareTargetPayload[] = [];
+  appWindow.__ELIZA_APP_SHARE_QUEUE__ = queue;
+  appWindow[BRANDED_WINDOW_KEYS.shareQueue] = queue;
+  return queue;
+}
 
 function dispatchShareTarget(payload: ShareTargetPayload): void {
-  if (!window.__MILADY_SHARE_QUEUE__) {
-    window.__MILADY_SHARE_QUEUE__ = [];
-  }
-  window.__MILADY_SHARE_QUEUE__.push(payload);
-  dispatchMiladyEvent(SHARE_TARGET_EVENT, payload);
+  getShareQueue().push(payload);
+  dispatchAppEvent(SHARE_TARGET_EVENT, payload);
+}
+
+function logNativePluginUnavailable(pluginName: string, error: unknown): void {
+  console.warn(
+    `${APP_LOG_PREFIX} ${pluginName} plugin not available:`,
+    error instanceof Error ? error.message : error,
+  );
 }
 
 async function initializeAgent(): Promise<void> {
   try {
     const status = await Agent.getStatus();
-    dispatchMiladyEvent(AGENT_READY_EVENT, status);
+    dispatchAppEvent(AGENT_READY_EVENT, status);
   } catch (err) {
     console.warn(
-      "[Milady] Agent not available:",
+      `${APP_LOG_PREFIX} Agent not available:`,
       err instanceof Error ? err.message : err,
     );
   }
@@ -277,24 +438,17 @@ async function initializePlatform(): Promise<void> {
   initializeCapacitorBridge();
 
   if (isIOS || isAndroid) {
-    await initializeStatusBar();
+    await import("@elizaos/app-core/platform/native-plugin-entrypoints");
     await initializeKeyboard();
     initializeAppLifecycle();
+    initializeMobileRuntimeModeListener();
+    void initializeMobileDeviceBridge();
   }
 
   if (isDesktopPlatform()) {
     await initializeDesktopShell();
   } else {
     await initializeAgent();
-  }
-}
-
-async function initializeStatusBar(): Promise<void> {
-  await StatusBar.setStyle({ style: Style.Dark });
-
-  if (isAndroid) {
-    await StatusBar.setOverlaysWebView({ overlay: true });
-    await StatusBar.setBackgroundColor({ color: "#0a0a0a" });
   }
 }
 
@@ -320,29 +474,45 @@ async function initializeKeyboard(): Promise<void> {
 }
 
 function initializeAppLifecycle(): void {
-  CapacitorApp.addListener("appStateChange", ({ isActive }) => {
-    if (isActive) {
-      dispatchMiladyEvent(APP_RESUME_EVENT);
-    } else {
-      dispatchMiladyEvent(APP_PAUSE_EVENT);
-    }
+  void Promise.resolve(
+    CapacitorApp.addListener("appStateChange", ({ isActive }) => {
+      if (isActive) {
+        dispatchAppEvent(APP_RESUME_EVENT);
+      } else {
+        dispatchAppEvent(APP_PAUSE_EVENT);
+      }
+    }),
+  ).catch((error) => {
+    logNativePluginUnavailable("App", error);
   });
 
-  CapacitorApp.addListener("backButton", ({ canGoBack }) => {
-    if (canGoBack) {
-      window.history.back();
-    }
+  void Promise.resolve(
+    CapacitorApp.addListener("backButton", ({ canGoBack }) => {
+      if (canGoBack) {
+        window.history.back();
+      }
+    }),
+  ).catch((error) => {
+    logNativePluginUnavailable("App", error);
   });
 
-  CapacitorApp.addListener("appUrlOpen", ({ url }) => {
-    handleDeepLink(url);
+  void Promise.resolve(
+    CapacitorApp.addListener("appUrlOpen", ({ url }) => {
+      handleDeepLink(url);
+    }),
+  ).catch((error) => {
+    logNativePluginUnavailable("App", error);
   });
 
-  CapacitorApp.getLaunchUrl().then((result) => {
-    if (result?.url) {
-      handleDeepLink(result.url);
-    }
-  });
+  void CapacitorApp.getLaunchUrl()
+    .then((result) => {
+      if (result?.url) {
+        handleDeepLink(result.url);
+      }
+    })
+    .catch((error) => {
+      logNativePluginUnavailable("App", error);
+    });
 }
 
 function handleDeepLink(url: string): void {
@@ -353,12 +523,30 @@ function handleDeepLink(url: string): void {
     return;
   }
 
-  if (parsed.protocol !== "milady:") return;
-  const path = (parsed.pathname || parsed.host || "").replace(/^\/+/, "");
+  if (parsed.protocol !== `${APP_URL_SCHEME}:`) return;
+  const path = getDeepLinkPath(parsed);
 
   switch (path) {
     case "chat":
       window.location.hash = "#chat";
+      break;
+    case "phone":
+    case "phone/call":
+      setHashRoute("phone", parsed.searchParams);
+      break;
+    case "messages":
+    case "messages/compose":
+      setHashRoute("messages", parsed.searchParams);
+      break;
+    case "contacts":
+      setHashRoute("contacts", parsed.searchParams);
+      break;
+    case "wallet":
+    case "inventory":
+      setHashRoute("wallet", parsed.searchParams);
+      break;
+    case "browser":
+      setHashRoute("browser", parsed.searchParams);
       break;
     case "lifeops":
       window.location.hash = "#lifeops";
@@ -378,16 +566,26 @@ function handleDeepLink(url: string): void {
             validatedUrl.protocol !== "http:"
           ) {
             console.error(
-              "[Milady] Invalid gateway URL protocol:",
+              `${APP_LOG_PREFIX} Invalid gateway URL protocol:`,
               validatedUrl.protocol,
             );
             break;
           }
-          dispatchMiladyEvent(CONNECT_EVENT, {
-            gatewayUrl: validatedUrl.href,
+          const token =
+            parsed.searchParams.get("token") ??
+            parsed.searchParams.get("accessToken") ??
+            null;
+          const connection = applyLaunchConnection({
+            kind: "remote",
+            apiBase: validatedUrl.href,
+            token,
+          });
+          dispatchAppEvent(CONNECT_EVENT, {
+            gatewayUrl: connection.apiBase,
+            token: connection.token ?? undefined,
           });
         } catch {
-          console.error("[Milady] Invalid gateway URL format");
+          console.error(`${APP_LOG_PREFIX} Invalid gateway URL format`);
         }
       }
       break;
@@ -419,9 +617,20 @@ function handleDeepLink(url: string): void {
       break;
     }
     default:
-      console.warn("[Milady] Unknown deep link path:", path);
+      console.warn(`${APP_LOG_PREFIX} Unknown deep link path:`, path);
       break;
   }
+}
+
+function getDeepLinkPath(parsed: URL): string {
+  const host = parsed.host.replace(/^\/+|\/+$/g, "");
+  const pathname = parsed.pathname.replace(/^\/+|\/+$/g, "");
+  return [host, pathname].filter(Boolean).join("/");
+}
+
+function setHashRoute(route: string, params: URLSearchParams): void {
+  const query = params.toString();
+  window.location.hash = query ? `#${route}?${query}` : `#${route}`;
 }
 
 async function initializeDesktopShell(): Promise<void> {
@@ -441,7 +650,7 @@ async function initializeDesktopShell(): Promise<void> {
 
   await Desktop.addListener("shortcutPressed", (event: { id: string }) => {
     if (event.id === "command-palette") {
-      dispatchMiladyEvent(COMMAND_PALETTE_EVENT);
+      dispatchAppEvent(COMMAND_PALETTE_EVENT);
     }
   });
 
@@ -452,7 +661,7 @@ async function initializeDesktopShell(): Promise<void> {
   await Desktop.addListener(
     "trayMenuClick",
     (event: { itemId: string; checked?: boolean }) => {
-      dispatchMiladyEvent(TRAY_ACTION_EVENT, event);
+      dispatchAppEvent(TRAY_ACTION_EVENT, event);
     },
   );
 
@@ -490,26 +699,56 @@ function setupPlatformStyles(): void {
   root.style.setProperty("--keyboard-height", "0px");
 }
 
+function isPhoneCompanionMode(): boolean {
+  if (typeof window === "undefined") return false;
+  const params = new URLSearchParams(
+    window.location.search || window.location.hash.split("?")[1] || "",
+  );
+  return params.get("mode") === "companion";
+}
+
+function resolveAppWindowSlug(): string | null {
+  if (!isAppWindowRoute()) return null;
+  const path = getWindowNavigationPath();
+  if (!path.startsWith("/apps/")) return null;
+  // Take only the first path segment after /apps/. URLs like
+  // `/apps/plugins/extra` would otherwise yield a malformed slug
+  // ("plugins/extra") that no descriptor can match.
+  const slug = path
+    .slice("/apps/".length)
+    .replace(/[?#].*$/, "")
+    .split("/")[0];
+  return slug.length > 0 ? slug : null;
+}
+
 function mountReactApp(): void {
   const rootEl = document.getElementById("root");
   if (!rootEl) throw new Error("Root element #root not found");
 
-  const root = window.__MILADY_REACT_ROOT__ ?? createRoot(rootEl);
-  window.__MILADY_REACT_ROOT__ = root;
+  const phoneCompanion = isPhoneCompanionMode();
+  const detachedShell = isDetachedWindowShell(windowShellRoute);
+  const appWindowSlug = detachedShell ? null : resolveAppWindowSlug();
 
-  root.render(
+  createRoot(rootEl).render(
     <ErrorBoundary>
       <StrictMode>
-        <AppProvider branding={MILADY_BRANDING}>
-          {isDetachedWindowShell(windowShellRoute) ? (
-            <div className="flex h-screen min-h-0 w-screen flex-col overflow-hidden">
+        <AppProvider branding={APP_BRANDING}>
+          {phoneCompanion ? (
+            <CompanionShell tab="companion" actionNotice={null} />
+          ) : detachedShell ? (
+            <div className="flex h-[100dvh] min-h-0 w-full max-w-full flex-col overflow-hidden">
               <DetachedShellRoot route={windowShellRoute} />
+            </div>
+          ) : appWindowSlug ? (
+            <div className="flex h-[100dvh] min-h-0 w-full max-w-full flex-col overflow-hidden">
+              <AppWindowRenderer slug={appWindowSlug} />
             </div>
           ) : (
             <>
               <DesktopOnboardingRuntime />
               <DesktopSurfaceNavigationRuntime />
               <DesktopTrayRuntime />
+              <LifeOpsActivitySignalsEffect />
               <App />
             </>
           )}
@@ -525,17 +764,6 @@ function isPopoutWindow(): boolean {
     window.location.search || window.location.hash.split("?")[1] || "",
   );
   return params.has("popout");
-}
-
-/**
- * Broadcast window detection is shared across the codebase via
- * `@miladyai/app-core/platform` — `isBroadcastWindowShared` wraps the
- * canonical path-aware + query-fallback detector so this file doesn't
- * maintain its own duplicate. Use `getBroadcastMode()` to distinguish
- * public viewer from internal capture below.
- */
-function isBroadcastWindow(): boolean {
-  return isBroadcastWindowShared();
 }
 
 /**
@@ -564,13 +792,16 @@ function validateAndSetApiBase(apiBase: string): void {
     ) {
       setBootConfig({ ...getBootConfig(), apiBase });
     } else {
-      console.warn("[Milady] Rejected non-local apiBase:", host);
+      console.warn(`${APP_LOG_PREFIX} Rejected non-local apiBase:`, host);
     }
   } catch {
     if (apiBase.startsWith("/") && !apiBase.startsWith("//")) {
       setBootConfig({ ...getBootConfig(), apiBase });
     } else {
-      console.warn("[Milady] Rejected invalid relative apiBase:", apiBase);
+      console.warn(
+        `${APP_LOG_PREFIX} Rejected invalid relative apiBase:`,
+        apiBase,
+      );
     }
   }
 }
@@ -588,18 +819,175 @@ function injectDetachedShellApiBase(): void {
   if (apiBase) validateAndSetApiBase(apiBase);
 }
 
+function mobileModeToIosRuntimeMode(
+  mode: ReturnType<typeof normalizeMobileRuntimeMode>,
+): IosRuntimeMode | null {
+  return mode === "remote-mac" ||
+    mode === "cloud" ||
+    mode === "cloud-hybrid" ||
+    mode === "local"
+    ? mode
+    : null;
+}
+
+function getCurrentIosRuntimeConfig(): IosRuntimeConfig {
+  if (typeof window === "undefined") return IOS_RUNTIME_ENV_CONFIG;
+  try {
+    const mode = mobileModeToIosRuntimeMode(
+      normalizeMobileRuntimeMode(
+        window.localStorage.getItem(MOBILE_RUNTIME_MODE_STORAGE_KEY),
+      ),
+    );
+    if (!mode) return IOS_RUNTIME_ENV_CONFIG;
+    return { ...IOS_RUNTIME_ENV_CONFIG, mode };
+  } catch {
+    return IOS_RUNTIME_ENV_CONFIG;
+  }
+}
+
+function applyBuildTimeIosConnection(): void {
+  if (!isNative) return;
+  if (!IOS_RUNTIME_ENV_CONFIG.apiBase && !IOS_RUNTIME_ENV_CONFIG.apiToken)
+    return;
+
+  const current = getBootConfig();
+  const next: AppBootConfig = {
+    ...current,
+    ...(IOS_RUNTIME_ENV_CONFIG.apiToken
+      ? { apiToken: IOS_RUNTIME_ENV_CONFIG.apiToken }
+      : {}),
+  };
+  setBootConfig(next);
+
+  if (IOS_RUNTIME_ENV_CONFIG.apiBase) {
+    validateAndSetApiBase(IOS_RUNTIME_ENV_CONFIG.apiBase);
+  }
+}
+
+async function getOrCreateDeviceBridgeId(): Promise<string> {
+  const existing = await Preferences.get({ key: DEVICE_BRIDGE_ID_KEY });
+  if (existing.value?.trim()) return existing.value.trim();
+
+  const prefix = isAndroid ? "android" : isIOS ? "ios" : "mobile";
+  const generated =
+    globalThis.crypto?.randomUUID?.() ??
+    `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  await Preferences.set({ key: DEVICE_BRIDGE_ID_KEY, value: generated });
+  return generated;
+}
+
+function resolveDeviceBridgeUrl(config: IosRuntimeConfig): string | null {
+  if (config.deviceBridgeUrl) {
+    return config.deviceBridgeUrl;
+  }
+  // cloud-hybrid: paired phone dials a remote agent via the cloud apiBase.
+  // Android local: the foreground agent service owns the loopback API and the
+  // WebView dials its device bridge for native llama.cpp calls.
+  // iOS local: requests are handled by the in-process ITTP route kernel, so a
+  // loopback WebSocket bridge is both unnecessary and unsafe in simulator runs
+  // where host-level adb port forwarding can expose another device's agent.
+  if (config.mode === "local" && isIOS) return null;
+  if (config.mode === "local" && isAndroid) {
+    return apiBaseToDeviceBridgeUrl(ANDROID_LOCAL_AGENT_API_BASE);
+  }
+  if (config.mode !== "cloud-hybrid" && config.mode !== "local") return null;
+  const apiBase = getBootConfig().apiBase?.trim();
+  if (!apiBase) return null;
+  try {
+    return apiBaseToDeviceBridgeUrl(apiBase);
+  } catch {
+    return null;
+  }
+}
+
+async function initializeMobileDeviceBridge(): Promise<void> {
+  const runtimeConfig = getCurrentIosRuntimeConfig();
+  if (
+    !isNative ||
+    (runtimeConfig.mode !== "cloud-hybrid" && runtimeConfig.mode !== "local")
+  ) {
+    return;
+  }
+  if (mobileDeviceBridgeClient) return;
+  if (mobileDeviceBridgeStartPromise) return;
+
+  const agentUrl = resolveDeviceBridgeUrl(runtimeConfig);
+  if (!agentUrl) return;
+
+  mobileDeviceBridgeStartPromise = (async () => {
+    try {
+      const deviceId = await getOrCreateDeviceBridgeId();
+      mobileDeviceBridgeClient = startDeviceBridgeClient({
+        agentUrl,
+        ...(runtimeConfig.deviceBridgeToken
+          ? { pairingToken: runtimeConfig.deviceBridgeToken }
+          : {}),
+        deviceId,
+        onStateChange: (state, detail) => {
+          console.info(
+            `${APP_LOG_PREFIX} Device bridge ${state}`,
+            detail ?? "",
+          );
+        },
+      });
+    } catch (error) {
+      console.warn(
+        `${APP_LOG_PREFIX} Device bridge unavailable:`,
+        error instanceof Error ? error.message : error,
+      );
+    } finally {
+      mobileDeviceBridgeStartPromise = null;
+    }
+  })();
+
+  await mobileDeviceBridgeStartPromise;
+}
+
+function stopMobileDeviceBridge(): void {
+  mobileDeviceBridgeClient?.stop();
+  mobileDeviceBridgeClient = null;
+}
+
+function initializeMobileRuntimeModeListener(): void {
+  if (!isNative || mobileRuntimeModeListenerInstalled) return;
+  mobileRuntimeModeListenerInstalled = true;
+  document.addEventListener(MOBILE_RUNTIME_MODE_CHANGED_EVENT, () => {
+    const mode = getCurrentIosRuntimeConfig().mode;
+    if (mode === "cloud-hybrid" || mode === "local") {
+      stopMobileDeviceBridge();
+      void initializeMobileDeviceBridge();
+      return;
+    }
+    stopMobileDeviceBridge();
+  });
+}
+
 function applyStoredDetachedShellTheme(): void {
   applyUiTheme(loadUiTheme());
 }
 
-async function runMain(): Promise<void> {
+async function initializeStatusBar(): Promise<void> {
+  if (!isNative) return;
+  try {
+    const { StatusBar, Style } = await import("@capacitor/status-bar");
+    await StatusBar.setStyle({ style: Style.Dark });
+    await StatusBar.setOverlaysWebView({ overlay: true });
+    await StatusBar.setBackgroundColor({ color: "#0a0a0a" });
+  } catch {
+    // StatusBar plugin unavailable on this platform — non-fatal.
+  }
+}
+
+async function main(): Promise<void> {
   setupPlatformStyles();
+  await initializeStatusBar();
+  applyBuildTimeIosConnection();
 
   try {
     await applyLaunchConnectionFromUrl();
   } catch (err) {
     console.error(
-      "[Milady] Failed to apply managed cloud launch session:",
+      `${APP_LOG_PREFIX} Failed to apply managed cloud launch session:`,
       err instanceof Error ? err.message : err,
     );
   }
@@ -626,127 +1014,6 @@ async function runMain(): Promise<void> {
     return;
   }
 
-  if (isBroadcastWindow()) {
-    // Broadcast mode is served by two transports that share the same
-    // renderer code (BroadcastShell → CompanionSceneHost) but have
-    // opposite trust levels:
-    //
-    //   PUBLIC  — alice.rndrntwrk.com/broadcast/:channel
-    //     Unauthenticated. Cloudflare Access bypass on /broadcast/*.
-    //     Must not mount LiveKitBroadcastPublisher, must not call
-    //     mutation APIs, must not consume apiToken (there is no
-    //     intended auth for this surface), must not mark onboarding
-    //     complete via the shared localStorage flag.
-    //
-    //   CAPTURE — http://alice-bot:3000/broadcast/:channel
-    //     Internal-only. Never reaches Cloudflare. Puppeteer injects
-    //     `window.__injectedShowConfig` before navigation.
-    //     Needs the onboarding-skip marker, the __agentShowControl
-    //     handshake global, and the apiToken bridge so LiveKit
-    //     publishing and WS-backed scene sync work.
-    //
-    // `getBroadcastMode()` distinguishes them purely by the presence
-    // of `window.__injectedShowConfig` (which the browser runtime
-    // sets before any script runs when Puppeteer calls
-    // evaluateOnNewDocument). A public viewer cannot spoof it —
-    // document content and query params have no way to produce a
-    // pre-script global.
-    const broadcastMode = getBroadcastMode();
-    console.log(
-      `[boot] broadcast mode=${broadcastMode} channel=${getBroadcastChannel() ?? "(none)"}`,
-    );
-
-    if (broadcastMode === "capture") {
-      // Set the 555stream capture-service "React mounted" handshake
-      // marker SYNCHRONOUSLY, before React mounts. The capture worker
-      // uses `page.waitForFunction(() => typeof window.__agentShowControl
-      // !== 'undefined')` as its primary ready gate. Setting the
-      // global here eliminates the race between React commit and the
-      // worker's 20s timeout.
-      //
-      // Only the capture transport sets this — a public viewer has no
-      // capture-service on the other side waiting for a handshake.
-      (
-        window as unknown as { __agentShowControl?: Record<string, unknown> }
-      ).__agentShowControl = { source: "broadcast-boot" };
-
-      // Teach the startup coordinator that onboarding is already
-      // complete. milaidy's SPA treats each browser as a personal
-      // install to onboard, but alice-bot is server-side/single-
-      // tenant/always-on — a fresh Chromium in the capture-service
-      // pod has empty localStorage, so the coordinator would
-      // transition to `onboarding-required` and render the character-
-      // select screen instead of the companion.
-      //
-      // Only the capture transport flips this flag — public viewers
-      // are non-operator surfaces and we don't want writing to the
-      // browser's own localStorage under a user-visible URL.
-      try {
-        localStorage.setItem("eliza:onboarding-complete", "1");
-      } catch {
-        /* storage unavailable — coordinator has its own try/catch */
-      }
-
-      // Bridge alice-bot auth into the SPA's API client.
-      // Only meaningful under the capture transport: WS + privileged
-      // REST need credentials so scene-state sync + emote replay
-      // work. Public viewers never authenticate — any apiToken
-      // query on the public URL is rejected here explicitly.
-      //
-      // Precedence:
-      //   1. `?apiToken=` — explicit override for internal debugging
-      //   2. `__injectedShowConfig.apiToken` — the real alice-bot API token
-      //      injected by capture-service/control-plane
-      //   3. `__injectedShowConfig.wsToken` — legacy renderer JWT fallback
-      //      kept only for auth-disabled migrations
-      {
-        const params = new URLSearchParams(
-          window.location.search || window.location.hash.split("?")[1] || "",
-        );
-        const urlToken = params.get("apiToken");
-        if (urlToken) {
-          setBootConfig({ ...getBootConfig(), apiToken: urlToken });
-        } else {
-          try {
-            const injectedConfig = (
-              window as unknown as {
-                __injectedShowConfig?: { apiToken?: string; wsToken?: string };
-              }
-            ).__injectedShowConfig;
-            if (injectedConfig?.apiToken) {
-              setBootConfig({
-                ...getBootConfig(),
-                apiToken: injectedConfig.apiToken,
-              });
-            } else if (injectedConfig?.wsToken) {
-              setBootConfig({
-                ...getBootConfig(),
-                apiToken: injectedConfig.wsToken,
-              });
-            }
-          } catch {
-            /* injectedShowConfig not available */
-          }
-        }
-      }
-
-      injectPopoutApiBase();
-    } else {
-      // PUBLIC broadcast viewer. Intentionally skip the capture-only
-      // side-effects above. No apiToken bridge even if the URL carries
-      // one — any `?apiToken=` on the public surface is refused by
-      // ignoring it here, which closes one obvious exfiltration shape.
-      //
-      // Still call the apiBase injector for development flexibility
-      // (it only accepts same-origin / private-network / HTTPS bases
-      // per its own allowlist, so this is safe for a public URL).
-      injectPopoutApiBase();
-    }
-
-    mountReactApp();
-    return;
-  }
-
   if (isDetachedWindowShell(windowShellRoute)) {
     injectDetachedShellApiBase();
     applyStoredDetachedShellTheme();
@@ -761,30 +1028,10 @@ async function runMain(): Promise<void> {
   await initializePlatform();
 }
 
-function main(): Promise<void> {
-  if (window.__MILADY_APP_BOOT_PROMISE__) {
-    return window.__MILADY_APP_BOOT_PROMISE__;
-  }
-
-  const bootPromise = runMain().catch((err) => {
-    delete window.__MILADY_APP_BOOT_PROMISE__;
-    throw err;
-  });
-  window.__MILADY_APP_BOOT_PROMISE__ = bootPromise;
-  return bootPromise;
-}
-
 if (document.readyState === "loading") {
   document.addEventListener("DOMContentLoaded", main);
 } else {
   main();
 }
 
-export {
-  isAndroid,
-  isDesktopPlatform as isDesktop,
-  isIOS,
-  isNative,
-  isWebPlatform as isWeb,
-  platform,
-};
+export { isAndroid, isDesktopPlatform as isDesktop, isIOS, isNative, platform };

--- a/apps/app/test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts
+++ b/apps/app/test/electrobun-packaged/electrobun-windows-startup.e2e.spec.ts
@@ -1,280 +1,89 @@
-import { type ChildProcess, execFile, spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { promisify } from "node:util";
 import { expect, test } from "@playwright/test";
+import { startLiveApiServer, type TestApiServer } from "./live-api";
+import {
+  PackagedDesktopHarness,
+  resolvePackagedLauncher,
+} from "./packaged-app-helpers";
+import {
+  getPackagedRendererBootstrapProbeScript,
+  hasPackagedRendererBootstrapRequests,
+  isPackagedRendererBootstrapProbeReady,
+  type PackagedRendererBootstrapProbe,
+} from "./windows-bootstrap";
 
-import { type MockApiServer, startMockApiServer } from "./mock-api";
-import { hasPackagedRendererBootstrapRequests } from "./windows-bootstrap";
-import { createPackagedWindowsAppEnv } from "./windows-test-env";
+const windowsTest = process.platform === "win32" ? test : null;
 
-const execFileAsync = promisify(execFile);
-const here = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(here, "../../../..");
-const electrobunArtifactsDir = path.join(
-  repoRoot,
-  "apps",
-  "app",
-  "electrobun",
-  "artifacts",
-);
-const electrobunBuildDir = path.join(
-  repoRoot,
-  "apps",
-  "app",
-  "electrobun",
-  "build",
-);
-
-// Find a launcher.exe in a given directory
-async function findLauncherExe(dir: string): Promise<string | null> {
-  async function search(currentDir: string): Promise<string | null> {
-    const entries = await fs
-      .readdir(currentDir, { withFileTypes: true })
-      .catch(() => []);
-    for (const entry of entries) {
-      const fullPath = path.join(currentDir, entry.name);
-      if (entry.isDirectory()) {
-        const found = await search(fullPath);
-        if (found) return found;
-      } else if (
-        entry.isFile() &&
-        entry.name.toLowerCase() === "launcher.exe"
-      ) {
-        return fullPath;
-      }
-    }
-    return null;
-  }
-  return search(dir);
-}
-
-// Resolve the launcher.exe to use, extracting a tarball if necessary.
-async function resolveWindowsLauncher(tempExtractDir: string): Promise<string> {
-  const explicit = process.env.MILADY_TEST_WINDOWS_LAUNCHER_PATH?.trim();
-  if (explicit) {
-    await fs.access(explicit);
-    const resolved = await fs.realpath(explicit);
-    console.log(`Using explicit Windows launcher: ${resolved}`);
-    return resolved;
-  }
-
-  // CI Windows builds already have launcher.exe under the live build output.
-  // Prefer that over re-extracting the packaged tarball, which is slow enough
-  // to consume the entire Playwright test timeout on hosted runners.
-  let launcher = await findLauncherExe(electrobunBuildDir);
-  if (launcher) {
-    return fs.realpath(launcher);
-  }
-
-  // First try to find an already extracted launcher in the artifacts dir
-  launcher = await findLauncherExe(electrobunArtifactsDir);
-  if (launcher) {
-    return fs.realpath(launcher);
-  }
-
-  // Otherwise find a .tar.zst in the artifacts dir
-  const entries = await fs
-    .readdir(electrobunArtifactsDir, { withFileTypes: true })
-    .catch(() => []);
-  const tarballs = entries
-    .filter((entry) => entry.isFile() && entry.name.endsWith(".tar.zst"))
-    .map((entry) => path.join(electrobunArtifactsDir, entry.name));
-
-  if (tarballs.length === 0) {
-    throw new Error(
-      `No Windows artifacts found in ${electrobunArtifactsDir}. Build Electrobun for Windows first.`,
-    );
-  }
-
-  // Sort by newest
-  const stats = await Promise.all(
-    tarballs.map(async (p) => ({ p, stat: await fs.stat(p) })),
-  );
-  stats.sort((a, b) => b.stat.mtimeMs - a.stat.mtimeMs);
-  const tarballPath = await fs.realpath(stats[0].p);
-
-  // Make sure we have system tar.exe
-  await fs.mkdir(tempExtractDir, { recursive: true });
-  console.log(`Extracting ${tarballPath} to ${tempExtractDir}...`);
-  await execFileAsync("tar", [
-    "--force-local",
-    "-xf",
-    tarballPath,
-    "-C",
-    tempExtractDir,
-  ]);
-
-  launcher = await findLauncherExe(tempExtractDir);
-  if (!launcher) {
-    throw new Error(
-      `Failed to find launcher.exe in extracted archive ${tarballPath}`,
-    );
-  }
-
-  return fs.realpath(launcher);
-}
-
-function collectProcessLogs(child: ChildProcess): {
-  stdout: string[];
-  stderr: string[];
-} {
-  const stdout: string[] = [];
-  const stderr: string[] = [];
-  const append = (target: string[], chunk: Buffer): void => {
-    const text = chunk.toString("utf8");
-    if (!text) return;
-    target.push(text);
-    if (target.length > 2000) target.splice(0, target.length - 2000);
-  };
-  child.stdout?.on("data", (chunk: Buffer) => append(stdout, chunk));
-  child.stderr?.on("data", (chunk: Buffer) => append(stderr, chunk));
-  return { stdout, stderr };
-}
-
-async function waitForRendererBootstrap(
-  api: MockApiServer,
-  child: ChildProcess,
-  timeoutMs: number,
-  processLogs: { stdout: string[]; stderr: string[] } | null,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (child.exitCode !== null) {
-      const stdoutText = processLogs?.stdout.join("") ?? "";
-      const stderrText = processLogs?.stderr.join("") ?? "";
-      throw new Error(
-        `Packaged Windows app exited before renderer bootstrap.\n` +
-          `Exit code: ${child.exitCode}\n` +
-          `Mock requests:\n${api.requests.join("\n")}\n\n` +
-          `App stdout:\n${stdoutText}\n\nApp stderr:\n${stderrText}`,
-      );
-    }
-
-    if (hasPackagedRendererBootstrapRequests(api.requests)) {
-      return;
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 250));
-  }
-
-  const stdoutText = processLogs?.stdout.join("") ?? "";
-  const stderrText = processLogs?.stderr.join("") ?? "";
-  throw new Error(
-    `Timed out waiting for packaged Windows renderer to reach the external API.\n` +
-      `Mock requests:\n${api.requests.join("\n")}\n\n` +
-      `App stdout:\n${stdoutText}\n\nApp stderr:\n${stderrText}`,
-  );
-}
-
-async function killProcess(child: ChildProcess): Promise<void> {
-  if (child.exitCode !== null || child.killed) return;
-  child.kill("SIGTERM");
-  await new Promise<void>((resolve) => {
-    const timeout = setTimeout(() => {
-      child.kill("SIGKILL");
-      resolve();
-    }, 5000);
-    child.once("exit", () => {
-      clearTimeout(timeout);
-      resolve();
-    });
-  });
-}
-
-if (process.platform === "win32") {
-  test("packaged Windows app bootstraps the renderer against the external API override", async () => {
-    const tempExtractDir = await fs.mkdtemp(
+windowsTest?.(
+  "packaged Windows app bootstraps the renderer against the external API override",
+  async () => {
+    const tempRoot = await fs.mkdtemp(
       path.join(os.tmpdir(), "milady-win-e2e-"),
     );
-    const userDataDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), "milady-win-userdata-"),
-    );
-    const localUserDataDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), "milady-win-localappdata-"),
-    );
+    const extractDir = path.join(tempRoot, "extract");
+    const launcherPath = await resolvePackagedLauncher(extractDir);
+    expect(launcherPath, "Windows packaged launcher is required.").toBeTruthy();
 
-    const executablePath = await resolveWindowsLauncher(tempExtractDir);
-
-    let api: MockApiServer | null = null;
-    let appProcess: ChildProcess | null = null;
-    let processLogs: { stdout: string[]; stderr: string[] } | null = null;
+    let api: TestApiServer | null = null;
+    let harness: PackagedDesktopHarness | null = null;
 
     try {
-      api = await startMockApiServer({ onboardingComplete: true, port: 0 });
-
-      appProcess = spawn(executablePath, [], {
-        cwd: path.dirname(executablePath),
-        env: createPackagedWindowsAppEnv({
-          baseEnv: process.env,
-          apiBase: api.baseUrl,
-          appData: userDataDir,
-          localAppData: localUserDataDir,
-        }),
-        stdio: ["ignore", "pipe", "pipe"],
+      api = await startLiveApiServer({ onboardingComplete: true, port: 0 });
+      harness = new PackagedDesktopHarness({
+        tempRoot,
+        launcherPath: launcherPath as string,
+        apiBase: api.baseUrl,
       });
-      processLogs = collectProcessLogs(appProcess);
 
-      await waitForRendererBootstrap(
-        api,
-        appProcess,
-        process.env.CI ? 180_000 : 90_000,
-        processLogs,
-      );
+      await harness.start();
 
-      await expect
-        .poll(
-          () =>
-            api ? hasPackagedRendererBootstrapRequests(api.requests) : false,
-          {
-            timeout: 30_000,
-            message:
-              "Expected the packaged renderer to reach the external API bootstrap requests",
-          },
-        )
-        .toBe(true);
+      let lastProbe: PackagedRendererBootstrapProbe | null = null;
+      try {
+        await expect
+          .poll(
+            async () => {
+              lastProbe = await harness.eval<PackagedRendererBootstrapProbe>(
+                getPackagedRendererBootstrapProbeScript(),
+              );
+              return (
+                isPackagedRendererBootstrapProbeReady(
+                  lastProbe,
+                  api?.baseUrl ?? "",
+                ) && hasPackagedRendererBootstrapRequests(api?.requests ?? [])
+              );
+            },
+            {
+              timeout: process.env.CI ? 180_000 : 90_000,
+              message:
+                "Expected the packaged Windows renderer to reach the external API bootstrap requests",
+            },
+          )
+          .toBe(true);
+      } catch (error) {
+        throw new Error(
+          [
+            "Expected the packaged Windows renderer to reach the external API bootstrap requests",
+            `Last renderer probe: ${JSON.stringify(lastProbe)}`,
+            `Observed API requests: ${JSON.stringify(api?.requests ?? [])}`,
+            error instanceof Error ? error.message : String(error),
+          ].join("\n"),
+        );
+      }
 
-      await expect
-        .poll(
-          () =>
-            appProcess && appProcess.exitCode === null ? "running" : "exited",
-          {
-            timeout: 15_000,
-            message:
-              "Expected the packaged Windows app to stay alive after bootstrap",
-          },
-        )
-        .toBe("running");
-
-      // Keep the process alive long enough to catch immediate post-bootstrap
-      // startup regressions that can happen after the first renderer requests.
-      await new Promise((resolve) => setTimeout(resolve, 8_000));
-      expect(appProcess.exitCode).toBeNull();
-
-      expect(hasPackagedRendererBootstrapRequests(api.requests)).toBe(true);
       expect(api.requests.length).toBeGreaterThan(0);
-
-      const stdoutText = processLogs?.stdout.join("") ?? "";
-      const stderrText = processLogs?.stderr.join("") ?? "";
       expect(
-        `${stdoutText}\n${stderrText}`,
-        `Packaged Windows app logs should not contain fatal startup errors.\n` +
-          `Mock requests:\n${api.requests.join("\n")}\n\n` +
-          `App stdout:\n${stdoutText}\n\nApp stderr:\n${stderrText}`,
+        `${harness.logs?.stdout.join("") ?? ""}\n${harness.logs?.stderr.join("") ?? ""}`,
       ).not.toMatch(
         /Fatal error during startup|startup failure|Cannot find module/i,
       );
     } finally {
+      await harness?.stop().catch(() => undefined);
       await api?.close().catch(() => undefined);
-      if (appProcess) await killProcess(appProcess);
       await fs
-        .rm(tempExtractDir, { recursive: true, force: true })
-        .catch(() => undefined);
-      await fs
-        .rm(userDataDir, { recursive: true, force: true })
+        .rm(tempRoot, { recursive: true, force: true })
         .catch(() => undefined);
     }
-  });
-}
+  },
+);

--- a/apps/app/test/electrobun-packaged/windows-bootstrap.ts
+++ b/apps/app/test/electrobun-packaged/windows-bootstrap.ts
@@ -5,6 +5,64 @@ function hasRequestForPath(
   return requests.some((request) => request.endsWith(` ${pathname}`));
 }
 
+export interface PackagedRendererBootstrapProbe {
+  ok: boolean;
+  apiBase: string | null;
+  bootApiBase: string | null;
+  legacyApiBase: string | null;
+  status: number | null;
+  error?: string;
+}
+
+export function getPackagedRendererBootstrapProbeScript(): string {
+  return `(async () => {
+    try {
+      const bootSymbol = Symbol.for("elizaos.app.boot-config");
+      const bootConfig =
+        window.__ELIZAOS_APP_BOOT_CONFIG__ ??
+        window.__ELIZA_APP_BOOT_CONFIG__ ??
+        window[bootSymbol]?.current ??
+        null;
+      const bootApiBase =
+        typeof bootConfig?.apiBase === "string" ? bootConfig.apiBase : null;
+      const legacyApiBase =
+        typeof window.__ELIZA_API_BASE__ === "string"
+          ? window.__ELIZA_API_BASE__
+          : null;
+      const response = await fetch("/api/status", { cache: "no-store" });
+      return {
+        ok: true,
+        apiBase: bootApiBase ?? legacyApiBase,
+        bootApiBase,
+        legacyApiBase,
+        status: response.status,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        apiBase: null,
+        bootApiBase: null,
+        legacyApiBase: null,
+        status: null,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  })()`;
+}
+
+export function isPackagedRendererBootstrapProbeReady(
+  probe: PackagedRendererBootstrapProbe,
+  expectedApiBase: string,
+): boolean {
+  return (
+    probe.ok &&
+    probe.apiBase === expectedApiBase &&
+    typeof probe.status === "number" &&
+    probe.status >= 200 &&
+    probe.status < 500
+  );
+}
+
 export function hasPackagedRendererBootstrapRequests(
   requests: readonly string[],
 ): boolean {

--- a/apps/app/tsconfig.json
+++ b/apps/app/tsconfig.json
@@ -3,7 +3,11 @@
     "target": "ES2022",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
@@ -12,13 +16,334 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "experimentalDecorators": true,
     "useUnknownInCatchVariables": true,
-    "types": ["vite/client"]
+    "types": [
+      "vite/client",
+      "bun-types"
+    ],
+    "baseUrl": "../..",
+    "paths": {
+      "@elizaos/app-core": [
+        "./node_modules/@elizaos/app-core"
+      ],
+      "@elizaos/app-core/platform/native-plugin-entrypoints": [
+        "./node_modules/@elizaos/app-core/platform/native-plugin-entrypoints"
+      ],
+      "@elizaos/app-core/*": [
+        "./node_modules/@elizaos/app-core/*"
+      ],
+      "@elizaos/app-hyperscape": [
+        "./node_modules/@elizaos/app-hyperscape",
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-hyperscape/*": [
+        "./node_modules/@elizaos/app-hyperscape/*",
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/agent": [
+        "./node_modules/@elizaos/agent"
+      ],
+      "@elizaos/agent/*": [
+        "./node_modules/@elizaos/agent/*"
+      ],
+      "@elizaos/plugin-browser-bridge": [
+        "./node_modules/@elizaos/plugin-browser-bridge"
+      ],
+      "@elizaos/plugin-browser-bridge/*": [
+        "./node_modules/@elizaos/plugin-browser-bridge/*"
+      ],
+      "@elizaos/core": [
+        "./node_modules/@elizaos/core"
+      ],
+      "@elizaos/core/*": [
+        "./node_modules/@elizaos/core/*"
+      ],
+      "@elizaos/shared": [
+        "./node_modules/@elizaos/shared"
+      ],
+      "@elizaos/shared/*": [
+        "./node_modules/@elizaos/shared/*"
+      ],
+      "@elizaos/skills": [
+        "./node_modules/@elizaos/skills"
+      ],
+      "@elizaos/skills/*": [
+        "./node_modules/@elizaos/skills/*"
+      ],
+      "@elizaos/ui": [
+        "./node_modules/@elizaos/ui"
+      ],
+      "@elizaos/ui/*": [
+        "./node_modules/@elizaos/ui/*"
+      ],
+      "react": [
+        "./node_modules/@types/react/index.d.ts"
+      ],
+      "react/jsx-runtime": [
+        "./node_modules/@types/react/jsx-runtime.d.ts"
+      ],
+      "react/jsx-dev-runtime": [
+        "./node_modules/@types/react/jsx-dev-runtime.d.ts"
+      ],
+      "react-dom": [
+        "./node_modules/@types/react-dom/index.d.ts"
+      ],
+      "react-dom/client": [
+        "./node_modules/@types/react-dom/client.d.ts"
+      ],
+      "@elizaos/*": [
+        "./node_modules/@elizaos/*"
+      ],
+      "@elizaos/app-2004scape": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-2004scape/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-babylon": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-babylon/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-elizamaker": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-elizamaker/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-task-coordinator": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-task-coordinator/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-companion": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-companion/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-contacts": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-contacts/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-defense-of-the-agents": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-defense-of-the-agents/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-lifeops": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-lifeops/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-scape": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-scape/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-shopify": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-shopify/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-hyperliquid": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-hyperliquid/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-polymarket": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-polymarket/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-phone": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-phone/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-steward": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-steward/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-screenshare": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-screenshare/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-training": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-training/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-trajectory-logger": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-trajectory-logger/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-vincent": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-vincent/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-wallet": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-wallet/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-wifi": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-wifi/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-workflow-builder": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/app-workflow-builder/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@clawville/app-clawville": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@clawville/app-clawville/*": [
+        "./apps/app/src/optional-eliza-app-stub.tsx"
+      ],
+      "@elizaos/capacitor-agent": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-agent/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-contacts": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-contacts/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-desktop": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-desktop/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-phone": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-phone/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-wifi": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-wifi/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-llama": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-llama/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-mobile-signals": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-mobile-signals/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-appblocker": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-appblocker/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-camera": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-camera/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-canvas": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-canvas/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-gateway": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-gateway/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-location": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-location/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-messages": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-messages/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-screencapture": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-screencapture/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-swabble": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-swabble/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-system": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-system/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-talkmode": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-talkmode/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-websiteblocker": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/capacitor-websiteblocker/*": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ],
+      "@elizaos/native-activity-tracker": [
+        "./apps/app/src/native-plugin-stubs.ts"
+      ]
+    }
   },
   "include": [
     "src/**/*.ts",
@@ -26,5 +351,11 @@
     "../../packages/app-core/src/ambient-modules.d.ts",
     "../../packages/agent/src/external-modules.d.ts"
   ],
-  "exclude": ["node_modules", "dist", "ios", "android", "electrobun"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "ios",
+    "android",
+    "electrobun"
+  ]
 }

--- a/scripts/run-production-build.mjs
+++ b/scripts/run-production-build.mjs
@@ -105,7 +105,7 @@ function run(command, args, cwd = repoRoot) {
   });
 }
 
-if (!isLocalElizaDisabled()) {
+if (isLocalElizaDisabled()) {
   // Upstream: packages-mode path — delegate to the elizaOS app-core script
   await run(node, [
     "scripts/run-eliza-app-core-script.mjs",

--- a/scripts/run-production-build.mjs
+++ b/scripts/run-production-build.mjs
@@ -1,25 +1,45 @@
 #!/usr/bin/env node
 /**
- * Full production build with maximal safe parallelism:
- * 1. tsdown (root dist) ∥ Capacitor plugin-build
- * 2. vite build (apps/app)
- * 3. write-build-info (dist metadata)
+ * Production build orchestrator.
  *
- * Requires prior `bun install` / postinstall (see apps/app/scripts/build.mjs).
+ * Upstream provides the mode-switching baseline:
+ *   - packages mode (isLocalElizaDisabled === true) → delegate to
+ *     scripts/run-eliza-app-core-script.mjs which runs the standard
+ *     elizaOS production build.
+ *   - local mode (default for alice's AWS deploy) → run the inline
+ *     local-mode flow with the elizaOS patch scripts + tsdown + vite.
+ *
+ * Alice layer on top of the local-mode flow:
+ *   - Capacitor plugin-build (apps/app/scripts/plugin-build.mjs) runs
+ *     in parallel with tsdown for build speed.
+ *   - Milady asset-CDN handling: resolveMiladyAssetBaseUrls() supplies
+ *     VITE_ASSET_BASE_URL so the vite build emits CDN-anchored asset
+ *     paths; prune-cdn-local-assets.mjs prunes the local copies after
+ *     the CDN upload step.
+ *   - write-build-info preferentially runs through bun when bun is on
+ *     PATH; falls back to `node --import tsx` so the script also works
+ *     from a pure-node host.
+ *   - resolveNodeExec() handles the case where this script is invoked
+ *     via `bun run`, where process.execPath is bun, not node — needed
+ *     because tsdown + vite CLIs require real node.
  */
+
 import { spawn, spawnSync } from "node:child_process";
-import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { resolveMiladyAssetBaseUrls } from "./lib/asset-cdn.mjs";
 
-const rootDir = path.resolve(
+import { resolveMiladyAssetBaseUrls } from "./lib/asset-cdn.mjs";
+import { isLocalElizaDisabled } from "./lib/eliza-package-mode.mjs";
+
+const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
 );
-const appDir = path.join(rootDir, "apps", "app");
+const appDir = path.join(repoRoot, "apps", "app");
 
-/** Real Node binary — when the script is started via `bun run`, process.execPath is Bun. */
+// ── alice: real Node binary even when started via `bun run` ────────────────
 function resolveNodeExec() {
   if (!process.versions.bun) {
     return process.execPath;
@@ -27,9 +47,7 @@ function resolveNodeExec() {
   const probe = spawnSync(
     "node",
     ["-e", "process.stdout.write(process.execPath)"],
-    {
-      encoding: "utf8",
-    },
+    { encoding: "utf8" },
   );
   const out = probe.stdout?.trim();
   if (probe.status === 0 && out) {
@@ -40,8 +58,6 @@ function resolveNodeExec() {
   );
 }
 
-const node = resolveNodeExec();
-
 function resolveBunForScripts() {
   if (process.versions.bun) {
     return process.execPath;
@@ -50,7 +66,10 @@ function resolveBunForScripts() {
   return probe.status === 0 ? "bun" : null;
 }
 
-function run(executable, args, cwd) {
+const node = resolveNodeExec();
+const { appAssetBaseUrl } = resolveMiladyAssetBaseUrls();
+
+function run(command, args, cwd = repoRoot) {
   const env = {
     ...process.env,
     ...(appAssetBaseUrl
@@ -63,19 +82,22 @@ function run(executable, args, cwd) {
       : {}),
   };
   return new Promise((resolve, reject) => {
-    const child = spawn(executable, args, {
+    const child = spawn(command, args, {
       cwd,
-      stdio: "inherit",
       env,
+      stdio: "inherit",
       shell: false,
+    });
+    child.on("error", (error) => {
+      reject(new Error(`${command} failed to start: ${error.message}`));
     });
     child.on("exit", (code, signal) => {
       if (signal) {
-        reject(new Error(`process exited with signal ${signal}`));
+        reject(new Error(`${command} exited due to signal ${signal}`));
         return;
       }
       if ((code ?? 1) !== 0) {
-        reject(new Error(`process exited with code ${code ?? 1}`));
+        reject(new Error(`${command} exited with code ${code ?? 1}`));
         return;
       }
       resolve();
@@ -83,55 +105,62 @@ function run(executable, args, cwd) {
   });
 }
 
-function resolveTsdownCli() {
-  const p = path.join(rootDir, "node_modules", "tsdown", "dist", "run.mjs");
-  if (!fs.existsSync(p)) {
-    throw new Error("tsdown not found under node_modules; run bun install");
-  }
-  return p;
-}
+if (!isLocalElizaDisabled()) {
+  // Upstream: packages-mode path — delegate to the elizaOS app-core script
+  await run(node, [
+    "scripts/run-eliza-app-core-script.mjs",
+    "run-production-build.mjs",
+  ]);
+} else {
+  // Local-mode (alice's deploy): upstream's patch+build flow + alice layer
+  const tsdownCli = require.resolve("tsdown/run");
+  const vitePackageRoot = path.dirname(require.resolve("vite/package.json"));
+  const viteCli = path.join(vitePackageRoot, "bin", "vite.js");
+  const pluginBuildScript = path.join(appDir, "scripts", "plugin-build.mjs");
+  const writeBuildInfoScript = path.join(
+    repoRoot,
+    "scripts",
+    "write-build-info.ts",
+  );
+  const pruneCdnAssetsScript = path.join(
+    repoRoot,
+    "scripts",
+    "prune-cdn-local-assets.mjs",
+  );
+  const bunForScripts = resolveBunForScripts();
 
-function resolveViteCli() {
-  for (const base of [appDir, rootDir]) {
-    const p = path.join(base, "node_modules", "vite", "bin", "vite.js");
-    if (fs.existsSync(p)) {
-      return p;
-    }
-  }
-  throw new Error("vite CLI not found; run bun install");
-}
+  // Upstream: elizaOS patch scripts that prepare the workspace for build
+  await run(node, ["scripts/ensure-elizaos-optional-app-stubs.mjs"]);
+  await run(node, ["scripts/patch-elizaos-package-styles.mjs"]);
+  await run(node, ["scripts/patch-elizaos-plugin-browser-bridge-package.mjs"]);
 
-const tsdownCli = resolveTsdownCli();
-const viteCli = resolveViteCli();
-const pluginBuildScript = path.join(appDir, "scripts", "plugin-build.mjs");
-const writeBuildInfoScript = path.join(
-  rootDir,
-  "scripts",
-  "write-build-info.ts",
-);
-const bunForScripts = resolveBunForScripts();
-const pruneCdnAssetsScript = path.join(
-  rootDir,
-  "scripts",
-  "prune-cdn-local-assets.mjs",
-);
-const { appAssetBaseUrl } = resolveMiladyAssetBaseUrls();
+  // Alice + upstream: tsdown ∥ Capacitor plugin-build (parallel)
+  await Promise.all([
+    run(node, [
+      tsdownCli,
+      "--config-loader",
+      "native",
+      "--fail-on-warn",
+      "false",
+    ]),
+    run(node, [pluginBuildScript], appDir),
+  ]);
 
-await Promise.all([
-  run(node, [tsdownCli], rootDir),
-  run(node, [pluginBuildScript], appDir),
-]);
+  // Upstream: post-tsdown patch for native browser package
+  await run(node, ["scripts/patch-elizaos-app-core-native-browser-package.mjs"]);
 
-async function runWriteBuildInfo() {
+  // Vite SPA build
+  await run(node, [viteCli, "build"], appDir);
+
+  // Alice: write-build-info — prefer bun if available
   if (bunForScripts) {
-    await run(bunForScripts, [writeBuildInfoScript], rootDir);
-    return;
+    await run(bunForScripts, [writeBuildInfoScript], repoRoot);
+  } else {
+    await run(node, ["--import", "tsx", writeBuildInfoScript], repoRoot);
   }
-  await run(node, ["--import", "tsx", writeBuildInfoScript], rootDir);
-}
 
-await run(node, [viteCli, "build"], appDir);
-await runWriteBuildInfo();
-if (appAssetBaseUrl) {
-  await run(node, [pruneCdnAssetsScript], rootDir);
+  // Alice: CDN asset pruning (only when MILADY_ASSET_BASE_URL is set)
+  if (appAssetBaseUrl) {
+    await run(node, [pruneCdnAssetsScript], repoRoot);
+  }
 }

--- a/scripts/run-release-contract-suite.mjs
+++ b/scripts/run-release-contract-suite.mjs
@@ -1,10 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Release contract suite — alice's flow.
+ *
+ * Runs alice's release-contract test list, the milaidy startup contract,
+ * then a production build + release:check verification. This script is
+ * invoked from CI.
+ *
+ * Upstream's helpers (mode-switching, eliza-worktree cleanup, legacy
+ * electrobun compat-dir handling, etc.) are exported below for callers
+ * that need them, but alice's release flow stays simple and explicit.
+ */
+
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const ROOT = path.resolve(import.meta.dirname, "..");
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(scriptDir, "..");
+const repoRoot = ROOT;
+const appCoreRoot = path.resolve(repoRoot, "eliza", "packages", "app-core");
+const legacyElectrobunDir = path.join(repoRoot, "apps", "app", "electrobun");
+const canonicalElectrobunDir = path.join(
+  repoRoot,
+  "eliza",
+  "packages",
+  "app-core",
+  "platforms",
+  "electrobun",
+);
 
-function run(command, args) {
+// ── alice's release-contract test list ──────────────────────────────────
+// These are the tests alice's CI runs as the release-readiness gate.
+// Distinct from upstream's `rootReleaseContractTests` (alice has different
+// release surface concerns, e.g. asset-cdn, docker, chrome-extension,
+// whisper-build-script).
+const aliceReleaseContractTests = [
+  "scripts/asset-cdn.test.ts",
+  "scripts/docker-contract.test.ts",
+  "scripts/chrome-extension-release-surface.test.ts",
+  "scripts/electrobun-release-workflow-drift.test.ts",
+  "scripts/electrobun-test-workflow-drift.test.ts",
+  "scripts/whisper-build-script-drift.test.ts",
+  "scripts/release-check.test.ts",
+  "scripts/static-asset-manifest.test.ts",
+];
+
+function runCmd(command, args) {
   const result = spawnSync(command, args, {
     cwd: ROOT,
     stdio: "inherit",
@@ -20,28 +62,200 @@ function run(command, args) {
   }
 }
 
-run("bunx", [
-  "vitest",
-  "run",
-  "scripts/asset-cdn.test.ts",
-  "scripts/docker-contract.test.ts",
-  "scripts/chrome-extension-release-surface.test.ts",
-  "scripts/electrobun-release-workflow-drift.test.ts",
-  "scripts/electrobun-test-workflow-drift.test.ts",
-  "scripts/whisper-build-script-drift.test.ts",
-  "scripts/release-check.test.ts",
-  "scripts/static-asset-manifest.test.ts",
-]);
-run("bun", ["run", "test:startup:contract"]);
+// ── alice's release flow ────────────────────────────────────────────────
+runCmd("bunx", ["vitest", "run", ...aliceReleaseContractTests]);
+runCmd("bun", ["run", "test:startup:contract"]);
 
-run("bunx", ["tsdown"]);
+runCmd("bunx", ["tsdown"]);
 fs.mkdirSync(path.join(ROOT, "dist"), { recursive: true });
 fs.writeFileSync(
   path.join(ROOT, "dist", "package.json"),
   '{"type":"module"}\n',
 );
-run("node", ["--import", "tsx", "scripts/write-build-info.ts"]);
+runCmd("node", ["--import", "tsx", "scripts/write-build-info.ts"]);
 // Regenerate static asset manifest from the CI build output so hashes
 // match what release:check will validate.
-run("node", ["scripts/generate-static-asset-manifest.mjs"]);
-run("bun", ["run", "release:check"]);
+runCmd("node", ["scripts/generate-static-asset-manifest.mjs"]);
+runCmd("bun", ["run", "release:check"]);
+
+// ── upstream helpers exported for callers that want the new infra ──────
+// These exist so other scripts can opt into upstream's release-contract
+// utilities (mode-switching, eliza-worktree restore, electrobun compat-dir)
+// without duplicating the logic. Alice's release flow above does NOT use
+// them — alice's contract is the simpler list above.
+
+const rootReleaseContractTests = [
+  "scripts/electrobun-runtime-root-contract.test.ts",
+  "scripts/release-workflow-contract.test.mjs",
+];
+const appCoreReleaseContractTests = [
+  "eliza/packages/app-core/scripts/electrobun-release-workflow-drift.test.ts",
+  "eliza/packages/app-core/scripts/release-check.test.ts",
+  "eliza/packages/app-core/scripts/static-asset-manifest.test.ts",
+];
+export const releaseContractTests = [
+  ...rootReleaseContractTests,
+  ...appCoreReleaseContractTests,
+];
+
+export function hasLocalElizaAppCore(root = repoRoot) {
+  return fs.existsSync(path.join(root, "eliza", "packages", "app-core"));
+}
+
+export function run(command, args, cwd = repoRoot) {
+  const result = spawnSync(command, args, {
+    cwd,
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      NODE_NO_WARNINGS: process.env.NODE_NO_WARNINGS ?? "1",
+    },
+    shell: process.platform === "win32",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(
+      `Command failed with exit code ${result.status ?? 1}: ${command} ${args.join(" ")}`,
+    );
+  }
+}
+
+export function isElizaWorktreeClean(root = repoRoot) {
+  const result = spawnSync("git", ["-C", "eliza", "status", "--porcelain"], {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  return result.status === 0 && result.stdout.trim().length === 0;
+}
+
+export function listElizaUntrackedFiles(root = repoRoot) {
+  const result = spawnSync(
+    "git",
+    ["-C", "eliza", "ls-files", "--others", "--exclude-standard"],
+    {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  if (result.status !== 0 || !result.stdout.trim()) {
+    return [];
+  }
+
+  return result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+export function restoreGeneratedElizaChanges(
+  shouldRestore,
+  root = repoRoot,
+  initialUntrackedFiles = [],
+) {
+  if (!shouldRestore) {
+    return false;
+  }
+
+  let restored = false;
+  const diff = spawnSync("git", ["-C", "eliza", "diff", "--binary"], {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (diff.status === 0 && diff.stdout.trim().length > 0) {
+    const apply = spawnSync("git", ["-C", "eliza", "apply", "-R", "-"], {
+      cwd: root,
+      encoding: "utf8",
+      input: diff.stdout,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    if (apply.status !== 0) {
+      const stderr = apply.stderr.trim();
+      throw new Error(
+        stderr || "failed to restore generated eliza release-contract changes",
+      );
+    }
+    restored = true;
+  }
+
+  const initialUntracked = new Set(initialUntrackedFiles);
+  for (const relativePath of listElizaUntrackedFiles(root)) {
+    if (initialUntracked.has(relativePath)) {
+      continue;
+    }
+    fs.rmSync(path.join(root, "eliza", relativePath), {
+      force: true,
+      recursive: true,
+    });
+    restored = true;
+  }
+
+  return restored;
+}
+
+export function symlinkOrCopy(sourcePath, targetPath) {
+  const sourceStat = fs.lstatSync(sourcePath);
+  if (sourceStat.isDirectory()) {
+    fs.symlinkSync(
+      path.relative(path.dirname(targetPath), sourcePath),
+      targetPath,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    return;
+  }
+
+  fs.copyFileSync(sourcePath, targetPath);
+}
+
+export function assertReleaseContractTestsExist(
+  tests = releaseContractTests,
+  root = repoRoot,
+) {
+  const missing = tests.filter(
+    (testPath) => !fs.existsSync(path.join(root, testPath)),
+  );
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Release contract suite references missing test files:\n${missing
+        .map((testPath) => `- ${testPath}`)
+        .join("\n")}`,
+    );
+  }
+}
+
+export function loadTrackedLegacyElectrobunPaths(root = repoRoot) {
+  const result = spawnSync(
+    "git",
+    ["ls-files", "--", path.relative(root, legacyElectrobunDir)],
+    {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    },
+  );
+
+  if (result.status !== 0 || !result.stdout.trim()) {
+    return [];
+  }
+
+  return result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+export {
+  aliceReleaseContractTests,
+  appCoreRoot,
+  canonicalElectrobunDir,
+  legacyElectrobunDir,
+  repoRoot,
+};

--- a/scripts/setup-upstreams.mjs
+++ b/scripts/setup-upstreams.mjs
@@ -3,23 +3,29 @@
 import { spawn, spawnSync } from "node:child_process";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readdirSync,
   readFileSync,
   realpathSync,
   rmSync,
+  statSync,
   symlinkSync,
+  unlinkSync,
+  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   getElizaGitBranch,
   getElizaGitUrl,
+  getElizaosPackageSpecifier,
   isLocalElizaDisabled,
   isLocalElizaForced,
   LOCAL_UPSTREAM_FORCE_ENV_KEYS,
   LOCAL_UPSTREAM_SKIP_ENV_KEYS,
 } from "./lib/eliza-package-mode.mjs";
+import { readPackageJson } from "./lib/read-package-json.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -33,7 +39,8 @@ export const ELIZA_REQUIRED_FILES = ["package.json"];
 export const ELIZA_BUILD_STEPS = [
   {
     // Fresh CI checkouts do not track generated protobuf types for @elizaos/core.
-    // Build the package once so src/types/generated exists before root typecheck/tests.
+    // Also rebuild core declarations on every setup run so nested plugin builds
+    // never typecheck against stale dist/ output after the submodule changes.
     check: path.join(
       "packages",
       "core",
@@ -47,11 +54,28 @@ export const ELIZA_BUILD_STEPS = [
     cwd: path.join("packages", "core"),
     args: ["run", "build"],
     label: "@elizaos/core",
+    alwaysRun: true,
   },
   {
-    check: path.join("packages", "prompts", "dist", "typescript", "index.ts"),
+    check: path.join("packages", "shared", "dist", "index.js"),
+    cwd: path.join("packages", "shared"),
+    args: ["run", "build"],
+    label: "@elizaos/shared",
+  },
+  {
+    // @elizaos/prompts ships a node script package. Older versions exposed a
+    // `build:typescript` target that emitted dist/typescript/index.ts; the
+    // current source uses a single `build` script that regenerates the
+    // plugin-action spec + action docs. Detect the actual build outputs.
+    check: path.join(
+      "packages",
+      "prompts",
+      "specs",
+      "actions",
+      "plugins.generated.json",
+    ),
     cwd: path.join("packages", "prompts"),
-    args: ["run", "build:typescript"],
+    args: ["run", "build"],
     label: "@elizaos/prompts",
   },
   {
@@ -77,9 +101,42 @@ export const ELIZA_BUILD_STEPS = [
     label: "@elizaos/cloud-routing",
   },
 ];
+export const ELIZA_TYPESCRIPT_BUILD_DEPENDENCIES = [
+  "@types/node",
+  "@types/bun",
+  "bun-types",
+];
+const ELIZA_TYPESCRIPT_AMBIENT_DEPENDENCIES = new Set(
+  ELIZA_TYPESCRIPT_BUILD_DEPENDENCIES,
+);
+
+const ELIZA_INSTALL_RETRY_DELAY_MS = 3_000;
+
+const OPTIONAL_ELIZA_PLUGIN_PACKAGES = [
+  {
+    submodulePath: "plugins/plugin-sql",
+    workspaceEntry: "plugins/plugin-sql/typescript",
+    packageName: "@elizaos/plugin-sql",
+  },
+  {
+    submodulePath: "plugins/plugin-ollama",
+    workspaceEntry: "plugins/plugin-ollama/typescript",
+    packageName: "@elizaos/plugin-ollama",
+  },
+  {
+    submodulePath: "plugins/plugin-local-ai",
+    workspaceEntry: "plugins/plugin-local-ai/typescript",
+    packageName: "@elizaos/plugin-local-ai",
+  },
+];
+const CONDITIONAL_ELIZA_WORKSPACE_ENTRIES = [
+  ...OPTIONAL_ELIZA_PLUGIN_PACKAGES.map(({ workspaceEntry }) => workspaceEntry),
+  "cloud/packages/billing",
+];
 
 const PACKAGE_LINK_ROOTS = [
   ["node_modules"],
+  ["eliza", "node_modules"],
   ["apps", "app", "node_modules"],
 ];
 const MILADY_SINGLETON_DEPENDENCY_LINKS = [
@@ -91,6 +148,102 @@ const MILADY_SINGLETON_DEPENDENCY_LINKS = [
     packageDir: path.join("eliza", "packages", "app-core"),
     dependencies: ["drizzle-orm"],
   },
+];
+const ELIZA_AGENT_SKILLS_PLUGIN_BUILD = {
+  label: "@elizaos/plugin-agent-skills",
+  cwd: path.join("eliza", "plugins", "plugin-agent-skills", "typescript"),
+  manifest: path.join(
+    "eliza",
+    "plugins",
+    "plugin-agent-skills",
+    "typescript",
+    "package.json",
+  ),
+  artifact: path.join(
+    "eliza",
+    "plugins",
+    "plugin-agent-skills",
+    "typescript",
+    "dist",
+    "index.js",
+  ),
+  args: [
+    "build",
+    "./src/index.ts",
+    "--outdir",
+    "./dist",
+    "--target",
+    "node",
+    "--format",
+    "esm",
+    "--sourcemap=linked",
+    "--external",
+    "node:*",
+    "--external",
+    "@elizaos/core",
+    "--external",
+    "fflate",
+  ],
+};
+const ELIZA_TELEGRAM_PLUGIN_BUILD = {
+  label: "@elizaos/plugin-telegram",
+  cwd: path.join("eliza", "plugins", "plugin-telegram"),
+  manifest: path.join("eliza", "plugins", "plugin-telegram", "package.json"),
+  artifact: path.join(
+    "eliza",
+    "plugins",
+    "plugin-telegram",
+    "dist",
+    "account-auth-service.js",
+  ),
+  args: ["run", "build"],
+};
+const ELIZA_EDGE_TTS_PLUGIN_BUILD = {
+  label: "@elizaos/plugin-edge-tts",
+  cwd: path.join("eliza", "plugins", "plugin-edge-tts", "typescript"),
+  manifest: path.join(
+    "eliza",
+    "plugins",
+    "plugin-edge-tts",
+    "typescript",
+    "package.json",
+  ),
+  artifact: path.join(
+    "eliza",
+    "plugins",
+    "plugin-edge-tts",
+    "typescript",
+    "dist",
+    "node",
+    "index.node.js",
+  ),
+  args: ["run", "build"],
+};
+const ELIZA_LOCAL_EMBEDDING_PLUGIN_BUILD = {
+  label: "@elizaos/plugin-local-embedding",
+  cwd: path.join("eliza", "plugins", "plugin-local-embedding", "typescript"),
+  manifest: path.join(
+    "eliza",
+    "plugins",
+    "plugin-local-embedding",
+    "typescript",
+    "package.json",
+  ),
+  artifact: path.join(
+    "eliza",
+    "plugins",
+    "plugin-local-embedding",
+    "typescript",
+    "dist",
+    "index.js",
+  ),
+  args: ["run", "build"],
+};
+const ELIZA_REQUIRED_PLUGIN_BUILDS = [
+  ELIZA_AGENT_SKILLS_PLUGIN_BUILD,
+  ELIZA_TELEGRAM_PLUGIN_BUILD,
+  ELIZA_EDGE_TTS_PLUGIN_BUILD,
+  ELIZA_LOCAL_EMBEDDING_PLUGIN_BUILD,
 ];
 
 function toDisplayPath(targetPath) {
@@ -142,14 +295,12 @@ function commandExists(command) {
   return result.status === 0;
 }
 
-function readPackageJson(packageDir) {
-  try {
-    return JSON.parse(
-      readFileSync(path.join(packageDir, "package.json"), "utf8"),
-    );
-  } catch {
-    return null;
-  }
+function writePackageJson(packagePath, raw, nextPackageJson) {
+  const indent = raw.match(/^(\s+)"/m)?.[1] ?? "  ";
+  writeFileSync(
+    packagePath,
+    `${JSON.stringify(nextPackageJson, null, indent)}\n`,
+  );
 }
 
 function uniqueLinks(links) {
@@ -158,6 +309,328 @@ function uniqueLinks(links) {
     deduped.set(link.linkPath, link);
   }
   return [...deduped.values()];
+}
+
+function uniquePaths(paths) {
+  return [...new Set(paths.map((targetPath) => path.resolve(targetPath)))];
+}
+
+function walkWorkspaceFiles(dirPath, visit) {
+  let entries;
+  try {
+    entries = readdirSync(dirPath, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const entryPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      if (
+        [
+          ".git",
+          "android",
+          "build",
+          "dist",
+          "ios",
+          "node_modules",
+          "out",
+          "target",
+        ].includes(entry.name)
+      ) {
+        continue;
+      }
+      walkWorkspaceFiles(entryPath, visit);
+      continue;
+    }
+
+    visit(entryPath);
+  }
+}
+
+function collectPackageJsonPaths(rootDir) {
+  const packageJsonPaths = [path.join(rootDir, "package.json")];
+
+  for (const rootName of ["packages", "plugins", "apps"]) {
+    walkWorkspaceFiles(path.join(rootDir, rootName), (entryPath) => {
+      if (path.basename(entryPath) === "package.json") {
+        packageJsonPaths.push(entryPath);
+      }
+    });
+  }
+
+  return packageJsonPaths;
+}
+
+function getMissingOptionalElizaPlugins(
+  elizaRoot,
+  { pathExists = existsSync } = {},
+) {
+  return OPTIONAL_ELIZA_PLUGIN_PACKAGES.filter(({ workspaceEntry }) => {
+    return !pathExists(path.join(elizaRoot, workspaceEntry, "package.json"));
+  });
+}
+
+function getPresentOptionalElizaPlugins(
+  elizaRoot,
+  { pathExists = existsSync } = {},
+) {
+  return OPTIONAL_ELIZA_PLUGIN_PACKAGES.filter(
+    ({ workspaceEntry, submodulePath }) => {
+      if (!pathExists(path.join(elizaRoot, workspaceEntry, "package.json"))) {
+        return false;
+      }
+      // After eliza's monorepo collapse, plugins/<name>/package.json is the
+      // canonical workspace and plugins/<name>/typescript/ is a legacy leftover
+      // that declares the same package name. Adding both makes bun fail with
+      // "Workspace name already exists". Skip the legacy entry when the flat
+      // layout is present.
+      if (pathExists(path.join(elizaRoot, submodulePath, "package.json"))) {
+        return false;
+      }
+      return true;
+    },
+  );
+}
+
+export function getTemporaryElizaWorkspaceEntries(
+  elizaRoot,
+  { pathExists = existsSync } = {},
+) {
+  const optionalPluginWorkspaceEntries = getPresentOptionalElizaPlugins(
+    elizaRoot,
+    { pathExists },
+  ).map(({ workspaceEntry }) => workspaceEntry);
+
+  const cloudBillingWorkspace = "cloud/packages/billing";
+  const cloudBillingPackageJson = path.join(
+    elizaRoot,
+    cloudBillingWorkspace,
+    "package.json",
+  );
+  const cloudWorkspaceReady =
+    pathExists(cloudBillingPackageJson) &&
+    pathExists(
+      path.join(elizaRoot, "cloud", ".external", "steward", "packages"),
+    );
+  const cloudBillingWorkspaceEntry =
+    cloudWorkspaceReady &&
+    !optionalPluginWorkspaceEntries.includes(cloudBillingWorkspace)
+      ? [cloudBillingWorkspace]
+      : [];
+
+  return [...optionalPluginWorkspaceEntries, ...cloudBillingWorkspaceEntry];
+}
+
+export function getMissingConditionalElizaWorkspaceEntries(
+  elizaRoot,
+  workspaces,
+  { pathExists = existsSync } = {},
+) {
+  if (!Array.isArray(workspaces)) {
+    return [];
+  }
+
+  return CONDITIONAL_ELIZA_WORKSPACE_ENTRIES.filter((workspaceEntry) => {
+    if (!workspaces.includes(workspaceEntry)) {
+      return false;
+    }
+
+    return !pathExists(path.join(elizaRoot, workspaceEntry, "package.json"));
+  });
+}
+
+export function stripMissingConditionalElizaWorkspaces(
+  elizaRoot,
+  { pathExists = existsSync } = {},
+) {
+  const packageJsonPath = path.join(elizaRoot, "package.json");
+  if (!pathExists(packageJsonPath)) {
+    return [];
+  }
+
+  const raw = readFileSync(packageJsonPath, "utf8");
+  let pkg;
+  try {
+    pkg = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+
+  if (!Array.isArray(pkg.workspaces)) {
+    return [];
+  }
+
+  const missingWorkspaceEntries = getMissingConditionalElizaWorkspaceEntries(
+    elizaRoot,
+    pkg.workspaces,
+    { pathExists },
+  );
+  if (missingWorkspaceEntries.length === 0) {
+    return [];
+  }
+
+  pkg.workspaces = pkg.workspaces.filter(
+    (workspaceEntry) => !missingWorkspaceEntries.includes(workspaceEntry),
+  );
+  writePackageJson(packageJsonPath, raw, pkg);
+  return missingWorkspaceEntries;
+}
+
+async function withTemporaryOptionalElizaPluginWorkspaces(elizaRoot, callback) {
+  const packageJsonPath = path.join(elizaRoot, "package.json");
+  const raw = readFileSync(packageJsonPath, "utf8");
+  let pkg;
+  try {
+    pkg = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `Failed to parse ${packageJsonPath} while staging optional eliza plugin workspaces`,
+      { cause: error },
+    );
+  }
+
+  if (!Array.isArray(pkg.workspaces)) {
+    return callback();
+  }
+
+  const additionalWorkspaceEntries = getTemporaryElizaWorkspaceEntries(
+    elizaRoot,
+  ).filter((workspaceEntry) => !pkg.workspaces.includes(workspaceEntry));
+  const removedWorkspaceEntries = getMissingConditionalElizaWorkspaceEntries(
+    elizaRoot,
+    pkg.workspaces,
+  );
+
+  if (
+    additionalWorkspaceEntries.length === 0 &&
+    removedWorkspaceEntries.length === 0
+  ) {
+    return callback();
+  }
+
+  pkg.workspaces = pkg.workspaces.filter(
+    (workspaceEntry) => !removedWorkspaceEntries.includes(workspaceEntry),
+  );
+  pkg.workspaces = [...pkg.workspaces, ...additionalWorkspaceEntries];
+  writePackageJson(packageJsonPath, raw, pkg);
+  if (additionalWorkspaceEntries.length > 0) {
+    console.log(
+      `[setup-upstreams] Temporarily enabling eliza workspace entries (${additionalWorkspaceEntries.join(", ")})`,
+    );
+  }
+  if (removedWorkspaceEntries.length > 0) {
+    console.log(
+      `[setup-upstreams] Temporarily disabling missing eliza workspace entries (${removedWorkspaceEntries.join(", ")})`,
+    );
+  }
+
+  try {
+    return await callback();
+  } finally {
+    writeFileSync(packageJsonPath, raw);
+  }
+}
+
+async function maybeInitOptionalElizaPluginSubmodules(elizaRoot) {
+  const missing = getMissingOptionalElizaPlugins(elizaRoot);
+  if (missing.length === 0 || !existsSync(path.join(elizaRoot, ".git"))) {
+    return missing;
+  }
+
+  try {
+    await runCommand(
+      "git",
+      [
+        "submodule",
+        "update",
+        "--init",
+        "--recursive",
+        ...missing.map(({ submodulePath }) => submodulePath),
+      ],
+      {
+        cwd: elizaRoot,
+        label: "git submodule update (optional eliza plugins)",
+      },
+    );
+  } catch {
+    // If these optional submodules are unavailable in CI, we fall back to
+    // published packages below instead of hard-failing the whole setup.
+  }
+
+  return getMissingOptionalElizaPlugins(elizaRoot);
+}
+
+function shouldApplyOptionalElizaPluginFallback(env = process.env) {
+  return env.CI === "true" && isLocalElizaDisabled(env);
+}
+
+function applyOptionalElizaPluginFallback(elizaRoot, missingPlugins) {
+  if (missingPlugins.length === 0) {
+    return 0;
+  }
+
+  const missingWorkspaceEntries = new Set(
+    missingPlugins.map(({ workspaceEntry }) => workspaceEntry),
+  );
+  const missingPackageNames = new Set(
+    missingPlugins.map(({ packageName }) => packageName),
+  );
+  let changedFiles = 0;
+
+  for (const packageJsonPath of collectPackageJsonPaths(elizaRoot)) {
+    const raw = readFileSync(packageJsonPath, "utf8");
+    let pkg;
+    try {
+      pkg = JSON.parse(raw);
+    } catch (error) {
+      throw new Error(
+        `Failed to parse ${packageJsonPath} while applying optional eliza plugin fallback`,
+        { cause: error },
+      );
+    }
+
+    let changed = false;
+
+    if (
+      packageJsonPath === path.join(elizaRoot, "package.json") &&
+      Array.isArray(pkg.workspaces)
+    ) {
+      const nextWorkspaces = pkg.workspaces.filter(
+        (entry) => !missingWorkspaceEntries.has(entry),
+      );
+      if (nextWorkspaces.length !== pkg.workspaces.length) {
+        pkg.workspaces = nextWorkspaces;
+        changed = true;
+      }
+    }
+
+    for (const section of [
+      "dependencies",
+      "devDependencies",
+      "optionalDependencies",
+      "peerDependencies",
+    ]) {
+      if (!pkg[section] || typeof pkg[section] !== "object") {
+        continue;
+      }
+      for (const packageName of missingPackageNames) {
+        if (pkg[section][packageName] === "workspace:*") {
+          pkg[section][packageName] = getElizaosPackageSpecifier();
+          changed = true;
+        }
+      }
+    }
+
+    if (!changed) {
+      continue;
+    }
+
+    writePackageJson(packageJsonPath, raw, pkg);
+    changedFiles += 1;
+  }
+
+  return changedFiles;
 }
 
 function getForceEnvKey(env = process.env) {
@@ -169,7 +642,7 @@ export function getRepoElizaRoot(repoRoot = DEFAULT_REPO_ROOT) {
 }
 
 export function getRepoPluginsRoot(repoRoot = DEFAULT_REPO_ROOT) {
-  return path.resolve(repoRoot, "plugins");
+  return path.resolve(repoRoot, "eliza", "plugins");
 }
 
 export function getElizaWorkspaceSkipReason(
@@ -222,7 +695,29 @@ export function hasInstalledElizaDependencies(
   );
 }
 
-function getPackageLinkEntries(repoRoot, packageName, targetPath) {
+function getPackageLinkRootPaths(
+  repoRoot,
+  { elizaRoot = getRepoElizaRoot(repoRoot) } = {},
+) {
+  const roots = PACKAGE_LINK_ROOTS.map((segments) =>
+    path.join(repoRoot, ...segments),
+  );
+  for (const packageDir of discoverElizaAppPackageDirs(elizaRoot)) {
+    const packageNodeModules = path.join(packageDir, "node_modules");
+    if (existsSync(packageNodeModules)) {
+      roots.push(packageNodeModules);
+    }
+  }
+
+  return uniquePaths(roots);
+}
+
+function getPackageLinkEntries(
+  repoRoot,
+  packageName,
+  targetPath,
+  linkRootPaths = getPackageLinkRootPaths(repoRoot),
+) {
   if (typeof packageName !== "string" || packageName.length === 0) {
     return [];
   }
@@ -238,10 +733,48 @@ function getPackageLinkEntries(repoRoot, packageName, targetPath) {
     return [];
   }
 
-  return PACKAGE_LINK_ROOTS.map((segments) => ({
-    linkPath: path.join(repoRoot, ...segments, ...packageSegments),
+  return linkRootPaths.map((rootPath) => ({
+    linkPath: path.join(rootPath, ...packageSegments),
     targetPath,
   }));
+}
+
+function discoverElizaPackageDirsForParents(elizaRoot, parentDirs) {
+  const packageDirs = [];
+  for (const parentDir of parentDirs) {
+    const searchRoot = path.join(elizaRoot, parentDir);
+    if (!existsSync(searchRoot)) {
+      continue;
+    }
+
+    let entries = [];
+    try {
+      entries = readdirSync(searchRoot, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) {
+        continue;
+      }
+      const packageDir = path.join(searchRoot, entry.name);
+      const packageJson = readPackageJson(packageDir);
+      const packageName = packageJson?.name;
+      if (
+        packageName?.startsWith("@elizaos/") &&
+        !packageName.endsWith("-root")
+      ) {
+        packageDirs.push(packageDir);
+      }
+    }
+  }
+
+  return packageDirs;
+}
+
+function discoverElizaAppPackageDirs(elizaRoot) {
+  return discoverElizaPackageDirsForParents(elizaRoot, ["apps"]);
 }
 
 function discoverElizaPackageDirs(elizaRoot) {
@@ -318,12 +851,18 @@ function discoverPluginPackageDirs(pluginsRoot) {
 export function getElizaPackageLinks(
   repoRoot = DEFAULT_REPO_ROOT,
   elizaRoot = getRepoElizaRoot(repoRoot),
+  linkRootPaths = getPackageLinkRootPaths(repoRoot, { elizaRoot }),
 ) {
   const links = [];
   for (const packageDir of discoverElizaPackageDirs(elizaRoot)) {
     const packageJson = readPackageJson(packageDir);
     links.push(
-      ...getPackageLinkEntries(repoRoot, packageJson?.name, packageDir),
+      ...getPackageLinkEntries(
+        repoRoot,
+        packageJson?.name,
+        packageDir,
+        linkRootPaths,
+      ),
     );
   }
   return uniqueLinks(links);
@@ -332,12 +871,18 @@ export function getElizaPackageLinks(
 export function getPluginPackageLinks(
   repoRoot = DEFAULT_REPO_ROOT,
   pluginsRoot = getRepoPluginsRoot(repoRoot),
+  linkRootPaths = getPackageLinkRootPaths(repoRoot, { pluginsRoot }),
 ) {
   const links = [];
   for (const packageDir of discoverPluginPackageDirs(pluginsRoot)) {
     const packageJson = readPackageJson(packageDir);
     links.push(
-      ...getPackageLinkEntries(repoRoot, packageJson?.name, packageDir),
+      ...getPackageLinkEntries(
+        repoRoot,
+        packageJson?.name,
+        packageDir,
+        linkRootPaths,
+      ),
     );
   }
   return uniqueLinks(links);
@@ -351,16 +896,99 @@ export function getUpstreamPackageLinks(
   } = {},
 ) {
   const combinedByTarget = new Map();
+  const linkRootPaths = getPackageLinkRootPaths(repoRoot, {
+    elizaRoot,
+    pluginsRoot,
+  });
 
-  for (const link of getElizaPackageLinks(repoRoot, elizaRoot)) {
+  for (const link of getElizaPackageLinks(repoRoot, elizaRoot, linkRootPaths)) {
     combinedByTarget.set(link.linkPath, link);
   }
 
-  for (const link of getPluginPackageLinks(repoRoot, pluginsRoot)) {
+  for (const link of getPluginPackageLinks(
+    repoRoot,
+    pluginsRoot,
+    linkRootPaths,
+  )) {
     combinedByTarget.set(link.linkPath, link);
   }
 
   return [...combinedByTarget.values()];
+}
+
+function isBuildArtifactStale(
+  manifestPath,
+  artifactPath,
+  { pathExists = existsSync, stat = statSync } = {},
+) {
+  if (!pathExists(artifactPath)) {
+    return true;
+  }
+
+  try {
+    return stat(manifestPath).mtimeMs > stat(artifactPath).mtimeMs;
+  } catch {
+    return true;
+  }
+}
+
+async function ensureElizaPluginBuild(
+  buildConfig,
+  repoRoot = DEFAULT_REPO_ROOT,
+  {
+    pathExists = existsSync,
+    stat = statSync,
+    runCommandImpl = runCommand,
+    log = console.log,
+  } = {},
+) {
+  const manifestPath = path.join(repoRoot, buildConfig.manifest);
+  if (!pathExists(manifestPath)) {
+    return false;
+  }
+
+  const artifactPath = path.join(repoRoot, buildConfig.artifact);
+  const stale = isBuildArtifactStale(manifestPath, artifactPath, {
+    pathExists,
+    stat,
+  });
+  if (!stale) {
+    return false;
+  }
+
+  const reason = !pathExists(artifactPath)
+    ? `${buildConfig.artifact} is missing`
+    : `${buildConfig.artifact} is older than ${buildConfig.manifest}`;
+  log(`[setup-upstreams] Building ${buildConfig.label} because ${reason}`);
+  await runCommandImpl("bun", buildConfig.args, {
+    cwd: path.join(repoRoot, buildConfig.cwd),
+    label: `bun ${buildConfig.args.join(" ")} (${buildConfig.label})`,
+  });
+  return true;
+}
+
+export async function ensureElizaAgentSkillsPluginBuild(
+  repoRoot = DEFAULT_REPO_ROOT,
+  options = {},
+) {
+  return ensureElizaPluginBuild(
+    ELIZA_AGENT_SKILLS_PLUGIN_BUILD,
+    repoRoot,
+    options,
+  );
+}
+
+export async function ensureRequiredElizaPluginBuilds(
+  repoRoot = DEFAULT_REPO_ROOT,
+  options = {},
+) {
+  let builtAny = false;
+  for (const buildConfig of ELIZA_REQUIRED_PLUGIN_BUILDS) {
+    builtAny =
+      (await ensureElizaPluginBuild(buildConfig, repoRoot, options)) ||
+      builtAny;
+  }
+  return builtAny;
 }
 
 export function isPackageLinkCurrent(linkPath, targetPath) {
@@ -380,10 +1008,17 @@ function createLink(linkPath, targetPath, kind = "dir") {
     return false;
   }
 
-  rmSync(linkPath, {
-    force: true,
-    recursive: true,
-  });
+  try {
+    const existingLinkStats = lstatSync(linkPath);
+    if (existingLinkStats.isSymbolicLink()) {
+      unlinkSync(linkPath);
+    } else {
+      rmSync(linkPath, {
+        force: true,
+        recursive: existingLinkStats.isDirectory(),
+      });
+    }
+  } catch {}
 
   mkdirSync(path.dirname(linkPath), { recursive: true });
 
@@ -407,7 +1042,31 @@ export function createPackageLink(linkPath, targetPath) {
 }
 
 function createBinLink(linkPath, targetPath) {
-  return createLink(linkPath, targetPath, "file");
+  const linked = createLink(linkPath, targetPath, "file");
+
+  if (process.platform !== "win32") {
+    return linked;
+  }
+
+  const cmdPath = `${linkPath}.cmd`;
+  const cmdContents = `@ECHO off\r\nnode "${targetPath}" %*\r\n`;
+  let wroteCmdShim = false;
+  try {
+    const currentContents = existsSync(cmdPath)
+      ? readFileSync(cmdPath, "utf8")
+      : null;
+    if (currentContents !== cmdContents) {
+      mkdirSync(path.dirname(cmdPath), { recursive: true });
+      writeFileSync(cmdPath, cmdContents);
+      wroteCmdShim = true;
+    }
+  } catch {
+    mkdirSync(path.dirname(cmdPath), { recursive: true });
+    writeFileSync(cmdPath, cmdContents);
+    wroteCmdShim = true;
+  }
+
+  return linked || wroteCmdShim;
 }
 
 function getPackageBinEntries(packageJson) {
@@ -467,31 +1126,33 @@ function ensurePackageBinLinks(
   return linkedBins;
 }
 
-function findInstalledPackageDir(
+export function findInstalledPackageDir(
   repoRoot,
   packageName,
   preferredVersion,
   localTargetPath = null,
+  { searchRoots = [repoRoot] } = {},
 ) {
-  const directPackagePath = path.join(
-    repoRoot,
-    "node_modules",
-    ...packageName.split("/"),
-  );
-  try {
-    const resolved = realpathSync(directPackagePath);
-    const resolvedLocalTarget =
-      localTargetPath && existsSync(localTargetPath)
-        ? realpathSync(localTargetPath)
-        : null;
-    if (existsSync(resolved) && resolved !== resolvedLocalTarget) {
-      return directPackagePath;
-    }
-  } catch {}
+  const resolvedLocalTarget =
+    localTargetPath && existsSync(localTargetPath)
+      ? realpathSync(localTargetPath)
+      : null;
+  const uniqueSearchRoots = [
+    ...new Set(searchRoots.map((root) => path.resolve(root))),
+  ];
 
-  const bunCacheRoot = path.join(repoRoot, "node_modules", ".bun");
-  if (!existsSync(bunCacheRoot)) {
-    return null;
+  for (const searchRoot of uniqueSearchRoots) {
+    const directPackagePath = path.join(
+      searchRoot,
+      "node_modules",
+      ...packageName.split("/"),
+    );
+    try {
+      const resolved = realpathSync(directPackagePath);
+      if (existsSync(resolved) && resolved !== resolvedLocalTarget) {
+        return directPackagePath;
+      }
+    } catch {}
   }
 
   const packagePrefix = `${packageName.replace("/", "+")}@`;
@@ -499,34 +1160,46 @@ function findInstalledPackageDir(
     preferredVersion === undefined
       ? null
       : `${packageName.replace("/", "+")}@${preferredVersion}+`;
-  const matches = [];
 
-  for (const entry of readdirSync(bunCacheRoot, { withFileTypes: true })) {
-    if (!entry.isDirectory() || !entry.name.startsWith(packagePrefix)) {
+  for (const searchRoot of uniqueSearchRoots) {
+    const bunCacheRoot = path.join(searchRoot, "node_modules", ".bun");
+    if (!existsSync(bunCacheRoot)) {
       continue;
     }
 
-    const candidate = path.join(
-      bunCacheRoot,
-      entry.name,
-      "node_modules",
-      ...packageName.split("/"),
+    const matches = [];
+
+    for (const entry of readdirSync(bunCacheRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory() || !entry.name.startsWith(packagePrefix)) {
+        continue;
+      }
+
+      const candidate = path.join(
+        bunCacheRoot,
+        entry.name,
+        "node_modules",
+        ...packageName.split("/"),
+      );
+      if (!existsSync(candidate)) {
+        continue;
+      }
+
+      matches.push({
+        candidate,
+        preferred:
+          preferredPrefix !== null && entry.name.startsWith(preferredPrefix),
+      });
+    }
+
+    matches.sort(
+      (left, right) => Number(right.preferred) - Number(left.preferred),
     );
-    if (!existsSync(candidate)) {
-      continue;
+    if (matches[0]?.candidate) {
+      return matches[0].candidate;
     }
-
-    matches.push({
-      candidate,
-      preferred:
-        preferredPrefix !== null && entry.name.startsWith(preferredPrefix),
-    });
   }
 
-  matches.sort(
-    (left, right) => Number(right.preferred) - Number(left.preferred),
-  );
-  return matches[0]?.candidate ?? null;
+  return null;
 }
 
 export function ensurePluginDependencyLinks(
@@ -534,6 +1207,7 @@ export function ensurePluginDependencyLinks(
   pluginsRoot = getRepoPluginsRoot(repoRoot),
 ) {
   let linkedDependencies = 0;
+  const searchRoots = [repoRoot, getRepoElizaRoot(repoRoot)];
 
   for (const packageDir of discoverPluginPackageDirs(pluginsRoot)) {
     const packageJson = readPackageJson(packageDir);
@@ -562,6 +1236,9 @@ export function ensurePluginDependencyLinks(
       const installedDependencyDir = findInstalledPackageDir(
         repoRoot,
         dependencyName,
+        undefined,
+        null,
+        { searchRoots },
       );
       if (!installedDependencyDir) {
         continue;
@@ -768,41 +1445,290 @@ async function ensureRepoLocalEliza(repoRoot) {
   return elizaRoot;
 }
 
+export function ensureElizaTypescriptDependencyLinks(
+  elizaRoot,
+  {
+    repoRoot = path.dirname(elizaRoot),
+    // Do not link @noble/hashes by default: the Milady root often resolves v1
+    // (ethers/viem), while @elizaos/core requires v2 entrypoints (sha2.js, legacy.js).
+    dependencies = ELIZA_TYPESCRIPT_BUILD_DEPENDENCIES,
+  } = {},
+) {
+  const packageDir = path.join(elizaRoot, "packages", "core");
+  let linkedDependencies = 0;
+
+  for (const dependency of dependencies) {
+    const target = findInstalledPackageDir(
+      repoRoot,
+      dependency,
+      undefined,
+      null,
+      {
+        searchRoots: [repoRoot, elizaRoot],
+      },
+    );
+    if (!target) {
+      continue;
+    }
+
+    const linkRoots = [packageDir];
+    if (ELIZA_TYPESCRIPT_AMBIENT_DEPENDENCIES.has(dependency)) {
+      linkRoots.push(elizaRoot);
+    }
+
+    for (const linkRoot of linkRoots) {
+      const linkPath = path.join(
+        linkRoot,
+        "node_modules",
+        ...dependency.split("/"),
+      );
+      if (
+        existsSync(linkPath) &&
+        existsSync(target) &&
+        realpathSync(linkPath) === realpathSync(target)
+      ) {
+        continue;
+      }
+      if (createPackageLink(linkPath, target)) {
+        linkedDependencies += 1;
+      }
+    }
+  }
+
+  if (linkedDependencies > 0) {
+    console.log(
+      "[setup-upstreams] Linked " +
+        linkedDependencies +
+        " @elizaos/core build " +
+        (linkedDependencies === 1 ? "dependency" : "dependencies") +
+        " into eliza/packages/core",
+    );
+  }
+
+  return linkedDependencies;
+}
+
 async function ensureElizaDependencies(elizaRoot) {
   if (hasInstalledElizaDependencies(elizaRoot)) {
+    await bootstrapBundledBunInstall(elizaRoot);
+    ensureElizaTypescriptDependencyLinks(elizaRoot);
     return;
+  }
+
+  const missingOptionalPlugins =
+    await maybeInitOptionalElizaPluginSubmodules(elizaRoot);
+  if (
+    missingOptionalPlugins.length > 0 &&
+    shouldApplyOptionalElizaPluginFallback()
+  ) {
+    const changedFiles = applyOptionalElizaPluginFallback(
+      elizaRoot,
+      missingOptionalPlugins,
+    );
+    console.log(
+      `[setup-upstreams] Falling back to published optional eliza plugins for CI (${missingOptionalPlugins
+        .map(({ packageName }) => packageName)
+        .join(", ")}); updated ${changedFiles} package.json file${
+        changedFiles === 1 ? "" : "s"
+      }.`,
+    );
   }
 
   console.log(
     `[setup-upstreams] Installing eliza workspace dependencies in ${toDisplayPath(elizaRoot)}`,
   );
-  await runCommand("bun", ["install"], {
-    cwd: elizaRoot,
-    label: "bun install (eliza)",
+  await withTemporaryOptionalElizaPluginWorkspaces(elizaRoot, async () => {
+    await runElizaInstallWithRetry(elizaRoot);
+    await bootstrapBundledBunInstall(elizaRoot);
   });
+  ensureElizaTypescriptDependencyLinks(elizaRoot);
 }
 
-async function ensureElizaBuildOutputs(elizaRoot) {
+export function getElizaInstallArgs(env = process.env) {
+  return env.MILADY_NO_VISION_DEPS === "1"
+    ? ["install", "--ignore-scripts"]
+    : ["install"];
+}
+
+export async function runElizaInstallWithRetry(
+  elizaRoot,
+  {
+    env = process.env,
+    retryDelayMs = ELIZA_INSTALL_RETRY_DELAY_MS,
+    runCommandImpl = runCommand,
+    wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  } = {},
+) {
+  const installArgs = getElizaInstallArgs(env);
+
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    try {
+      await runCommandImpl("bun", installArgs, {
+        cwd: elizaRoot,
+        label: "bun install (eliza)",
+      });
+      return;
+    } catch (error) {
+      if (attempt >= 2) {
+        throw error;
+      }
+
+      console.warn(
+        `[setup-upstreams] bun install (eliza) failed on attempt ${attempt}; retrying once after ${retryDelayMs}ms to recover from transient dependency fetch errors`,
+      );
+      await wait(retryDelayMs);
+    }
+  }
+}
+
+export async function bootstrapBundledBunInstall(
+  workspaceRoot,
+  {
+    env = process.env,
+    pathExists = existsSync,
+    runCommandImpl = runCommand,
+  } = {},
+) {
+  if (env.MILADY_NO_VISION_DEPS !== "1") {
+    return false;
+  }
+
+  const bunExecutableRelativePath = path.join(
+    "node_modules",
+    "bun",
+    "bin",
+    "bun.exe",
+  );
+  const bunExecutablePath = path.join(workspaceRoot, bunExecutableRelativePath);
+  if (pathExists(bunExecutablePath)) {
+    try {
+      await runCommandImpl(bunExecutableRelativePath, ["--version"], {
+        cwd: workspaceRoot,
+        label: `${bunExecutableRelativePath} --version (eliza bun bootstrap probe)`,
+      });
+      return false;
+    } catch {}
+  }
+
+  const bunInstallScriptRelativePath = path.join(
+    "node_modules",
+    "bun",
+    "install.js",
+  );
+  const bunInstallScriptPath = path.join(
+    workspaceRoot,
+    bunInstallScriptRelativePath,
+  );
+
+  if (!pathExists(bunInstallScriptPath)) {
+    throw new Error(
+      `[setup-upstreams] Expected ${bunInstallScriptRelativePath} after bun install --ignore-scripts in ${toDisplayPath(
+        workspaceRoot,
+      )}, but it was missing.`,
+    );
+  }
+
+  await runCommandImpl("node", [bunInstallScriptRelativePath], {
+    cwd: workspaceRoot,
+    label: "node node_modules/bun/install.js (eliza bun bootstrap)",
+  });
+  return true;
+}
+
+async function ensureElizaGeneratedKeywordData(
+  elizaRoot,
+  {
+    pathExists = existsSync,
+    runCommandImpl = runCommand,
+    log = console.log,
+  } = {},
+) {
+  const generatedKeywordDataPath = path.join(
+    elizaRoot,
+    "packages",
+    "typescript",
+    "src",
+    "i18n",
+    "generated",
+    "validation-keyword-data.ts",
+  );
+
+  if (pathExists(generatedKeywordDataPath)) {
+    return;
+  }
+
+  log("[setup-upstreams] Generating eliza i18n keyword data");
+  await runCommandImpl(
+    "node",
+    ["packages/shared/scripts/generate-keywords.mjs", "--target", "ts"],
+    {
+      cwd: elizaRoot,
+      label: "node packages/shared/scripts/generate-keywords.mjs --target ts",
+    },
+  );
+}
+
+export async function ensureElizaBuildOutputs(
+  elizaRoot,
+  {
+    pathExists = existsSync,
+    runCommandImpl = runCommand,
+    log = console.log,
+  } = {},
+) {
+  await ensureElizaGeneratedKeywordData(elizaRoot, {
+    pathExists,
+    runCommandImpl,
+    log,
+  });
+
   for (const step of ELIZA_BUILD_STEPS) {
-    if (existsSync(path.join(elizaRoot, step.check))) {
+    if (!step.alwaysRun && pathExists(path.join(elizaRoot, step.check))) {
       continue;
     }
 
-    console.log(`[setup-upstreams] Building ${step.label}`);
-    await runCommand("bun", step.args, {
+    log(`[setup-upstreams] Building ${step.label}`);
+    await runCommandImpl("bun", step.args, {
       cwd: path.join(elizaRoot, step.cwd),
       label: `bun ${step.args.join(" ")} (${step.label})`,
     });
   }
 }
 
+/**
+ * Ensure plugin-anthropic's tsconfig.build.json explicitly loads Bun types.
+ *
+ * When tsc runs `bun run build` for plugin-anthropic on fresh CI checkouts,
+ * it reports TS2868 "Cannot find name 'Bun'" on init.ts / utils/claude-cli.ts
+ * because the build config extends tsconfig.json but does not carry the
+ * `compilerOptions.types` array forward deterministically. We force the
+ * setting in-place so every CI/dev checkout sees a build config that
+ * resolves Bun globals without relying on extends inheritance.
+ *
+ * Idempotent: only writes when the desired types list is not already present.
+ */
 export async function ensurePluginBuildOutputs(
   pluginsRoot,
-  { pathExists = existsSync, runCommandImpl = runCommand } = {},
+  {
+    pathExists = existsSync,
+    runCommandImpl = runCommand,
+    requiredPackageNames = new Set(),
+  } = {},
 ) {
-  for (const packageDir of discoverPluginPackageDirs(pluginsRoot)) {
+  const packageDirs = discoverPluginPackageDirs(pluginsRoot).sort(
+    (left, right) => {
+      const leftName = readPackageJson(left)?.name;
+      const rightName = readPackageJson(right)?.name;
+      const leftRequired = requiredPackageNames.has(leftName) ? 0 : 1;
+      const rightRequired = requiredPackageNames.has(rightName) ? 0 : 1;
+      return leftRequired - rightRequired || left.localeCompare(right);
+    },
+  );
+
+  for (const packageDir of packageDirs) {
     const packageJson = readPackageJson(packageDir);
-    if (!packageJson?.name?.startsWith("@elizaos/")) {
+    const packageName = packageJson?.name;
+    if (!packageName?.startsWith("@elizaos/")) {
       continue;
     }
 
@@ -812,11 +1738,20 @@ export async function ensurePluginBuildOutputs(
       continue;
     }
 
-    console.log(`[setup-upstreams] Building ${packageJson.name}`);
-    await runCommandImpl("bun", ["run", "build"], {
-      cwd: packageDir,
-      label: `bun run build (${packageJson.name})`,
-    });
+    console.log(`[setup-upstreams] Building ${packageName}`);
+    try {
+      await runCommandImpl("bun", ["run", "build"], {
+        cwd: packageDir,
+        label: `bun run build (${packageName})`,
+      });
+    } catch (error) {
+      if (requiredPackageNames.has(packageName)) {
+        throw error;
+      }
+      console.warn(
+        `[setup-upstreams] WARNING: Skipping optional upstream plugin ${packageName}; build failed (${error instanceof Error ? error.message : String(error)})`,
+      );
+    }
   }
 }
 
@@ -844,6 +1779,32 @@ export async function setupUpstreams(repoRoot = DEFAULT_REPO_ROOT) {
   if (skipReason) {
     if (skipReason.endsWith("=1")) {
       ensurePublishedElizaPackageLinks(repoRoot);
+      // Strip missing conditional workspace entries from eliza/package.json so
+      // that any subsequent `bun install --cwd eliza` doesn't fail on nested
+      // paths that are intentionally absent in this checkout.
+      // Guard: eliza/ may have been renamed by disable-local-eliza-workspace.mjs.
+      const elizaRoot = getRepoElizaRoot(repoRoot);
+      if (existsSync(path.join(elizaRoot, "package.json"))) {
+        const strippedWorkspaces =
+          stripMissingConditionalElizaWorkspaces(elizaRoot);
+        if (strippedWorkspaces.length > 0) {
+          console.log(
+            `[setup-upstreams] Stripped missing conditional eliza workspace entries (${strippedWorkspaces.join(", ")})`,
+          );
+        }
+        const missingPlugins = getMissingOptionalElizaPlugins(elizaRoot);
+        if (missingPlugins.length > 0) {
+          const patched = applyOptionalElizaPluginFallback(
+            elizaRoot,
+            missingPlugins,
+          );
+          if (patched > 0) {
+            console.log(
+              `[setup-upstreams] Stripped ${missingPlugins.length} missing optional plugin workspace(s) from eliza/package.json`,
+            );
+          }
+        }
+      }
     }
     console.log(`[setup-upstreams] Skipping: ${skipReason}`);
     return { skipped: true, reason: skipReason };
@@ -862,15 +1823,25 @@ export async function setupUpstreams(repoRoot = DEFAULT_REPO_ROOT) {
   }
 
   const elizaRoot = await ensureRepoLocalEliza(repoRoot);
+  const pluginsRoot = getRepoPluginsRoot(repoRoot);
+  const requiredPluginPackageNames = new Set(
+    getPublishedElizaPackageSpecs(repoRoot)
+      .map(([packageName]) => packageName)
+      .filter((packageName) => packageName.startsWith("@elizaos/plugin-")),
+  );
+  requiredPluginPackageNames.add("@elizaos/plugin-zai");
+
   await ensureElizaDependencies(elizaRoot);
   await ensureElizaBuildOutputs(elizaRoot);
 
-  const pluginsRoot = getRepoPluginsRoot(repoRoot);
   ensurePluginDependencyLinks(repoRoot, pluginsRoot);
-  await ensurePluginBuildOutputs(pluginsRoot);
+  ensureMiladySingletonDependencyLinks(repoRoot);
   const updatedLinks = linkUpstreamPackages(repoRoot, {
     elizaRoot,
     pluginsRoot,
+  });
+  await ensurePluginBuildOutputs(pluginsRoot, {
+    requiredPackageNames: requiredPluginPackageNames,
   });
 
   if (updatedLinks === 0) {


### PR DESCRIPTION
## What this PR is

Single integrated drop of the 8 component sync PRs (#143–#150). All cherry-picked clean onto `origin/alice`, no conflicts during integration. Reason for consolidation: the staging deploy needs the union of these changes to boot cleanly with the new eliza submodule's local-mode subpath exports and browser stubs (commit `0346182ff1` upstream). Splitting the merges into 8 PRs let each be reviewed surgically; this PR is the staging gate.

## Constituent commits (in order)

| # | sha | scope | source PR |
|---|-----|-------|-----------|
| 1 | `35bfad2c2` | eliza submodule bump `be182cc..30c595e1` (~150 commits) | #143 |
| 2 | `7931d5837` | `.gitignore` — upstream baseline + alice-only patterns preserved | #144 |
| 3 | `7eb32c944` | Windows packaged-app test stack — adopted upstream wholesale | #145 |
| 4 | `3af5bb23b` | `apps/app/tsconfig.json` — upstream `paths`+`baseUrl`+`bun-types` over alice's `include` | #146 |
| 5 | `62d623523` | `scripts/run-production-build.mjs` — upstream baseline with `isLocalElizaDisabled()` gate; alice's `resolveNodeExec`/`resolveBunForScripts`/parallel tsdown∥plugin-build/CDN prune retained | #147 |
| 6 | `bd7f16de5` | `scripts/run-release-contract-suite.mjs` — alice's release flow on top, upstream helpers exported | #148 |
| 7 | `2fd4b1018` | `scripts/setup-upstreams.mjs` — upstream baseline (24 new helpers) + alice's `discoverElizaPackageDirs` restored | #149 |
| 8 | `b81b48c3d` | `apps/app/src/main.tsx` — upstream baseline with alice's milady-branding injected | #150 |

## Verification done locally

- `git cherry-pick` of all 8 commits onto `origin/alice` — clean, no conflicts
- `git submodule update --init eliza` synced to `30c595e10ea5`
- `node --check scripts/run-production-build.mjs` — OK
- `node --check scripts/run-release-contract-suite.mjs` — OK
- `node --check scripts/setup-upstreams.mjs` — OK
- `node scripts/apply-alice-eliza-runtime-patches.mjs` — clean run: rerouted 30 upstream eliza package.json files to TS source (`src/index.ts`), patched 4 app plugin register exports, telegram account-auth exposed, plugin-elizacloud agent re-exports applied. Sentinel `_aliceSourceMainSentinel: "v1"` field, not version mutation.

## Alice-specific preservation guarantees

- All milady-branding (theme, appName "Milady", orgName, repoName "milady", docsUrl, appUrl, packageScope "miladyai", `shouldUseCloudOnlyBranding`) — preserved in main.tsx
- `discoverElizaPackageDirs` (29-line alice version vs upstream's 9) — restored verbatim
- Asset-CDN injection (`VITE_ASSET_BASE_URL`, `prune-cdn-local-assets.mjs`) — preserved
- Alice's release contract test list (asset-cdn, docker, chrome-extension, electrobun-release, whisper-build-script, release-check, static-asset-manifest) — preserved verbatim
- `.gitignore` alice-only entries (vrm/animation, foundry artifacts) — appended under marker section

## Closes

Closes #143, #144, #145, #146, #147, #148, #149, #150 once merged.