### PR TITLE
fix(patcher): bridge full @elizaos/ui surface through @elizaos/app-core

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -800,6 +800,100 @@ export function applyAliceCoreBrowserRuntimeEnvReexportPatch({
   return "applied";
 }
 
+const appCoreIndexRelativePath = "packages/app-core/src/index.ts";
+const appCoreUiFullReexportSentinel =
+  "// [milaidy:app-core-ui-full-reexport]";
+const appCoreUiFullReexport = `${appCoreUiFullReexportSentinel}
+// Bridge the full @elizaos/ui surface through @elizaos/app-core, mirroring
+// upstream-milady's eliza/packages/app-core/src/browser.ts line 1
+// (\`export * from "@elizaos/ui"\`).
+//
+// Why: alice's main.tsx has 11 import blocks of the form
+// \`import { ... } from "@elizaos/app-core"\` covering ~50 value+type names
+// (App, ErrorBoundary, client, AppBootConfig, getBootConfig, dispatchAppEvent,
+// AGENT_READY_EVENT, applyForceFreshOnboardingReset, isAppWindowRoute,
+// resolveWindowShellRoute, DESKTOP_TRAY_MENU_ITEMS, DesktopTrayRuntime,
+// DetachedShellRoot, AppProvider, applyUiTheme, loadUiTheme, AppWindowRenderer,
+// BrandingConfig type, etc.). Almost all of these names live in
+// \`@elizaos/ui\`, not \`@elizaos/app-core\`. Upstream-milady's main.tsx
+// works because its package.json exports map \`@elizaos/app-core\` to
+// \`browser.ts\` for browser builds, which re-exports the whole ui surface.
+//
+// Alice's pinned eliza (30c595e10ea5) has the older package.json export
+// map that resolves \`@elizaos/app-core\` to \`src/index.ts\` directly,
+// bypassing browser.ts. The result: every one of those 11 import blocks
+// fails the Rollup static bind on the SPA build, surfacing one missing
+// name per deploy iteration.
+//
+// Append the same wildcard re-export to alice's pinned app-core/src/index.ts
+// to bridge the gap. PR #180's \`applyAliceAppCoreUiCompatReexportPatch\`
+// (\`export * from "./ui-compat"\`) is a narrow subset of this surface
+// (~30 names); this patch is the comprehensive companion. Duplicates with
+// ui-compat are harmless at runtime (both routes resolve to the same
+// @elizaos/ui source).
+//
+// Browser safety: \`@elizaos/ui\` is the UI package — fully browser-safe by
+// design. No node:* imports flow into the SPA via this re-export.
+export * from "@elizaos/ui";
+
+// Disambiguation: \`./registry\` and \`@elizaos/ui\` both export \`ConfigField\`
+// and \`getPlugins\` with DIFFERENT declarations. \`./registry\` has the
+// Zod-inferred type for plugin config schema fields and a registry loader
+// helper; \`@elizaos/ui\` has a React component and a bridge helper.
+// Wildcard \`export *\` from two sources with the same names → TS2308
+// "Module has already exported a member named ..." build error. Mirror the
+// disambiguation pattern from upstream-milady's eliza/packages/app-core/
+// src/browser.ts line ~51 which pins the registry side explicitly.
+export { type ConfigField, getPlugins } from "./registry";
+
+// DesktopOnboardingRuntime is consumed by alice's apps/app/src/main.tsx
+// block 8 alongside DESKTOP_TRAY_MENU_ITEMS / DesktopSurfaceNavigationRuntime
+// / DesktopTrayRuntime / DetachedShellRoot. The latter four flow through
+// the \`export * from "@elizaos/ui"\` above (they live in
+// eliza/packages/ui/src/desktop-runtime/). DesktopOnboardingRuntime does
+// NOT exist in @elizaos/ui — upstream's eliza/packages/app-core/src/
+// browser.ts line ~62 emits it as a no-op stub. Mirror that here so the
+// SPA bind for alice's main.tsx block 8 resolves without throwing.
+// Runtime impact: nothing — alice's actual desktop onboarding runtime
+// lives in its local packages/app-core/src/shell/DesktopOnboardingRuntime.tsx
+// and is referenced through the desktop runtime mount path, not through
+// this barrel export. The barrel-bound value is only reached if a SPA
+// code path constructs the imported reference directly.
+export const DesktopOnboardingRuntime = (): null => null;
+`;
+
+export function isAliceAppCoreUiFullReexportPatched(source) {
+  return source.includes(appCoreUiFullReexportSentinel);
+}
+
+export function applyAliceAppCoreUiFullReexportPatch({
+  elizaRoot,
+  log = console.log,
+} = {}) {
+  const indexPath = path.join(elizaRoot, appCoreIndexRelativePath);
+  if (!existsSync(indexPath)) {
+    log(
+      "[alice-eliza-runtime-patches] eliza app-core source absent; skipping app-core ui-full reexport patch",
+    );
+    return "skipped";
+  }
+  const source = readFileSync(indexPath, "utf8");
+  if (isAliceAppCoreUiFullReexportPatched(source)) {
+    log(
+      "[alice-eliza-runtime-patches] app-core ui-full reexport already applied",
+    );
+    return "already-applied";
+  }
+  const next = source.endsWith("\n")
+    ? `${source}\n${appCoreUiFullReexport}`
+    : `${source}\n\n${appCoreUiFullReexport}`;
+  writeFileSync(indexPath, next);
+  log(
+    "[alice-eliza-runtime-patches] patched eliza app-core/src/index.ts to re-export the full @elizaos/ui surface (mirrors upstream's browser.ts pattern; bridges ~50 names main.tsx imports from @elizaos/app-core)",
+  );
+  return "applied";
+}
+
 const appCoreUiCompatReexportRelativePath = "packages/app-core/src/index.ts";
 const appCoreUiCompatReexportSentinel =
   "// [milaidy:app-core-ui-compat-reexport]";
@@ -3044,6 +3138,7 @@ export function applyAliceElizaRuntimePatches({
     applyAliceCoreBrowserCloudTopologyReexportPatch({ elizaRoot, log }),
     applyAliceCoreBrowserSpokenTextReexportPatch({ elizaRoot, log }),
     applyAliceAppCoreUiCompatReexportPatch({ elizaRoot, log }),
+    applyAliceAppCoreUiFullReexportPatch({ elizaRoot, log }),
     applyAliceCoreBuildBrowserExternalsPatch({ elizaRoot, log }),
     applyAliceCoreBuildBrowserExternalsMammothPatch({ elizaRoot, log }),
     applyAliceAppViteStubMammothPatch({ elizaRoot, log }),


### PR DESCRIPTION
Deploy iteration #38 → #42 has been one-name-at-a-time fixing missing exports on `@elizaos/app-core` (PR #182 shouldUseCloudOnlyBranding, PR #183 ios-runtime helpers, PR #185 bridge helpers, now `resolveWindowShellRoute` on #42).

**Audit of ALL `@elizaos/app-core` imports** in `apps/app/src/main.tsx` found 11 import blocks covering ~50 names. Almost all of these names live in `@elizaos/ui`.

**Root cause (structural)**: upstream-milady's `eliza/packages/app-core/src/browser.ts` line 1: `export * from "@elizaos/ui"`. Their `package.json` resolves `@elizaos/app-core` to `browser.ts` for browser builds. Alice's pinned eliza (`30c595e10ea5`) lacks the `browser` exports entry — SPA imports resolve directly to `src/index.ts`, missing the ui surface.

**Fix**: new patcher `applyAliceAppCoreUiFullReexportPatch` appends three things to alice's pinned `eliza/packages/app-core/src/index.ts`:

1. `export * from "@elizaos/ui"` — bridges the full UI surface
2. **Disambiguation epilogue** (per reviewer fix): explicit named re-export of `ConfigField` and `getPlugins` from `./registry` to resolve TS2308 collisions with @elizaos/ui's identically-named React component + bridge helper. Mirrors upstream's browser.ts:51 pattern.
3. **No-op stub for `DesktopOnboardingRuntime`** (per reviewer fix): consumed by main.tsx block 8 but not in @elizaos/ui (lives only in alice's local `packages/app-core/src/shell/`). Stub matches upstream browser.ts:62 form. Real runtime is reached via the desktop runtime mount path, not the barrel.

Sentinel `// [milaidy:app-core-ui-full-reexport]` for idempotence. Wired into mainline dispatch alongside PR #180's narrower `./ui-compat` re-export (complementary).

**Browser safety**: @elizaos/ui is the UI package, fully browser-safe. No `node:*` imports flow in. Verified by upstream-milady's use of the same pattern.

PRs #182/#183/#185 (moved imports to `@elizaos/ui` directly) remain correct and complementary — source-of-truth imports + this structural bridge for any other paths.

After merge → trigger deploy #43. Expectation: this should clear the 11-block iteration in one shot.