### PR TITLE
fix(patcher): re-export ./runtime-env from core/src/index.browser.ts

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -749,6 +749,57 @@ export function applyAliceElizacloudReexportPatch({
   return "applied";
 }
 
+const coreBrowserIndexRelativePath = "packages/core/src/index.browser.ts";
+const coreBrowserRuntimeEnvReexportSentinel =
+  "// [milaidy:core-browser-runtime-env-reexport]";
+const coreBrowserRuntimeEnvReexport = `${coreBrowserRuntimeEnvReexportSentinel}
+// eliza/packages/core/src/runtime-env.ts exports ~30 pure-JS helpers
+// (resolveApiSecurityConfig, resolveAllowedOrigins, resolveApiBindHost,
+// DEFAULT_DESKTOP_API_PORT, etc.) used by plugins that bundle into the SPA
+// (notably plugin-elizacloud/src/services/cloud-auth.ts which statically
+// imports resolveApiSecurityConfig). Upstream's index.node.ts re-exports
+// runtime-env wholesale (line ~203: \`export * from "./runtime-env"\`),
+// but index.browser.ts does not — even though runtime-env.ts has zero
+// node-specific imports (only "./env-utils.js" sibling + pure regex/string).
+// Rollup fails the static bind in the SPA build when the missing names are
+// referenced. Re-exporting runtime-env from the browser entry resolves the
+// entire family of names in one shot, mirroring upstream's node-entry
+// surface for these browser-safe utilities.
+export * from "./runtime-env";
+`;
+
+export function isAliceCoreBrowserRuntimeEnvReexportPatched(source) {
+  return source.includes(coreBrowserRuntimeEnvReexportSentinel);
+}
+
+export function applyAliceCoreBrowserRuntimeEnvReexportPatch({
+  elizaRoot,
+  log = console.log,
+} = {}) {
+  const indexPath = path.join(elizaRoot, coreBrowserIndexRelativePath);
+  if (!existsSync(indexPath)) {
+    log(
+      "[alice-eliza-runtime-patches] eliza core source absent; skipping core-browser runtime-env reexport patch",
+    );
+    return "skipped";
+  }
+  const source = readFileSync(indexPath, "utf8");
+  if (isAliceCoreBrowserRuntimeEnvReexportPatched(source)) {
+    log(
+      "[alice-eliza-runtime-patches] core-browser runtime-env reexport already applied",
+    );
+    return "already-applied";
+  }
+  const next = source.endsWith("\n")
+    ? `${source}\n${coreBrowserRuntimeEnvReexport}`
+    : `${source}\n\n${coreBrowserRuntimeEnvReexport}`;
+  writeFileSync(indexPath, next);
+  log(
+    "[alice-eliza-runtime-patches] patched core index.browser.ts to re-export runtime-env (resolveApiSecurityConfig + ~29 sibling browser-safe helpers)",
+  );
+  return "applied";
+}
+
 export function applyAliceTelegramSourcePackageJsonExportPatch({
   elizaRoot,
   log = console.log,
@@ -2672,6 +2723,7 @@ export function applyAliceElizaRuntimePatches({
     applyAliceRuntimeApiBindPatch({ rootDir, elizaRoot, runtimePath, log }),
     applyAliceKubeHealthReadinessPatch({ elizaRoot, log }),
     applyAliceCoreBasicCapabilitiesBrowserSafePatch({ elizaRoot, log }),
+    applyAliceCoreBrowserRuntimeEnvReexportPatch({ elizaRoot, log }),
     applyAliceCoreBuildBrowserExternalsPatch({ elizaRoot, log }),
     applyAliceCoreBuildBrowserExternalsMammothPatch({ elizaRoot, log }),
     applyAliceAppViteStubMammothPatch({ elizaRoot, log }),


### PR DESCRIPTION
Deploy #28 (milaidy@b192d8cd, PR #170 merged) cleared the previous stub gap and reached vite, but Rollup hit the next missing export:

```
error during build:
eliza/plugins/plugin-elizacloud/src/services/cloud-auth.ts (27:2):
"resolveApiSecurityConfig" is not exported by
"eliza/packages/core/dist/browser/index.browser.js"
```

**Root cause (structural)**

`eliza/packages/core/src/runtime-env.ts` defines ~30 pure-JS helpers — `resolveApiSecurityConfig`, `resolveAllowedOrigins`, `resolveApiBindHost`, `resolveApiToken`, `DEFAULT_SERVER_ONLY_PORT`, `DEFAULT_DESKTOP_API_PORT`, plus the rest. Upstream's `index.node.ts` re-exports the whole file (`export * from "./runtime-env"`, line ~203). `index.browser.ts` does NOT — even though `runtime-env.ts` has zero node-specific imports (only `./env-utils.js` sibling + pure regex/string utilities). Rollup statically binds the missing names when SPA consumers reference them.

**Fix**

New patcher function `applyAliceCoreBrowserRuntimeEnvReexportPatch` (in `scripts/apply-alice-eliza-runtime-patches.mjs`) appends `export * from "./runtime-env"` to `eliza/packages/core/src/index.browser.ts` with sentinel `// [milaidy:core-browser-runtime-env-reexport]` for idempotence. Wired into mainline dispatch alongside the other core-browser patches (basic-capabilities, build externals, mammoth).

**Why not extend the missingExports vite-stub map (PR #170 pattern)**

Adding 30 individual transform-time stubs would be whack-a-mole and would produce false stubs for names that work natively once exported. Re-exporting the whole module preserves the real implementations and mirrors how upstream's node entry surfaces them.

**Browser safety verified**

`runtime-env.ts` imports only `./env-utils.js` (sibling, pure) and uses regex/string operations. No `fs`/`path`/`child_process`/`crypto`/`os`/`node:*` imports. Constants and resolver functions read `process.env` defensively.

After merge → trigger deploy #29.