### PR TITLE
fix(deps): pin libsignal to npm v6.0.0 instead of git+https

### DIFF
--- a/package.json
+++ b/package.json
@@ -405,7 +405,7 @@
     "ai": "6.0.30",
     "@stwd/sdk": "^0.3.0",
     "@ai-sdk/groq": "3.0.31",
-    "libsignal": "git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
+    "libsignal": "6.0.0",
     "crypto-browserify": "3.12.1",
     "tar": "7.5.13",
     "lodash": "4.18.1",


### PR DESCRIPTION
## Why

Last 3 deploys failed at `bun install`:

```
Resolved, downloaded and extracted [9888]
error: libsignal@git+https://github.com/whiskeysockets/libsignal-node.git failed to resolve
```

Diagnosed:
- The pinned commit `1c30d7d` and the GitHub URL **are reachable** (verified with `git clone` from the deploy host directly).
- bun installs the exact same `libsignal@git+https://...#1c30d7d` spec **in isolation** in a fresh docker container on the same host in 500ms.
- The failure only occurs when bun's git fetcher is invoked at the tail of alice's ~9888-package workspace install. Likely a concurrency/resource issue in bun's git fetcher under load. Not a network, repo, or rate-limit problem.

## Coincidence that gives us a clean fix

The libsignal maintainers (WhiskeySockets) published **`libsignal@6.0.0`** to npm at 2026-05-13T08:11:23Z today. gitHead `bcea72d`.

Diff between alice's pinned commit `1c30d7d` and v6.0.0 is purely CI/tooling/docs/lockfile — **zero source code changes**:

- `.github/workflows/{manual,publish}-release.yml` (new)
- `.gitignore` / `.release-it.yml` / `.yarnrc.yml` / `CODE_OF_CONDUCT.md` / `SECURITY.md` (new)
- `package.json` (19 lines metadata)
- `yarn.lock` (3857 install-state lines)

Pinning to npm v6.0.0 is functionally equivalent.

## Fix

```diff
-    "libsignal": "git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
+    "libsignal": "6.0.0",
```

## Verified locally

`bun install` with `{libsignal: "6.0.0", "@whiskeysockets/baileys": "7.0.0-rc.9"}` resolves cleanly in 9s, no git operations.

Baileys's own transitive dep `"libsignal": "git+https://..."` (no commit pin in baileys) is satisfied by alice's `^6.0.0` since they resolve to the same package.

Alice does not import libsignal directly — grep for `from .libsignal` in alice's source returns no results. Only `@whiskeysockets/baileys` (WhatsApp encryption) uses it transitively.

## Trade-offs

- Reliability ⬆: npm tarball is more reliable than bun's git fetcher.
- Reproducibility ⬇ slightly: pinning to `6.0.0` vs immutable commit means any future `6.0.x` patch release would be taken. Mitigated by semver minor pin.
- Runtime behaviour: unchanged (same JS source).

## Test plan

- [ ] Merge.
- [ ] Trigger commit on `render-network-os/555-bot:alice`.
- [ ] Watch deploy log; bun install should complete without git resolution, vite reaches 7242+ modules.
