### PR TITLE
fix(apps/app): import shouldUseCloudOnlyBranding from @elizaos/ui

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -124,7 +124,7 @@ import { useVincentState } from "@elizaos/app-vincent/ui";
 import "@elizaos/app-vincent/register";
 import "@elizaos/app-wallet/register";
 import "@elizaos/app-workflow-builder/register";
-import { shouldUseCloudOnlyBranding } from "@elizaos/app-core";
+import { shouldUseCloudOnlyBranding } from "@elizaos/ui";
 import {
   APP_BRANDING_BASE,
   APP_CONFIG,


### PR DESCRIPTION
Deploy #39 (PR #181 merged) cleared brand-env and hit:

```
error during build:
src/main.tsx (128:0):
"shouldUseCloudOnlyBranding" is not exported by
"../../eliza/packages/app-core/src/index.ts"
```

`shouldUseCloudOnlyBranding` is defined in:
- `eliza/packages/shared/src/config/cloud-only.ts` (re-exported via `@elizaos/shared` index)
- `eliza/packages/ui/src/config/cloud-only.ts` (re-exported via `@elizaos/ui` index line 17: `export * from "./config"`)

`@elizaos/app-core` does **not** export it — alice's prior import via app-core was working only accidentally or via a prior version since trimmed.

**Upstream's main.tsx** (`eliza/packages/app/src/main.tsx:128`) imports it from `@elizaos/ui`. Adopt the same source.

**One-line change**: `from "@elizaos/app-core"` → `from "@elizaos/ui"`. Semantically identical (same canonical file via different re-export chain). No alice-unique behavior lost — alice's local `apps/app/src/cloud-only.ts` is byte-identical to upstream's; the SPA just consumes via the workspace alias surface.

After merge → trigger deploy #40.