### PR TITLE
fix(patcher): re-export ./spoken-text from core/src/index.browser.ts

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -800,6 +800,54 @@ export function applyAliceCoreBrowserRuntimeEnvReexportPatch({
   return "applied";
 }
 
+const coreBrowserSpokenTextReexportSentinel =
+  "// [milaidy:core-browser-spoken-text-reexport]";
+const coreBrowserSpokenTextReexport = `${coreBrowserSpokenTextReexportSentinel}
+// eliza/packages/core/src/spoken-text.ts exports sanitizeSpeechText
+// (and ~3 sibling helpers — collapseWhitespace, stripUrls, etc., though
+// only sanitizeSpeechText is exported by name from index.node.ts).
+// The file is 65 lines, has ZERO imports (pure regex/string functions),
+// and is trivially browser-safe. plugin-elizacloud/src/lib/server-cloud-tts.ts
+// statically imports sanitizeSpeechText from @elizaos/core and Rollup
+// fails the bind. index.node.ts re-exports it via a named-export block
+// (line ~252: \`export { sanitizeSpeechText } from "./spoken-text"\`).
+// Wholesale wildcard re-export pulls in any additional public helpers
+// if they get added upstream.
+export * from "./spoken-text";
+`;
+
+export function isAliceCoreBrowserSpokenTextReexportPatched(source) {
+  return source.includes(coreBrowserSpokenTextReexportSentinel);
+}
+
+export function applyAliceCoreBrowserSpokenTextReexportPatch({
+  elizaRoot,
+  log = console.log,
+} = {}) {
+  const indexPath = path.join(elizaRoot, coreBrowserIndexRelativePath);
+  if (!existsSync(indexPath)) {
+    log(
+      "[alice-eliza-runtime-patches] eliza core source absent; skipping core-browser spoken-text reexport patch",
+    );
+    return "skipped";
+  }
+  const source = readFileSync(indexPath, "utf8");
+  if (isAliceCoreBrowserSpokenTextReexportPatched(source)) {
+    log(
+      "[alice-eliza-runtime-patches] core-browser spoken-text reexport already applied",
+    );
+    return "already-applied";
+  }
+  const next = source.endsWith("\n")
+    ? `${source}\n${coreBrowserSpokenTextReexport}`
+    : `${source}\n\n${coreBrowserSpokenTextReexport}`;
+  writeFileSync(indexPath, next);
+  log(
+    "[alice-eliza-runtime-patches] patched core index.browser.ts to re-export spoken-text (sanitizeSpeechText)",
+  );
+  return "applied";
+}
+
 const coreBrowserCloudTopologyReexportSentinel =
   "// [milaidy:core-browser-cloud-topology-reexport]";
 const coreBrowserCloudTopologyReexport = `${coreBrowserCloudTopologyReexportSentinel}
@@ -2940,6 +2988,7 @@ export function applyAliceElizaRuntimePatches({
     applyAliceCoreBrowserOnboardingReexportPatch({ elizaRoot, log }),
     applyAliceCoreBrowserSettingsDebugReexportPatch({ elizaRoot, log }),
     applyAliceCoreBrowserCloudTopologyReexportPatch({ elizaRoot, log }),
+    applyAliceCoreBrowserSpokenTextReexportPatch({ elizaRoot, log }),
     applyAliceCoreBuildBrowserExternalsPatch({ elizaRoot, log }),
     applyAliceCoreBuildBrowserExternalsMammothPatch({ elizaRoot, log }),
     applyAliceAppViteStubMammothPatch({ elizaRoot, log }),


### PR DESCRIPTION
Deploy #33 (PR #175 merged) cleared cloud-topology but Rollup hit:

```
plugin-elizacloud/src/lib/server-cloud-tts.ts (11:9):
"sanitizeSpeechText" is not exported by core/dist/browser/index.browser.js
```

**Strategic shift**: instead of iterating one PR per missing export, I mapped ALL 26 `@elizaos/core` value imports across plugin-elizacloud and cross-referenced with what's currently exported by `index.browser.ts` (including my prior PRs #170-#175). `spoken-text.ts` is the only remaining unfixed source module.

**Adds one reexport patch**:
`./spoken-text` (65 lines, ZERO imports, pure regex/string functions) — surfaces `sanitizeSpeechText` and any future sibling helpers.

**Pattern**: identical to PRs #171 / #173 / #174 / #175. New patcher `applyAliceCoreBrowserSpokenTextReexportPatch`, sentinel `// [milaidy:core-browser-spoken-text-reexport]`, wired into mainline dispatch.

**Earlier draft note (force-pushed)**: an earlier version of this PR also tried to re-export `./runtime/system-prompt`. Reviewer caught that `index.browser.ts` already has `export * from "./runtime/system-prompt"` at line 51 — the additional patch would have been a redundant no-op. Removed.

**Convergence**: after this PR, the 26-name `@elizaos/core` import surface of plugin-elizacloud should be fully resolvable in the browser bundle:
- 11 names addressed by PRs #170-#175
- 14 names already reachable via existing browser-entry wildcards (`logger`, `ModelType`, `ChannelType`, `ContentType`, `EventType`, `VECTOR_DIMS`, `Service`, `createUniqueUuid`, `createMessageMemory`, `getRuntimeRouteHostContext`, `registerAppRoutePluginLoader`, `resolveStateDir`, `buildCanonicalSystemPrompt`, `renderChatMessagesForPrompt`, `resolveEffectiveSystemPrompt`)
- `sanitizeSpeechText` (this PR)