### PR TITLE
fix(main.tsx): import CharacterEditor from @miladyai/app-core

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -141,10 +141,14 @@ import {
   resolveIosRuntimeConfig,
 } from "@elizaos/app-core";
 
-// CharacterEditor is statically re-exported by `@elizaos/app-core/browser`,
-// so the previous `lazy()` wrapper here was eagerly merged back into the
-// main chunk by Rollup. Static import keeps the load path honest.
-import { CharacterEditor } from "@elizaos/app-core/components/character/CharacterEditor";
+// CharacterEditor lives in alice's local @miladyai/app-core (the 2009-line
+// version is alice-specific; upstream eliza moved this component to
+// @elizaos/ui as part of the Wave A refactor, but alice keeps its own
+// customized fork). The @miladyai/app-core package's `./components/*`
+// wildcard export resolves this to packages/app-core/src/components/.
+// A static import keeps the load path honest — `lazy()` here was eagerly
+// merged back into the main chunk by Rollup anyway.
+import { CharacterEditor } from "@miladyai/app-core/components/character/CharacterEditor";
 
 declare global {
   interface Window {


### PR DESCRIPTION
## Why

Deploy #20 hit the next blocker, surfaced cleanly via the buildEnd diagnostic from #161:

```
[vite-build-error] dump={
  "name": "Error",
  "code": "PLUGIN_ERROR",
  "message": "Could not load /src/milaidy/eliza/packages/app-core/src/components/character/CharacterEditor.ts (imported by src/main.tsx): ENOENT: no such file or directory",
  "plugin": "vite:load-fallback"
}
```

The import at `apps/app/src/main.tsx:147` was:

```ts
import { CharacterEditor } from "@elizaos/app-core/components/character/CharacterEditor";
```

That file does not exist in this eliza checkout. Verified by:

- `find eliza/packages/app-core -name "CharacterEditor*"` → no results
- `eliza/packages/app-core/src/components/` does not exist at all
- Upstream eliza moved `CharacterEditor` to `@elizaos/ui` as part of the Wave A refactor (matches the same pattern as `resolveAppBranding` moving from `@elizaos/app-core` → `@elizaos/ui/config/app-config` that we already fixed in #159)

## Fix

Alice keeps its own customized `CharacterEditor` at `packages/app-core/src/components/character/CharacterEditor.tsx` — **2009 lines vs eliza's 1488**, the diff is alice-specific. The fix is to import from `@miladyai/app-core` directly:

```ts
import { CharacterEditor } from "@miladyai/app-core/components/character/CharacterEditor";
```

`@miladyai/app-core`'s `package.json` already has a `./components/*` wildcard export pointing at `./src/components/*` — so the existing `buildWorkspaceExportAliases` machinery rewrites this to alice's source file. Vite's load-fallback then probes `.tsx` and finds the real component.

This is the *preserve alice-specific code* path per [[feedback]] — we keep alice's customized component instead of falling back to upstream's leaner version.

## Test plan

- [ ] Merge.
- [ ] Trigger commit on `render-network-os/555-bot:alice`.
- [ ] Watch deploy log via `journalctl` for either a clean vite output (chunks emitted) or the next `[vite-build-error]` block.