### PR TITLE
fix(vite): register @clawville/app-clawville scope-rename alias

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1546,6 +1546,27 @@ export default defineConfig({
         const optionalAppStub = resolveOptionalElizaAppStubAlias(realAppNames);
         if (optionalAppStub) generatedAliases.push(optionalAppStub);
 
+        // Scope-rename alias for @clawville/app-clawville: the package.json
+        // at eliza/plugins/app-clawville/ declares name "@elizaos/app-clawville",
+        // but main.tsx imports it under "@clawville/app-clawville/ui" because
+        // 555stream's deploy-555-bot-staging.sh materialize_pkg step
+        // creates node_modules/@clawville/app-clawville/ at runtime. Vite
+        // runs BEFORE that materialize step, so we register the
+        // @clawville scope directly against the eliza source via
+        // buildWorkspaceExportAliases.
+        const clawvillePkgPath = path.resolve(
+          miladyRoot,
+          "eliza/plugins/app-clawville/package.json",
+        );
+        if (fs.existsSync(clawvillePkgPath)) {
+          generatedAliases.push(
+            ...buildWorkspaceExportAliases(
+              "@clawville/app-clawville",
+              clawvillePkgPath,
+            ),
+          );
+        }
+
         const uiSource = path.resolve(miladyRoot, "packages/ui/src");
         const _autonomousSource = path.resolve(
           miladyRoot,


### PR DESCRIPTION
## Summary

15th alice staging deploy retry (trigger `d02e95181`, milaidy `ac05f7773`) cleared all `@elizaos/*` workspace imports via PR #157's dynamic resolvers but immediately surfaced:

```
[vite]: Rollup failed to resolve import "@clawville/app-clawville/ui" from "/src/milaidy/apps/app/src/main.tsx"
```

`apps/app/src/main.tsx:97` imports under the `@clawville` scope, but the package.json at `eliza/plugins/app-clawville/` declares name `@elizaos/app-clawville`. The 555stream deploy script runs `materialize_pkg "@clawville/app-clawville" "app-clawville" "src/index.ts"` which creates `node_modules/@clawville/app-clawville/` at runtime — but vite's SPA build happens **earlier in the same docker layer**, before materialize_pkg, so the `@clawville/` scope path doesn't exist yet.

## Fix

Register an explicit Vite alias for `@clawville/app-clawville` pointing at the same `eliza/plugins/app-clawville/package.json` via the existing `buildWorkspaceExportAliases` function. Adds the `@clawville` scope at vite-time without touching the @elizaos scope alias or anything else.

Gated with `fs.existsSync` so the alias is a no-op if app-clawville is absent (defensive).

## Test plan

- [ ] Merge to `alice`
- [ ] Push trigger commit on `render-network-os/555-bot:alice`
- [ ] Confirm vite SPA build proceeds past the `@clawville/app-clawville` resolver failure, reaches `✔ Build complete`, ECR push, EKS rollout