### PR TITLE
fix(apps/app): add missing apps/app/src/app-config.ts wrapper

### DIFF
--- a/apps/app/src/app-config.ts
+++ b/apps/app/src/app-config.ts
@@ -1,0 +1,21 @@
+// Thin wrapper around `../app.config.ts` that surfaces the derived
+// branding/log-prefix/namespace/url-scheme constants used by main.tsx.
+//
+// Upstream milady-ai/milady's apps/app/src/app-config.ts imports
+// `resolveAppBranding` from `@elizaos/app-core` — that import path is
+// stale for current eliza (commit 5a6f5f3370 moved branding into
+// @elizaos/ui via the Wave A refactor; @elizaos/app-core no longer
+// exports it). Alice uses the canonical post-refactor path
+// `@elizaos/ui/config/app-config`, matching what
+// eliza/packages/app/src/app-config.ts itself does.
+import { resolveAppBranding } from "@elizaos/ui/config/app-config";
+
+import appConfig from "../app.config";
+
+export const APP_CONFIG = appConfig;
+export const APP_BRANDING_BASE = resolveAppBranding(APP_CONFIG);
+export const APP_LOG_PREFIX = `[${APP_CONFIG.appName}]`;
+export const APP_NAMESPACE =
+  APP_CONFIG.namespace?.trim() || APP_CONFIG.cliName.trim();
+export const APP_URL_SCHEME =
+  APP_CONFIG.desktop?.urlScheme?.trim() || APP_CONFIG.cliName.trim();


### PR DESCRIPTION
## Summary

16th alice staging deploy retry (trigger `e5cb7212c`, milaidy `651d14b6c`) cleared **every other vite resolver** (42 modules transformed cleanly) and surfaced the final gap:

```
[vite]: Could not resolve "./app-config" from "src/main.tsx"
```

`apps/app/src/main.tsx` imports `APP_BRANDING_BASE`, `APP_CONFIG`, `APP_LOG_PREFIX`, `APP_NAMESPACE`, `APP_URL_SCHEME` from `./app-config`. The wrapper file is present in upstream milady-ai/milady (10 lines, thin wrapper around `../app.config.ts`) but never made it onto alice — the integrated upstream-sync (PR #151) brought the import into main.tsx but not the wrapper file itself.

## Change

New file `apps/app/src/app-config.ts` (~20 lines). One adjustment from upstream's version: the `resolveAppBranding` import path is corrected from `@elizaos/app-core` to `@elizaos/ui/config/app-config`, matching the canonical post-refactor path used by `eliza/packages/app/src/app-config.ts` itself.

Upstream eliza commit `5a6f5f3370` (the Wave A refactor that moved `@elizaos/app-core/styles/*` to `@elizaos/ui/styles`, fixed in PR #152) moved branding into `@elizaos/ui`; `@elizaos/app-core` no longer exports `resolveAppBranding`. Upstream-milady's app-config.ts still uses the stale path because they ship against an older eliza checkout — alice tracks the current eliza so we use the post-refactor path.

## Verification

- Re-exports the 5 named exports main.tsx consumes (`APP_BRANDING_BASE`, `APP_CONFIG`, `APP_LOG_PREFIX`, `APP_NAMESPACE`, `APP_URL_SCHEME`)
- `apps/app/app.config.ts` exists with the right `AppConfig` shape (provides `appName: "Milady"`, `cliName`, `namespace`, `desktop.urlScheme`, etc.)
- `@elizaos/ui/config/app-config` exports `resolveAppBranding` — confirmed via `eliza/packages/ui/src/config/app-config.ts`

## Test plan

- [ ] Merge to `alice`
- [ ] Push trigger commit on `render-network-os/555-bot:alice`
- [ ] Confirm vite SPA build proceeds past `[vite]: Could not resolve "./app-config"`, reaches `✔ Build complete`, ECR push, EKS rollout, pod state transitions from `CrashLoopBackOff` to `Running 1/1`