### PR TITLE
fix(vite): add diagnostic onwarn handler to surface real build errors

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1705,6 +1705,23 @@ export default defineConfig({
     cssMinify: desktopFastDist ? false : undefined,
     reportCompressedSize: !desktopFastDist,
     rollupOptions: {
+      // Print every rollup warning verbatim to stderr before delegating to
+      // the default handler. Without this, @vitejs/plugin-react-swc's
+      // silenceUseClientWarning wrapper + the build environment's stdout
+      // post-processing can collapse an UNRESOLVED_IMPORT error to a
+      // bare "undefined" line in the CI/deploy log, hiding the failing
+      // module path. Keep this delegate-then-default shape so we don't
+      // suppress vite's own escalation of warnings to build errors.
+      onwarn(warning, defaultHandler) {
+        const code = warning.code ?? "WARN";
+        const loc =
+          warning.loc?.file ?? warning.id ?? warning.importer ?? "<unknown>";
+        const msg = warning.message ?? "<no message>";
+        process.stderr.write(
+          `[vite-build-warning] ${code} at ${loc}: ${msg}\n`,
+        );
+        defaultHandler(warning);
+      },
       // Native-only deps that must not be resolved during the browser build.
       // Node built-ins (node:fs, fs, path, etc.) are NOT externalized here —
       // they are intercepted by nativeModuleStubPlugin which replaces them


### PR DESCRIPTION
## Why

The last 4 alice staging deploys (trigger commits #14–17 on 555-bot:alice) all failed with the same shape of error in the deploy log:

```
✓ 61 modules transformed.
✗ Build failed in 471ms
error during build:
undefined
```

That `undefined` is vite's error-handler falling back to stringifying a thrown error whose `.stack` and `.message` are both unset — typically because a plugin further up the chain re-threw a warning object whose displayable fields got stripped.

## Root cause of the obscured message

The path:

1. Rollup hits an `UNRESOLVED_IMPORT` warning during module loading.
2. The warning is delivered to vite's `onLog → onRollupLog → onwarn` chain.
3. `@vitejs/plugin-react-swc`'s `silenceUseClientWarning` wraps the user's `onwarn` (we don't define one, so it's `defaultHandler` — `viteLog`).
4. `viteLog` escalates `UNRESOLVED_IMPORT` to a thrown error during `build`.
5. The thrown error propagates up through the swc wrapper, then through vite's build promise's `.catch`.
6. Vite's catch does `console.error(\`error during build:\n${err.stack || err.message || err}\`)` — and the deploy host's stdout post-processing collapses this to just `undefined`.

Reproduced locally against an incomplete `bun install` — got the real message via direct stderr (`@capacitor/preferences` was missing).

## Fix

Add `build.rollupOptions.onwarn` to `apps/app/vite.config.ts` that:

- Prints every rollup warning verbatim to `process.stderr` with a `[vite-build-warning]` prefix, including `code`, `loc.file ?? id ?? importer`, and `message`.
- Then delegates to the default handler so vite's own warning-to-error escalation is preserved.

This is diagnostic-only — no behavior change. The next deploy's log will show the real unresolved import (or other warning) instead of `undefined`.

## Test plan

- [ ] Merge.
- [ ] Push trigger commit on `render-network-os/555-bot:alice`.
- [ ] Watch deploy log via SSM `journalctl` for `[vite-build-warning]` lines just before the build failure.
- [ ] Use the surfaced module path to add the correct alias or install the missing dep in a follow-up PR.

## Out of scope

This PR does **not** fix the underlying unresolved import — it only makes the failure observable. A follow-up PR will address the actual module after the diagnostic output identifies it.