### PR TITLE
fix(vite): register @elizaos/app-lifeops in workspace alias builder + revert main.tsx /index workaround

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -52,16 +52,7 @@ import {
   syncDetachedShellLocation,
 } from "@elizaos/app-core";
 import { AppWindowRenderer } from "@elizaos/app-core";
-// Explicit "/platform/index" suffix: rollup-plugin-commonjs's resolver
-// doesn't match the explicit "./platform" subpath export added by
-// scripts/apply-alice-eliza-runtime-patches.mjs (apparently due to a
-// workspace-symlink quirk where the exports field isn't fully honoured),
-// so we route through the wildcard `./*` -> `./dist/*.js` mapping which
-// resolves cleanly to `./dist/platform/index.js`. Upstream
-// milady-ai/milady's main.tsx still uses the no-index form because they
-// ship against published @elizaos/app-lifeops bundles whose exports field
-// vite's standard alias-builder honours correctly.
-import { dispatchQueuedLifeOpsGithubCallbackFromUrl } from "@elizaos/app-lifeops/platform/index";
+import { dispatchQueuedLifeOpsGithubCallbackFromUrl } from "@elizaos/app-lifeops/platform";
 import type { ShareTargetPayload } from "@elizaos/app-core/platform";
 import {
   DESKTOP_TRAY_MENU_ITEMS,
@@ -91,8 +82,7 @@ import {
 } from "@elizaos/app-companion";
 import "@elizaos/app-companion/register";
 // Side-effect: register LifeOps sidebar widgets + client methods on ElizaClient.
-// See the note above on platform/index for why "/widgets/index" is needed.
-import "@elizaos/app-lifeops/widgets/index";
+import "@elizaos/app-lifeops/widgets";
 // Side-effect: register coding-agent (task-coordinator) slots so app-core
 // slot wrappers (CodingAgentControlChip, PtyConsoleBase, etc.) render the
 // real components instead of nulls.

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1357,12 +1357,28 @@ export default defineConfig({
           miladyRoot,
           "eliza/plugins/app-wallet/package.json",
         );
+        // app-lifeops carries dir-style subpath imports (`./platform`,
+        // `./widgets`) that rollup-plugin-commonjs's default resolver
+        // ignores when the package is workspace-symlinked. The patcher
+        // (scripts/apply-alice-eliza-runtime-patches.mjs) adds explicit
+        // `./platform` and `./widgets` exports pointing at the source
+        // tree; registering app-lifeops here makes Vite read those
+        // exports via the workspace alias builder, sidestepping the
+        // commonjs resolver entirely.
+        const appLifeOpsPkgPath = path.resolve(
+          miladyRoot,
+          "eliza/plugins/app-lifeops/package.json",
+        );
 
         const generatedAliases = [
           ...buildWorkspaceExportAliases("@miladyai/app-core", appCorePkgPath),
           ...buildWorkspaceExportAliases("@miladyai/agent", agentPkgPath),
           ...buildWorkspaceExportAliases("@miladyai/shared", sharedPkgPath),
           ...buildWorkspaceExportAliases("@elizaos/app-wallet", appWalletPkgPath),
+          ...buildWorkspaceExportAliases(
+            "@elizaos/app-lifeops",
+            appLifeOpsPkgPath,
+          ),
         ];
 
         const uiSource = path.resolve(miladyRoot, "packages/ui/src");


### PR DESCRIPTION
## Summary

13-attempt deploy saga's final fix. rollup-plugin-commonjs's default resolver does not honour subpath exports for workspace-symlinked packages — both PR #154's explicit-export reorder and PR #155's `/index`-suffix workaround were rejected with the same error:

```
[vite]: Rollup failed to resolve import "@elizaos/app-lifeops/platform"
[vite]: Rollup failed to resolve import "@elizaos/app-lifeops/platform/index"
```

## Root cause + fix

`apps/app/vite.config.ts:1361-1365` registers 4 packages (`@miladyai/app-core`, `@miladyai/agent`, `@miladyai/shared`, `@elizaos/app-wallet`) with `buildWorkspaceExportAliases` — this builds Vite-level `resolve.alias` regex entries from each package's exports field, which Vite processes **before** handing off to rollup-plugin-commonjs. Those 4 packages' subpath imports work cleanly because Vite resolves them at the alias step.

`@elizaos/app-lifeops` was never registered. Its subpath imports (`./platform`, `./widgets`) fell through to rollup-plugin-commonjs, which empirically does not honour subpath exports for symlinked workspace packages even when entries are explicit and ordered first.

This PR registers app-lifeops in the same alias builder:

```diff
 const appWalletPkgPath = ...;
+const appLifeOpsPkgPath = path.resolve(
+  miladyRoot,
+  "eliza/plugins/app-lifeops/package.json",
+);

 const generatedAliases = [
   ...buildWorkspaceExportAliases("@miladyai/app-core",   appCorePkgPath),
   ...buildWorkspaceExportAliases("@miladyai/agent",      agentPkgPath),
   ...buildWorkspaceExportAliases("@miladyai/shared",     sharedPkgPath),
   ...buildWorkspaceExportAliases("@elizaos/app-wallet",  appWalletPkgPath),
+  ...buildWorkspaceExportAliases("@elizaos/app-lifeops", appLifeOpsPkgPath),
 ];
```

The `buildWorkspaceExportAliases` reads app-lifeops's (already-patched, post-#153/#154) `exports` field and creates:
- `^@elizaos/app-lifeops$` → `<pkg>/dist/index.js`
- `^@elizaos/app-lifeops/platform$` → `<pkg>/src/platform/index.ts` ← explicit export from patcher
- `^@elizaos/app-lifeops/widgets$` → `<pkg>/src/widgets/index.ts` ← explicit export from patcher
- `^@elizaos/app-lifeops/plugin$` → `<pkg>/dist/plugin.js`
- `^@elizaos/app-lifeops/(.+)$` → `<pkg>/dist/$1.js` (wildcard)
- `.js` and `.css` variants

Vite hands these aliases off to rollup; the imports in main.tsx resolve directly via alias regex without touching rollup-plugin-commonjs's exports walker.

## Revert /index workaround

PR #155 added `/index` suffix to dodge the original failure. With the proper alias registration, this divergence from upstream milady-ai/milady is no longer needed. Reverting both imports back to the no-index form:

```diff
-import { dispatchQueuedLifeOpsGithubCallbackFromUrl } from "@elizaos/app-lifeops/platform/index";
+import { dispatchQueuedLifeOpsGithubCallbackFromUrl } from "@elizaos/app-lifeops/platform";

-import "@elizaos/app-lifeops/widgets/index";
+import "@elizaos/app-lifeops/widgets";
```

Plus deleting the 9-line comment block above the platform import.

## Test plan

- [ ] Merge to `alice`
- [ ] Push empty trigger commit on `render-network-os/555-bot:alice`
- [ ] Confirm vite SPA build proceeds past `[vite]: Rollup failed to resolve`, reaches `✔ Build complete`, ECR push, EKS rollout, pod state transitions from `CrashLoopBackOff` to `Running 1/1`