### PR TITLE
fix(vite): alias bare @elizaos/plugin-sql to schema source

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1630,6 +1630,41 @@ export default defineConfig({
           "packages/plugin-selfcontrol/src/index.ts",
         ),
       },
+      // Bare `@elizaos/plugin-sql` import resolves to the npm-installed
+      // package's `dist/browser/index.browser.js`, which omits the Drizzle
+      // schema tables (authIdentityTable, authSessionTable, agentTable, etc.)
+      // because the browser-conditional dist intentionally strips the
+      // server-only DB-adapter surface. But alice's
+      // `eliza/packages/app-core/src/services/auth-store.ts` does
+      // `import { authIdentityTable, ... } from "@elizaos/plugin-sql"` for
+      // the Drizzle TABLE DEFINITIONS (used in queries at runtime — they are
+      // pure pgTable() calls, no server-only deps). Rollup fails the static
+      // bind in the SPA build.
+      //
+      // The source `eliza/plugins/plugin-sql/src/index.ts` imports
+      // `node:fs` and is NOT browser-safe, but the schema sub-tree
+      // (`src/schema/index.ts` plus its sibling `./authIdentity.ts`,
+      // `./authSession.ts`, etc.) is pure drizzle-orm `pgTable` definitions
+      // with zero node imports. Aliasing the bare specifier to
+      // `src/schema/index.ts` exposes every table the SPA imports while
+      // skipping the node-only adapter/manager files.
+      //
+      // Guarded with fs.existsSync so a fresh CI build without the eliza
+      // submodule initialized falls back to the npm package (matches the
+      // pattern used for the @elizaos/agent alias from #169 and other
+      // workspace alias entries above).
+      {
+        find: /^@elizaos\/plugin-sql$/,
+        replacement: (() => {
+          const pluginSqlSchemaSrc = path.resolve(
+            miladyRoot,
+            "eliza/plugins/plugin-sql/src/schema/index.ts",
+          );
+          return fs.existsSync(pluginSqlSchemaSrc)
+            ? pluginSqlSchemaSrc
+            : path.resolve(here, "src/stubs/empty-node-module.ts");
+        })(),
+      },
       // Keep plugin-sql subpath imports on the repo-local source layout. Some
       // installed package copies can be stale enough to miss these exports.
       {


### PR DESCRIPTION
Deploy #34 (PR #176 merged) cleared the last mapped plugin-elizacloud blocker but vite hit a NEW class of error from a DIFFERENT module surface:

```
error during build:
eliza/packages/app-core/src/services/auth-store.ts (16:2):
"authIdentityTable" is not exported by
".../@elizaos/plugin-sql/dist/browser/index.browser.js"
```

**Different from this session's prior PRs** (which were all about @elizaos/core's browser entry). This is about the published npm `@elizaos/plugin-sql` (v2.0.0-alpha.19) — its browser-conditional dist intentionally strips the server-only DB-adapter surface but ALSO strips the Drizzle TABLE DEFINITIONS that ARE browser-safe (pure `pgTable()` declarations).

**Imports in auth-store.ts**: six tables (`authAuditEventTable`, `authBootstrapJtiSeenTable`, `authIdentityTable`, `authOwnerBindingTable`, `authOwnerLoginTokenTable`, `authSessionTable`) for query construction, plus type-only `DrizzleDatabase`. All six tables are exported by `eliza/plugins/plugin-sql/src/schema/index.ts`.

**Why not alias to `src/index.ts`** — that file imports `node:fs` (used for adapter init). NOT browser-safe.

**Why `src/schema/index.ts` works** — pure drizzle-orm `pgTable` definitions, zero node imports. Completely browser-safe.

**Pattern**: mirrors PR #169's `@elizaos/agent` alias. Adds a bare-specifier alias with `fs.existsSync` fallback to the local `empty-node-module.ts` stub for CI contexts without the eliza submodule.

Subpath imports (`/drizzle`, `/schema`, `/types`) are unaffected — those existing aliases above still cover them via `pluginSqlSrcRoot`.

Fixes auth-store.ts in one shot. After merge → trigger deploy #35.