### PR TITLE
fix(apps/app): export APP_ENV_PREFIX + APP_ENV_ALIASES from brand-env.ts

### DIFF
--- a/apps/app/src/brand-env.ts
+++ b/apps/app/src/brand-env.ts
@@ -33,3 +33,21 @@ export const MILADY_ENV_ALIASES = [
   ["MILADY_GATEWAY_PORT", "ELIZA_GATEWAY_PORT"],
   ["MILADY_BRIDGE_PORT", "ELIZA_BRIDGE_PORT"],
 ] as const;
+
+/**
+ * Upstream-compatible aliases for the generic boot config surface.
+ *
+ * After PR #150 brought the upstream baseline of main.tsx into alice,
+ * main.tsx imports `APP_ENV_PREFIX` and `APP_ENV_ALIASES` from this
+ * module — but the file still only exported the legacy `MILADY_ENV_ALIASES`
+ * name, so Rollup failed the static bind in the SPA build (deploy #38).
+ *
+ * Re-export the same shape under the upstream-canonical names. The prefix
+ * is the bare brand token; main.tsx uses it as a template literal for
+ * injection variable names (`__${APP_ENV_PREFIX}_API_BASE__`).
+ *
+ * Kept additive (rather than replacing `MILADY_ENV_ALIASES`) so the
+ * existing `brand-env.test.ts` still asserts against the legacy name.
+ */
+export const APP_ENV_PREFIX = "MILADY";
+export const APP_ENV_ALIASES = MILADY_ENV_ALIASES;


### PR DESCRIPTION
Deploy #38 (PR #180 merged) cleared the app-core ui-compat reexport and reached main.tsx, where Rollup hit:

```
error during build:
apps/app/src/main.tsx (136:9):
"APP_ENV_PREFIX" is not exported by "src/brand-env.ts"
```

**Root cause**: PR #150 (yesterday) brought the upstream baseline of main.tsx into alice. Upstream's main.tsx imports `APP_ENV_PREFIX` and `APP_ENV_ALIASES` from `./brand-env`. Alice's brand-env.ts still only exports the legacy `MILADY_ENV_ALIASES` table (Milady-specific naming from before the upstream main.tsx sync). Rollup fails the static bind.

main.tsx uses `APP_ENV_PREFIX` as a template literal segment:
```ts
apiBase: `__${APP_ENV_PREFIX}_API_BASE__`,
characterEditor: `__${APP_ENV_PREFIX}_CHARACTER_EDITOR__`,
shareQueue: `__${APP_ENV_PREFIX}_SHARE_QUEUE__`,
```

So it's a bare brand token. For alice/milady, that's `"MILADY"`.

**Fix**: additive exports under the upstream-canonical names:
```ts
export const APP_ENV_PREFIX = "MILADY";
export const APP_ENV_ALIASES = MILADY_ENV_ALIASES;
```

Kept additive (rather than renaming `MILADY_ENV_ALIASES`) so the existing `brand-env.test.ts` continues to assert against the legacy name. A later upstream-sync (the parallel `chore/upstream-milady-sync-2026-05-13` integration PR being prepared by the dispatched Opus agent) may consolidate to the dynamic `buildBrandEnvAliases(prefix)` upstream pattern — this minimal fix unblocks the deploy immediately.

After merge → trigger deploy #39.