### PR TITLE
fix(vite): alias @elizaos/agent to upstream's elizaos-agent-browser-stub

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1767,12 +1767,23 @@ export default defineConfig({
           // statically import from @elizaos/agent.  The browser never executes
           // any of these — eliza/packages/app-core's services/account-pool.ts is
           // gated behind `isMobilePlatform()` / `isNode()` checks at runtime.
+          //
+          // Guard with `fs.existsSync` and fall back to the local stub if the
+          // eliza submodule isn't checked out (package-mode, fresh CI without
+          // submodules, etc.).  Mirrors the pattern used by the
+          // elizaSharedPkgPath / elizaUiPkgPath / elizaAppCorePkgPath blocks
+          // above and the eliza alias entries from #156/#157/#162.
           {
             find: /^@elizaos\/agent$/,
-            replacement: path.resolve(
-              miladyRoot,
-              "eliza/packages/app-core/src/platform/elizaos-agent-browser-stub.ts",
-            ),
+            replacement: (() => {
+              const elizaAgentStubPath = path.resolve(
+                miladyRoot,
+                "eliza/packages/app-core/src/platform/elizaos-agent-browser-stub.ts",
+              );
+              return fs.existsSync(elizaAgentStubPath)
+                ? elizaAgentStubPath
+                : path.resolve(here, "src/stubs/empty-node-module.ts");
+            })(),
           },
           // @elizaos/core — force ALL copies (including nested ones in plugins
           // like plugin-secrets-manager that ship their own older core) to the

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1756,10 +1756,23 @@ export default defineConfig({
           // server.ts) that imports native modules (node-llama-cpp, node:module).
           // Nothing in the browser needs the barrel — only subpath imports like
           // @miladyai/agent/contracts/onboarding are used.  Map the bare import
-          // to an empty module so Vite never traverses the server-side tree.
+          // to upstream eliza's comprehensive browser stub (which exports
+          // ACCOUNT_CREDENTIAL_PROVIDER_IDS, getAccessToken, listProviderAccounts,
+          // and ~140 other server-only names as no-ops).  Upstream provides this
+          // stub specifically for browser builds — using the local
+          // `src/stubs/empty-node-module.ts` instead causes Rollup to fail with
+          // `"ACCOUNT_CREDENTIAL_PROVIDER_IDS" is not exported by ...stubs/empty-node-module.ts`
+          // when files like eliza/packages/app-core/src/services/account-pool.ts
+          // (pulled in via the @elizaos/app-core barrel from main.tsx) try to
+          // statically import from @elizaos/agent.  The browser never executes
+          // any of these — eliza/packages/app-core's services/account-pool.ts is
+          // gated behind `isMobilePlatform()` / `isNode()` checks at runtime.
           {
             find: /^@elizaos\/agent$/,
-            replacement: path.resolve(here, "src/stubs/empty-node-module.ts"),
+            replacement: path.resolve(
+              miladyRoot,
+              "eliza/packages/app-core/src/platform/elizaos-agent-browser-stub.ts",
+            ),
           },
           // @elizaos/core — force ALL copies (including nested ones in plugins
           // like plugin-secrets-manager that ship their own older core) to the


### PR DESCRIPTION
## Summary
- Switches the SPA build's `@elizaos/agent` alias from `apps/app/src/stubs/empty-node-module.ts` to upstream eliza's `eliza/packages/app-core/src/platform/elizaos-agent-browser-stub.ts`
- Resolves the Rollup failure that crashed every staging deploy since PR #162 (the switch to src-rooted `@elizaos/app-*` aliases)

## Why
\`apps/app/src/main.tsx\` imports from \`@elizaos/app-core\` — the eliza submodule package, not the milaidy slot. Its barrel \`eliza/packages/app-core/src/index.ts\` re-exports \`./services/account-pool\` and a dozen other server-only modules. \`account-pool.ts\` statically imports ~12 names from \`@elizaos/agent\` (ACCOUNT_CREDENTIAL_PROVIDER_IDS, DIRECT_ACCOUNT_PROVIDER_ENV, DIRECT_ACCOUNT_PROVIDER_IDS, getAccessToken, isSubscriptionProvider, listProviderAccounts, …).

Vite's alias mapped \`@elizaos/agent\` → \`apps/app/src/stubs/empty-node-module.ts\`. That stub only exports \`util/types\` + \`stream/web\` polyfills — nothing close to the server-only API surface. Rollup binds named imports statically and bails with:

\`\`\`
error during build:
../../eliza/packages/app-core/src/services/account-pool.ts (35:2):
"ACCOUNT_CREDENTIAL_PROVIDER_IDS" is not exported by "src/stubs/empty-node-module.ts",
imported by "../../eliza/packages/app-core/src/services/account-pool.ts".
\`\`\`

Upstream eliza ships a comprehensive browser stub at \`eliza/packages/app-core/src/platform/elizaos-agent-browser-stub.ts\` that exports ~140 server-only names from \`@elizaos/agent\` as no-ops (\`const noop = () => undefined; export const X = noop;\`). It's authored specifically for browser builds.

I verified all **41 runtime names** imported from \`@elizaos/agent\` across \`eliza/packages/app-core/src/\` are present in the upstream stub (137 exports total — \`comm -23\` returns zero missing).

The browser never executes any of this code — account-pool, runtime/eliza, api/server, etc. are all behind \`isMobilePlatform()\` / \`isNode()\` runtime guards. Tree-shaking eliminates them after the bind passes.

## Test plan
- [ ] Triggers a staging deploy on `Render-Network-OS/555-bot:alice`
- [ ] Vite SPA build completes (no Rollup "is not exported by" error)
- [ ] alice-bot pod transitions to Running and serves the SPA at https://staging-alice.rndrntwrk.com/