### PR TITLE
fix(apps/app): export APP_CHARACTER_CATALOG alias from character-catalog.ts

### DIFF
--- a/apps/app/src/character-catalog.ts
+++ b/apps/app/src/character-catalog.ts
@@ -6,3 +6,18 @@ import { buildMiladyCharacterCatalog } from "@miladyai/shared/onboarding-presets
 
 export const MILADY_CHARACTER_CATALOG: CharacterCatalogData =
   buildMiladyCharacterCatalog() as CharacterCatalogData;
+
+/**
+ * Upstream-compatible alias for the generic boot config surface.
+ *
+ * PR #150 brought the upstream baseline of `apps/app/src/main.tsx` into
+ * alice. Upstream's main.tsx imports `APP_CHARACTER_CATALOG` from
+ * `./character-catalog` — but alice's file still only exports the legacy
+ * `MILADY_CHARACTER_CATALOG` name. Rollup fails the static bind in the
+ * SPA build (deploy #43).
+ *
+ * Same additive shape as PR #181's `APP_ENV_PREFIX` / `APP_ENV_ALIASES`
+ * aliases in `brand-env.ts`: keep `MILADY_*` as the canonical alice
+ * symbol, expose `APP_*` as the upstream-name alias.
+ */
+export const APP_CHARACTER_CATALOG = MILADY_CHARACTER_CATALOG;


### PR DESCRIPTION
Deploy #43 (PR #186 merged — full @elizaos/ui surface now flows through @elizaos/app-core) cleared every `@elizaos/app-core` import gap in main.tsx. Vite hit:

```
src/main.tsx (137:0):
"APP_CHARACTER_CATALOG" is not exported by "src/character-catalog.ts"
```

Same pattern as PR #181 (`APP_ENV_PREFIX` / `APP_ENV_ALIASES` in `brand-env.ts`). PR #150 brought the upstream baseline of `main.tsx` into alice — upstream imports `APP_CHARACTER_CATALOG` from `./character-catalog`. Alice's file still only exports the legacy `MILADY_CHARACTER_CATALOG` name.

**Two-line additive fix**:
```ts
export const APP_CHARACTER_CATALOG = MILADY_CHARACTER_CATALOG;
```

Keeps the canonical milady symbol intact; surfaces the upstream-name alias the upstream baseline main.tsx expects. After merge → trigger deploy #44.