### PR TITLE
fix(apps/app): import bridge helpers from @elizaos/ui

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -14,7 +14,7 @@ import {
   subscribeDesktopBridgeEvent,
   initializeStorageBridge,
   isElectrobunRuntime,
-} from "@elizaos/app-core";
+} from "@elizaos/ui";
 import type { BrandingConfig } from "@elizaos/app-core";
 import { MILADY_DEFAULT_THEME } from "@elizaos/shared";
 import {


### PR DESCRIPTION
Same surface gap as PR #182 / #183. Deploy #41 hit:

```
src/main.tsx (16:2):
"isElectrobunRuntime" is not exported by
"eliza/packages/app-core/src/index.ts"
```

All four names in this import block live under `eliza/packages/ui/src/bridge/`:
- `initializeCapacitorBridge` → `bridge/capacitor-bridge.ts`
- `subscribeDesktopBridgeEvent` → `bridge/electrobun-rpc.ts`
- `initializeStorageBridge` → `bridge/storage-bridge.ts`
- `isElectrobunRuntime` → `bridge/electrobun-runtime.ts`

`@elizaos/ui` re-exports via `index.ts:9 export * from "./bridge"`. `@elizaos/app-core` does not export any of these.

One-line import-path change, no semantic change. Surgical fix unblocking the deploy iteration; PR #184 (integration agent) may consolidate this and other similar imports later.

After merge → trigger deploy #42.