### PR TITLE
fix(patcher): re-export ./settings-debug from core/src/index.browser.ts

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -800,6 +800,54 @@ export function applyAliceCoreBrowserRuntimeEnvReexportPatch({
   return "applied";
 }
 
+const coreBrowserSettingsDebugReexportSentinel =
+  "// [milaidy:core-browser-settings-debug-reexport]";
+const coreBrowserSettingsDebugReexport = `${coreBrowserSettingsDebugReexportSentinel}
+// eliza/packages/core/src/settings-debug.ts exports isElizaSettingsDebugEnabled,
+// sanitizeForSettingsDebug, and settingsDebugCloudSummary. Upstream's
+// index.node.ts re-exports the first two via a named-export block (line ~248).
+// index.browser.ts omits the module entirely — even though settings-debug.ts
+// is fully browser-safe: imports only "./env-utils.js" (pure), uses
+// typeof process !== "undefined" defensively, and reads import.meta.env for
+// Vite/browser environments. plugin-elizacloud/src/lib/cloud-connection.ts
+// statically imports isElizaSettingsDebugEnabled AND settingsDebugCloudSummary
+// from @elizaos/core, and Rollup fails the bind. Wholesale re-export surfaces
+// both names plus sanitizeForSettingsDebug (which the node entry oddly omits).
+export * from "./settings-debug";
+`;
+
+export function isAliceCoreBrowserSettingsDebugReexportPatched(source) {
+  return source.includes(coreBrowserSettingsDebugReexportSentinel);
+}
+
+export function applyAliceCoreBrowserSettingsDebugReexportPatch({
+  elizaRoot,
+  log = console.log,
+} = {}) {
+  const indexPath = path.join(elizaRoot, coreBrowserIndexRelativePath);
+  if (!existsSync(indexPath)) {
+    log(
+      "[alice-eliza-runtime-patches] eliza core source absent; skipping core-browser settings-debug reexport patch",
+    );
+    return "skipped";
+  }
+  const source = readFileSync(indexPath, "utf8");
+  if (isAliceCoreBrowserSettingsDebugReexportPatched(source)) {
+    log(
+      "[alice-eliza-runtime-patches] core-browser settings-debug reexport already applied",
+    );
+    return "already-applied";
+  }
+  const next = source.endsWith("\n")
+    ? `${source}\n${coreBrowserSettingsDebugReexport}`
+    : `${source}\n\n${coreBrowserSettingsDebugReexport}`;
+  writeFileSync(indexPath, next);
+  log(
+    "[alice-eliza-runtime-patches] patched core index.browser.ts to re-export settings-debug (isElizaSettingsDebugEnabled, settingsDebugCloudSummary, sanitizeForSettingsDebug)",
+  );
+  return "applied";
+}
+
 const coreBrowserOnboardingReexportSentinel =
   "// [milaidy:core-browser-onboarding-reexport]";
 const coreBrowserOnboardingReexport = `${coreBrowserOnboardingReexportSentinel}
@@ -2841,6 +2889,7 @@ export function applyAliceElizaRuntimePatches({
     applyAliceCoreBrowserRuntimeEnvReexportPatch({ elizaRoot, log }),
     applyAliceCoreBrowserStateDirStubsPatch({ elizaRoot, log }),
     applyAliceCoreBrowserOnboardingReexportPatch({ elizaRoot, log }),
+    applyAliceCoreBrowserSettingsDebugReexportPatch({ elizaRoot, log }),
     applyAliceCoreBuildBrowserExternalsPatch({ elizaRoot, log }),
     applyAliceCoreBuildBrowserExternalsMammothPatch({ elizaRoot, log }),
     applyAliceAppViteStubMammothPatch({ elizaRoot, log }),


### PR DESCRIPTION
Deploy #31 (milaidy@504fba0f, PR #173 merged) cleared the onboarding family but Rollup hit:

```
error during build:
eliza/plugins/plugin-elizacloud/src/lib/cloud-connection.ts (4:2):
"isElizaSettingsDebugEnabled" is not exported by
"eliza/packages/core/dist/browser/index.browser.js"
```

cloud-connection.ts imports four names from `@elizaos/core` on the same line:
- `isCloudInferenceSelectedInConfig` ← fixed by PR #173 (onboarding)
- `migrateLegacyRuntimeConfig` ← fixed by PR #173 (onboarding)
- `isElizaSettingsDebugEnabled` ← THIS PR (settings-debug)
- `settingsDebugCloudSummary` ← THIS PR (settings-debug)

**Same structural pattern as PR #171 / #173**: a browser-safe core module that the node entry re-exports but the browser entry omits.

`eliza/packages/core/src/settings-debug.ts` is fully browser-safe:
- Imports only `./env-utils.js` (pure JS)
- Uses `typeof process !== "undefined"` defensively
- Reads `import.meta.env` for Vite/browser environments
- The `isElizaSettingsDebugEnabled` function is literally **designed** for browser bundles (its second parameter is `importMetaEnv` for the Vite case)

New patcher `applyAliceCoreBrowserSettingsDebugReexportPatch` appends `export * from "./settings-debug"` to `index.browser.ts`. Sentinel `// [milaidy:core-browser-settings-debug-reexport]` for idempotence. Wired into mainline dispatch alongside the other core-browser reexport patches.

**Bonus**: also surfaces `sanitizeForSettingsDebug` (which the node entry oddly omits but is part of the same browser-safe module).

Fixes both `isElizaSettingsDebugEnabled` and `settingsDebugCloudSummary` on the same cloud-connection.ts:4 bind line in one shot.

After merge → trigger deploy #32.