### PR TITLE
fix(apps/app): import ios-runtime helpers from @elizaos/ui

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -139,7 +139,7 @@ import {
   type IosRuntimeConfig,
   type IosRuntimeMode,
   resolveIosRuntimeConfig,
-} from "@elizaos/app-core";
+} from "@elizaos/ui";
 
 // CharacterEditor lives in alice's local @miladyai/app-core (the 2009-line
 // version is alice-specific; upstream eliza moved this component to


### PR DESCRIPTION
Deploy #40 cleared shouldUseCloudOnlyBranding (PR #182) and hit:

```
src/main.tsx (141:2):
"resolveIosRuntimeConfig" is not exported by
"eliza/packages/app-core/src/index.ts"
```

Same pattern as PR #182. The four ios-runtime names alice's main.tsx imports (`apiBaseToDeviceBridgeUrl`, `IosRuntimeConfig`, `IosRuntimeMode`, `resolveIosRuntimeConfig`) are defined in `eliza/packages/ui/src/platform/ios-runtime.ts` and re-exported by `@elizaos/ui` via `index.ts:31 → platform/index.ts:38`. Not exported by `@elizaos/app-core`.

Upstream's main.tsx (`eliza/packages/app/src/main.tsx:138-143`) imports these from `./ios-runtime` (sibling file). Alice doesn't have a local ios-runtime.ts — adopt `@elizaos/ui` as the source.

One-line import-path change, no semantic change.

After merge → trigger deploy #41.