### PR TITLE
fix(vite): scope-aware modName extraction in nativeModuleStubPlugin

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1210,7 +1210,18 @@ function nativeModuleStubPlugin(): Plugin {
     load(id) {
       if (!id.startsWith(VIRTUAL_PREFIX)) return null;
 
-      const modName = id.slice(VIRTUAL_PREFIX.length).split("/")[0];
+      // Scope-aware module-name extraction. For "@scope/name" (with or
+      // without further subpaths) we keep "@scope/name". For unscoped
+      // packages we keep the first segment. Without this the modName for
+      // a scoped package like "@node-rs/argon2" became just "@node-rs",
+      // silently bypassing the specialized stub branch below (PR #178
+      // bug — added the @node-rs/argon2 branch but it never fired
+      // because of this split). Affects every scoped native package
+      // routed through this stub plugin.
+      const stripped = id.slice(VIRTUAL_PREFIX.length);
+      const modName = stripped.startsWith("@")
+        ? stripped.split("/").slice(0, 2).join("/")
+        : stripped.split("/")[0];
       // node-llama-cpp is the most import-heavy native module — its consumers
       // use many named exports (LlamaLogLevel, getLlama, etc.).  Return a
       // module whose default export is a Proxy that returns no-op stubs for


### PR DESCRIPTION
Deploy #36 (milaidy@ed6bcb89, PR #178 merged) STILL failed with the same passwords.ts error PR #178 was meant to fix:

```
error during build:
eliza/packages/app-core/src/api/auth/passwords.ts (21:9):
"hash" is not exported by "\0native-stub:@node-rs/argon2"
```

**Root cause** — bug in line 1213 of `apps/app/vite.config.ts`:
```ts
const modName = id.slice(VIRTUAL_PREFIX.length).split("/")[0];
```

For `\0native-stub:@node-rs/argon2`:
- After stripping prefix: `@node-rs/argon2`
- After `.split("/")[0]`: `@node-rs` ← truncates at the first slash!

PR #178's `if (modName === "@node-rs/argon2")` check **never fired** — modName was always `@node-rs`. The handler fell through to the generic `export default {};` fallback, which doesn't satisfy the named imports of `hash` / `verify` from passwords.ts.

**Fix**: scope-aware modName. For specifiers starting with `@`, keep `@scope/name`. Unscoped packages keep first segment as before. Defensive for every future scoped-package stub branch (`@elizaos/*`, `@aws-sdk/*`, `@miladyai/*`, etc.).

Pre-existing branches (`node-llama-cpp`, `fs-extra`, `events`, `undici`, `node:*`) are all unscoped — unaffected.

After this lands, PR #178's argon2 stub will actually fire. Deploy should clear the passwords.ts bind.