### PR TITLE
fix(vite): stub DEFAULT_ELIZA_CLOUD_TEXT_MODEL in @elizaos/core browser entry

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1370,6 +1370,17 @@ function nativeModuleStubPlugin(): Plugin {
         AgentEventService: "function(){}",
         AutonomyService: "function(){}",
         createBasicCapabilitiesPlugin: "function(){return{name:'stub'}}",
+        // eliza/packages/core/src/contracts/service-routing.ts exports these
+        // model-id constants. They are re-exported by index.node.ts but NOT
+        // by index.browser.ts (which doesn't re-export service-routing). The
+        // SPA build resolves @elizaos/core through dist/browser/index.browser.js
+        // and Rollup fails the static bind when eliza/plugins/plugin-elizacloud/
+        // src/utils/config.ts imports DEFAULT_ELIZA_CLOUD_TEXT_MODEL from
+        // @elizaos/core. The constants are server-only at runtime (model
+        // selection happens behind isNode()/isProxyMode() guards), so stub
+        // strings satisfy the bind without affecting browser behavior.
+        DEFAULT_ELIZA_CLOUD_TEXT_MODEL: '"openai/gpt-oss-120b:nitro"',
+        DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL: '"openai/gpt-oss-120b:free"',
       };
       // Check which are actually missing from the existing export block
       const needed = Object.keys(missingExports).filter((n) => {


### PR DESCRIPTION
Deploy #26 (milaidy@e2ac03f3, PR #169 merged) failed at vite/rollup with:

```
error during build:
eliza/plugins/plugin-elizacloud/src/utils/config.ts (5:7):
"DEFAULT_ELIZA_CLOUD_TEXT_MODEL" is not exported by
"eliza/packages/core/dist/browser/index.browser.js",
imported by "eliza/plugins/plugin-elizacloud/src/utils/config.ts".
```

`DEFAULT_ELIZA_CLOUD_TEXT_MODEL` + `DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL` are defined in `eliza/packages/core/src/contracts/service-routing.ts` and re-exported by `index.node.ts` — but `index.browser.ts` does not re-export `./contracts/service-routing`, so the browser dist is missing them. plugin-elizacloud's `utils/config.ts` imports the constant from `@elizaos/core`, and Rollup's static bind fails when the SPA resolves `@elizaos/core` to its browser dist.

Fix uses the existing `missingExports` transform-plugin pattern in `apps/app/vite.config.ts` (already adds 7 stubs: `resolveSecretKeyAlias`, `SECRET_KEY_ALIASES`, `OnboardingStateMachine`, `isOnboardingComplete`, `AgentEventService`, `AutonomyService`, `createBasicCapabilitiesPlugin`). Adds the two model-id strings with their real upstream values as stubs.

Runtime safety: these constants drive cloud-routing model selection, which only fires behind `isNode()` / `isProxyMode()` runtime guards in the SPA. The browser never reaches them at execution time — the stubs only satisfy Rollup's static named-import bind.

After merge → trigger deploy #27 on 555-bot:alice.