### PR TITLE
fix(vite): stub @elizaos/plugin-edge-tts in nativeModuleStubPlugin

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1122,6 +1122,17 @@ function nativeModuleStubPlugin(): Plugin {
     "electron",
     "undici",
     "@elizaos/plugin-local-embedding",
+    // Edge-TTS is a Node-only voice plugin. Its package.json declares
+    // `./dist/browser/index.browser.js` under the `browser` export
+    // condition, but that file is never built (only `dist/node/` ships,
+    // and even that isn't prebuilt for staging — plugin-edge-tts isn't
+    // in the Dockerfile build_pkg list). alice's
+    // `packages/app-core/src/runtime/eliza.ts` imports it eagerly for
+    // the server runtime. In the SPA build the runtime/eliza module is
+    // unreachable, but vite still resolves the bare specifier while
+    // walking the module graph. Stubbing here matches the existing
+    // pattern for @elizaos/plugin-local-embedding.
+    "@elizaos/plugin-edge-tts",
     // mammoth (statically imported from @elizaos/core/src/features/knowledge/
     // utils.ts) calls fs.readFile.bind(fs) inside its DocumentXmlReader factory
     // at module init. In a browser where fs is stubbed empty that lookup throws


### PR DESCRIPTION
## Why

Deploy #22 with the proper `@miladyai/app-core/services/n8n-sidecar` import (PR #165) transformed 2296 modules and hit the next blocker, surfaced cleanly via the #161 buildEnd diagnostic:

```
[vite-build-error] dump={
  "name": "Error",
  "code": "PLUGIN_ERROR",
  "message": "Failed to resolve entry for package '@elizaos/plugin-edge-tts'. The package may have incorrect main/module/exports specified in its package.json.",
  "plugin": "commonjs--resolver"
}
```

## Root cause

`@elizaos/plugin-edge-tts` is a Node-only voice plugin. Its `package.json` declares `./dist/browser/index.browser.js` under the `browser` export condition (the plugin's own `build.ts` emits an intentional browser stub there). At staging-deploy time:

1. `plugins/plugin-edge-tts/` is a **git submodule** that's not initialized in the build context — `git submodule status` reports `-d9d9282...` (unchecked-out). The 555stream deploy host relies on runtime materialization (`materialize_pkg`) for this package, not on git submodule init.
2. The Dockerfile's `build_pkg` prebuild list does NOT include `plugin-edge-tts`, so even if the directory existed, `dist/browser/` wouldn't be built.

The SPA bundle pulls in this package because `eliza/packages/app-core/src/runtime/eliza.ts` imports it eagerly for the server runtime. The runtime branch is tree-shaken away from the browser bundle, but vite/rollup still has to resolve the bare specifier while walking the module graph.

## Fix

Add `@elizaos/plugin-edge-tts` to `nativeModuleStubPlugin`'s `nativePackages` set in `apps/app/vite.config.ts`. Vite replaces the import with a no-op Proxy stub. The runtime branch is never reached in the SPA, so the stub is functionally invisible.

This is the **existing alice pattern** for server-only plugins — the same list already stubs `@elizaos/plugin-local-embedding`, `node-llama-cpp`, `fs-extra`, `pty-state-capture`, `electron`, `undici`, `mammoth`. Adding edge-tts is structurally consistent, not a hack.

## Considered alternatives

- **Add to Dockerfile prebuild list**: the submodule isn't initialized in the build context, so `bun run build` in that directory would fail with "no package.json". The deploy materializes the workspace stub at runtime, not at image-build time.
- **Initialize the submodule** in `milaidy-sync`: a much larger change to the deploy host; would also require ensuring the plugin's `build.ts` runs before the SPA build. The deploy host explicitly avoids this — see the `workspace-stub skipped` lines for edge-tts in the deploy log.
- **Restructure `@elizaos/app-core` to not re-export server-only code**: this is upstream eliza's code and a much bigger refactor.

The stub is the minimal correct change.

## Test plan

- [ ] Merge.
- [ ] Trigger commit on `render-network-os/555-bot:alice`.
- [ ] Watch deploy. The #161 buildEnd diagnostic stays in place; any further blocker surfaces cleanly.

## Build progress

| Deploy | Modules transformed | Next blocker | Fix |
|---|---|---|---|
| #17 | 12 → 42 → 61 | various early errors | #157, #159 |
| #21 | 3870 | n8n-sidecar dynamic import | #165 |
| #22 | 2296 | @elizaos/plugin-edge-tts | this PR |