### PR TITLE
fix(apps/app): migrate styles import from @elizaos/app-core to @elizaos/ui/styles

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -1,6 +1,8 @@
 import { App, ErrorBoundary } from "@elizaos/app-core";
-import "@elizaos/app-core/styles/styles.css";
-import "@elizaos/app-core/styles/brand-gold.css";
+// Styles bundled via the @elizaos/ui barrel. The Wave A refactor (eliza
+// commit 5a6f5f337) moved CSS out of @elizaos/app-core/styles/ but
+// didn't update this consumer; the new shape is a single subpath.
+import "@elizaos/ui/styles";
 
 import { App as CapacitorApp } from "@capacitor/app";
 import { Capacitor } from "@capacitor/core";


### PR DESCRIPTION
## Summary

Unblocks the SPA vite build in the alice staging deploy. Upstream eliza's Wave A refactor (commit `5a6f5f337`) removed `@elizaos/app-core/styles/styles.css` and `.../brand-gold.css`, consolidating CSS under `@elizaos/ui/styles`. Milaidy's `apps/app/src/main.tsx` still imports the old paths; upstream milady-ai/milady has already made the migration verbatim — copying that single change here.

## Surfaced as

```
[commonjs--resolver] Missing "./styles/styles.css" specifier in "@elizaos/app-core" package
✗ Build failed in 330ms
```

…during builder 6/9's post-build-pkg vite production build of `apps/app`, after all runtime package builds finished and the whatsapp removal (`Render-Network-OS/stream#390`) cleared the prior blocker.

## Change

```diff
 import { App, ErrorBoundary } from "@elizaos/app-core";
-import "@elizaos/app-core/styles/styles.css";
-import "@elizaos/app-core/styles/brand-gold.css";
+// Styles bundled via the @elizaos/ui barrel. The Wave A refactor (eliza
+// commit 5a6f5f337) moved CSS out of @elizaos/app-core/styles/ but
+// didn't update this consumer; the new shape is a single subpath.
+import "@elizaos/ui/styles";
```

## Resolution evidence

`eliza/packages/ui/package.json` exports `./styles` → `./src/styles.ts` — resolves cleanly.

## Test plan

- [ ] Merge to `alice`
- [ ] Push empty trigger commit on `render-network-os/555-bot:alice`
- [ ] Confirm vite SPA build proceeds past `[commonjs--resolver]`, reaches `Build complete!`, image push, and EKS rollout