### PR TITLE
fix(eliza-patch): mark n8n-sidecar dynamic import as @vite-ignore

### DIFF
--- a/scripts/alice-eliza-runtime-patches/app-core-server-only-api-bind.patch
+++ b/scripts/alice-eliza-runtime-patches/app-core-server-only-api-bind.patch
@@ -254,7 +254,7 @@ index 71f9f391a2..75580e284d 100644
 +        // never used.
 +        try {
 +          const { disposeN8nSidecar } = await import(
-+            "../services/n8n-sidecar.js"
++            /* @vite-ignore */ "../services/n8n-sidecar.js"
 +          );
 +          await disposeN8nSidecar();
 +        } catch {


### PR DESCRIPTION
## Why

Deploy #21 progressed dramatically — **3870 modules transformed** (up from 37–61 on previous attempts) — then hit the next blocker, surfaced cleanly via PR #161's `buildEnd` diagnostic:

```
[vite-build-error] dump={
  "name": "RollupError",
  "code": "UNRESOLVED_IMPORT",
  "message": "Could not resolve '../services/n8n-sidecar.js' from '../../eliza/packages/app-core/src/runtime/eliza.ts'",
  "stack": "... at resolveDynamicImport ..."
}
```

This dynamic import is injected into eliza's `runtime/eliza.ts` by `scripts/alice-eliza-runtime-patches/app-core-server-only-api-bind.patch`:

```ts
const { disposeN8nSidecar } = await import(
  "../services/n8n-sidecar.js"
);
```

The path `../services/n8n-sidecar.js` is correct for Bun's runtime resolver against alice's patched eliza checkout — but the file lives in alice's `@miladyai/app-core` (`packages/app-core/src/services/n8n-sidecar.ts`), NOT in eliza's `@elizaos/app-core`. Vite/Rollup statically resolves the import from eliza's src tree and fails.

## Fix

Add a `/* @vite-ignore */` magic comment to the dynamic import. Vite skips static resolution and leaves the import as a runtime string. This is safe because:

1. The entire `startEliza` server-only branch is unreachable in the browser SPA and gets tree-shaken away.
2. The surrounding `try { } catch { /* non-critical — best effort */ }` already handles failures gracefully.
3. In the Node.js bundle (server-only), Bun's loader handles the relative path against the runtime-patched eliza checkout.

The patch hunk header is unchanged (same `+` line count) so `git apply` continues to apply cleanly. Verified the only character difference is on a single content line: `"../services/n8n-sidecar.js"` → `/* @vite-ignore */ "../services/n8n-sidecar.js"`.

## Test plan

- [ ] Merge.
- [ ] Trigger commit on `render-network-os/555-bot:alice`.
- [ ] Watch deploy. Either next `[vite-build-error]` block (further blocker) OR successful chunk emission and image push.