### PR TITLE
fix(vite): add buildEnd diagnostic plugin to capture real build error

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1320,6 +1320,62 @@ function watchWorkspacePackagesPlugin(): Plugin {
   };
 }
 
+// Diagnostic plugin: surface the real build failure in CI/deploy logs.
+//
+// The CI deploy host was rendering `error during build: undefined` for every
+// failed alice deploy because Vite's CLI error catcher does
+// `err.stack || err.message || err` — when something throws a non-Error
+// value (or an object whose stack/message strip to nothing through stdout
+// buffering) the message collapses to "undefined" and the underlying cause
+// is invisible.
+//
+// `buildEnd(error)` fires after the input phase regardless of success, with
+// the rollup error passed in when the build failed. Stringifying the error
+// here (including stack/name/code/loc/plugin/cause) before propagating
+// guarantees the deploy log shows the actual cause even when Vite's catcher
+// fails to format it.
+function diagnoseBuildErrorPlugin(): Plugin {
+  return {
+    name: "diagnose-build-error",
+    enforce: "post",
+    buildEnd(error) {
+      if (!error) return;
+      try {
+        process.stderr.write(
+          `[vite-build-error] type=${typeof error} ctor=${(error as { constructor?: { name?: string } }).constructor?.name ?? "n/a"}\n`,
+        );
+        const fields = [
+          "name",
+          "code",
+          "message",
+          "plugin",
+          "id",
+          "loc",
+          "frame",
+          "cause",
+          "stack",
+        ] as const;
+        const dump: Record<string, unknown> = {};
+        for (const key of fields) {
+          const value = (error as Record<string, unknown>)[key];
+          if (value !== undefined) dump[key] = value;
+        }
+        process.stderr.write(
+          `[vite-build-error] dump=${JSON.stringify(dump, null, 2)}\n`,
+        );
+        const stack = (error as { stack?: string }).stack;
+        if (typeof stack === "string") {
+          process.stderr.write(`[vite-build-error] stack:\n${stack}\n`);
+        }
+      } catch (writeErr) {
+        process.stderr.write(
+          `[vite-build-error] failed to serialise build error: ${String(writeErr)}\n`,
+        );
+      }
+    },
+  };
+}
+
 export default defineConfig({
   root: here,
   base: "./",
@@ -1347,6 +1403,7 @@ export default defineConfig({
     ),
   },
   plugins: [
+    diagnoseBuildErrorPlugin(),
     nativeModuleStubPlugin(),
     asyncLocalStoragePatchPlugin(),
     watchWorkspacePackagesPlugin(),


### PR DESCRIPTION
## Why

Follow-up to #160. The `onwarn` handler added there never fired during deploy #18 — the build log shows no `[vite-build-warning]` lines, just the same `error during build: undefined`. That means the build failure is **not** a rollup warning escalated to error (which would have triggered `onwarn`); it's a thrown exception during the input/render phase that Vite's CLI catcher cannot stringify.

## Fix

Add a plugin with a `buildEnd(error)` hook. Rollup invokes `buildEnd` after the input phase regardless of success — and when it failed, the error object is passed in directly. The plugin:

- Logs `type=...` / `ctor=...` so we know the shape even if it's a non-Error value.
- Dumps `name`, `code`, `message`, `plugin`, `id`, `loc`, `frame`, `cause`, `stack` from the error.
- Prints the stack separately for readability.
- Catches its own serialisation errors so it can't fail silently.

Plugin sits first in the `plugins` array (so its `buildEnd` is registered early) and uses `enforce: "post"` so it runs after user transforms.

## Test plan

- [ ] Merge.
- [ ] Push trigger commit on `render-network-os/555-bot:alice`.
- [ ] Watch deploy log for `[vite-build-error]` lines — that block will show the real failure (likely a plugin throwing during render/chunking).
- [ ] Follow-up PR fixes the actual cause.

## Out of scope

Diagnostic-only — no behaviour change. Removing once we have the cause identified and fixed.