### PR TITLE
fix(patcher): order app-lifeops dir-subpath exports BEFORE wildcards

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -1084,6 +1084,16 @@ export function applyAliceAppLifeOpsDirSubpathExportsPatch({
     packageJson.exports = {};
   }
 
+  // Build the new explicit subpath entries first, then rebuild the
+  // exports object so they appear BEFORE the `./*` / `./*.css` wildcards.
+  // Node's subpath-exports resolver spec is "longest specific match wins",
+  // but rollup-plugin-commonjs (used by vite) walks the exports object in
+  // declaration order and short-circuits on the first match — which means
+  // `./*` -> `./dist/*.js` claims `./platform` before our `./platform`
+  // entry is ever considered. Inserting the explicit entries above the
+  // wildcards in declaration order gets us the rollup resolver behaviour
+  // we need without breaking Node-spec consumers.
+  const newDirSubpathEntries = {};
   let addedCount = 0;
   for (const subpath of aliceAppLifeOpsDirSubpathPaths) {
     const dirIndexPath = path.join(
@@ -1100,10 +1110,36 @@ export function applyAliceAppLifeOpsDirSubpathExportsPatch({
       continue;
     }
     const exportTarget = `./src/${subpath}/index.ts`;
-    packageJson.exports[`./${subpath}`] =
+    newDirSubpathEntries[`./${subpath}`] =
       aliceAppLifeOpsDirSubpathEntry(exportTarget);
     addedCount += 1;
   }
+
+  // Rebuild exports: keep `.` and `./package.json` first (they're the
+  // canonical anchors), then the new explicit dir subpaths, then any
+  // existing non-wildcard entries (e.g. `./plugin`), then the wildcards
+  // (`./*.css`, `./*`). This order satisfies both the Node spec (which
+  // doesn't care) and the rollup-plugin-commonjs first-match walker
+  // (which does).
+  const isWildcardKey = (key) => typeof key === "string" && key.includes("*");
+  const existingEntries = Object.entries(packageJson.exports);
+  const anchorEntries = existingEntries.filter(
+    ([key]) => key === "." || key === "./package.json",
+  );
+  const otherSpecificEntries = existingEntries.filter(
+    ([key]) =>
+      key !== "." &&
+      key !== "./package.json" &&
+      !isWildcardKey(key) &&
+      !(key in newDirSubpathEntries),
+  );
+  const wildcardEntries = existingEntries.filter(([key]) => isWildcardKey(key));
+  packageJson.exports = Object.fromEntries([
+    ...anchorEntries,
+    ...Object.entries(newDirSubpathEntries),
+    ...otherSpecificEntries,
+    ...wildcardEntries,
+  ]);
 
   if (addedCount === 0) {
     log(


### PR DESCRIPTION
## Summary

PR rndrntwrk/milaidy#153 added explicit `./platform` and `./widgets` entries to `eliza/plugins/app-lifeops/package.json` exports, but appended them at the end. **Node spec is order-agnostic** ("longest specific match wins"), but **rollup-plugin-commonjs walks exports in declaration order and short-circuits on the first match**. With the appended-at-end ordering the wildcard `./*` -> `./dist/*.js` claimed `./platform` before the new explicit entry was ever considered, mapping `./platform` to a non-existent `./dist/platform.js`.

11th alice staging deploy retry (trigger `20695e9af`, milaidy `8de55fb7b`) verified: the patcher emitted `[alice-eliza-runtime-patches] added 2 explicit dir-subpath export(s)` but vite still failed identically to attempt #10:

```
[vite]: Rollup failed to resolve import "@elizaos/app-lifeops/platform" from "/src/milaidy/apps/app/src/main.tsx"
✗ Build failed in 344ms
```

## Change

Rebuild `packageJson.exports` so explicit subpaths land BEFORE wildcards in declaration order. New order:

```
./package.json
.
./platform    ← new (was last)
./widgets     ← new (was last)
./plugin
./*.css
./*
```

Resolves cleanly for both rollup-plugin-commonjs (which short-circuits on first match) and Node-spec consumers (which don't care).

## Verification

- `node --check scripts/apply-alice-eliza-runtime-patches.mjs` — OK
- Smoke run produces the documented order:
  ```
  0. ./package.json
  1. .
  2. ./platform
  3. ./widgets
  4. ./plugin
  5. ./*.css
  6. ./*
  ```
- Idempotency check `isAliceAppLifeOpsDirSubpathExportsPatched` unchanged (presence-based); fresh deploys always start from the upstream package.json so the reorder happens in a single pass.

## Test plan

- [ ] Merge to `alice`
- [ ] Push empty trigger commit on `render-network-os/555-bot:alice`
- [ ] Confirm vite SPA build proceeds past `[vite]: Rollup failed to resolve`, reaches `✔ Build complete`, image push, and EKS rollout