### PR TITLE
fix(vite): stub @node-rs/argon2 in nativeModuleStubPlugin

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1857,6 +1857,14 @@ export default defineConfig({
       "undici",
       // Native LLM embedding — uses node-llama-cpp, never runs in browser
       "@elizaos/plugin-local-embedding",
+      // Node-only Edge-TTS voice plugin; browser entry is an unbuilt stub.
+      // Pairs with the nativePackages entry — esbuild's pre-bundle pass would
+      // otherwise hit the package before the stub plugin gets a chance.
+      "@elizaos/plugin-edge-tts",
+      // Native argon2 password hashing — declared by @elizaos/app-core for
+      // server-side credential hashing. Browser entry imports an optional
+      // WASM peer (@node-rs/argon2-wasm32-wasi) that isn't installed.
+      "@node-rs/argon2",
       // OS keychain binding is desktop/server-only and pulls native .node assets.
       "@napi-rs/keyring",
     ],

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1133,6 +1133,15 @@ function nativeModuleStubPlugin(): Plugin {
     // walking the module graph. Stubbing here matches the existing
     // pattern for @elizaos/plugin-local-embedding.
     "@elizaos/plugin-edge-tts",
+    // @node-rs/argon2 is a Node-native password-hashing module, declared as a
+    // direct dep of @elizaos/app-core (used for credential hashing on the
+    // server). Its package.json exposes a `browser` export condition pointing
+    // at `browser.js`, which dynamically imports the optional WASM peer
+    // `@node-rs/argon2-wasm32-wasi`. That peer is not installed in alice's
+    // workspace (it's an optional dep), so the browser resolution fails.
+    // The SPA never executes credential hashing (all auth flows live on the
+    // server), so stubbing here is safe.
+    "@node-rs/argon2",
     // mammoth (statically imported from @elizaos/core/src/features/knowledge/
     // utils.ts) calls fs.readFile.bind(fs) inside its DocumentXmlReader factory
     // at module init. In a browser where fs is stubbed empty that lookup throws


### PR DESCRIPTION
## Why

Deploy #23 reached **7242 modules transformed** (up from 2296 after the edge-tts stub in #166), then hit:

```
Rollup failed to resolve import "@node-rs/argon2-wasm32-wasi"
from ".../@node-rs/argon2/browser.js"
```

## Root cause

`@node-rs/argon2` is a Node-native password-hashing module, declared as a direct dependency of `@elizaos/app-core` (used by credential hashing on the server side). Its `package.json` declares a `browser` export condition pointing at `browser.js`, which **dynamically imports** `@node-rs/argon2-wasm32-wasi` as an optional WASM peer.

That WASM peer is one of 14 `optionalDependencies` in argon2's package.json (per `bun.lock`). Bun only installs optional deps that match the runtime platform — `wasm32-wasi` isn't selected on a linux-x64 build host. So when vite/rollup walks the SPA's module graph through the `@elizaos/app-core` barrel and reaches the argon2 browser entry, the import to the WASM peer fails.

The SPA never executes credential hashing — all auth flows live on the server. The argon2 module is only transitively pulled in because the @elizaos/app-core barrel re-exports the server runtime.

## Fix

Add `@node-rs/argon2` to `nativeModuleStubPlugin`'s `nativePackages` set in `apps/app/vite.config.ts`. The existing pattern already covers:
- `node-llama-cpp` (Node-native ML)
- `fs-extra` (Node fs)
- `pty-state-capture`, `electron`, `undici` (server-only)
- `@elizaos/plugin-local-embedding`, `@elizaos/plugin-edge-tts` (server-only plugins)
- `mammoth` (Node fs at init)

`@node-rs/argon2` is structurally identical — Node-native, server-only, transitively pulled into the SPA graph.

## Test plan

- [ ] Merge.
- [ ] Trigger commit on `render-network-os/555-bot:alice`.
- [ ] Watch deploy. #161 buildEnd diagnostic stays in place.

## Build progress

| Deploy | Modules transformed | Next blocker | Fix |
|---|---|---|---|
| #21 | 3870 | n8n-sidecar dynamic import | #165 |
| #22 | 2296 | @elizaos/plugin-edge-tts | #166 |
| #23 | 7242 | @node-rs/argon2 → wasm peer | this PR |