### PR TITLE
fix(eliza-patch): import n8n-sidecar via @miladyai/app-core package name

### DIFF
--- a/scripts/alice-eliza-runtime-patches/app-core-server-only-api-bind.patch
+++ b/scripts/alice-eliza-runtime-patches/app-core-server-only-api-bind.patch
@@ -254,7 +254,7 @@ index 71f9f391a2..75580e284d 100644
 +        // never used.
 +        try {
 +          const { disposeN8nSidecar } = await import(
-+            "../services/n8n-sidecar.js"
++            "@miladyai/app-core/services/n8n-sidecar"
 +          );
 +          await disposeN8nSidecar();
 +        } catch {


### PR DESCRIPTION
## Why

Replaces the hacky #164 (closed). Deploy #21's buildEnd diagnostic surfaced:

```
RollupError UNRESOLVED_IMPORT:
  "Could not resolve '../services/n8n-sidecar.js'
   from '../../eliza/packages/app-core/src/runtime/eliza.ts'"
```

The dynamic import was injected by `app-core-server-only-api-bind.patch`. The relative path `../services/n8n-sidecar.js` resolves to a file inside eliza's package tree — but `n8n-sidecar` actually lives in alice's `@miladyai/app-core`, not in eliza's `@elizaos/app-core`. **The relative path was wrong from day one**:

- Vite/Rollup fails statically with ENOENT (what we hit).
- Bun's runtime resolver would also fail with ENOENT. The surrounding `try/catch` swallows that failure, so **n8n cleanup never actually ran**, regardless of bundler behaviour.

The previous #164 (`/* @vite-ignore */`) was a hack: it suppressed vite's error but didn't fix the runtime behaviour. The shutdown would still throw, the catch would still swallow, n8n would still leak.

## Fix

Change the import path to use the package name:

```diff
-          const { disposeN8nSidecar } = await import(
-            "../services/n8n-sidecar.js"
-          );
+          const { disposeN8nSidecar } = await import(
+            "@miladyai/app-core/services/n8n-sidecar"
+          );
```

`@miladyai/app-core/services/n8n-sidecar` is a real export entry — verified at `packages/app-core/package.json:101`:

```json
"./services/n8n-sidecar": "./src/services/n8n-sidecar.ts",
```

This path resolves correctly in:
- **Vite SPA build** via the `buildWorkspaceExportAliases("@miladyai/app-core", ...)` call in `apps/app/vite.config.ts` (which reads the exports field and emits a regex alias). Tree-shaken out of the SPA bundle since the surrounding `startEliza` branch is server-only and main.tsx never reaches it.
- **Bun runtime** via the npm workspace package resolver.
- **tsdown server bundle** via the same workspace resolver.

## Side benefit

`disposeN8nSidecar()` will now actually fire on server shutdown. Before this fix, the "best effort" comment was misleading — the import always failed at runtime and the cleanup never ran.

## Test plan

- [ ] Merge.
- [ ] Trigger commit on `render-network-os/555-bot:alice`.
- [ ] Watch deploy log. The buildEnd diagnostic from #161 stays in place so any further blocker surfaces cleanly.