### PR TITLE
fix(patcher): disambiguate MessageExample between onboarding and types/agent

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -1093,6 +1093,59 @@ export function applyAliceCoreBrowserSettingsDebugReexportPatch({
   return "applied";
 }
 
+const coreBrowserOnboardingTypesDisambiguateSentinel =
+  "// [milaidy:core-browser-onboarding-types-disambiguate]";
+const coreBrowserOnboardingTypesDisambiguate = `${coreBrowserOnboardingTypesDisambiguateSentinel}
+// Pin MessageExample to types/agent to resolve TS2308 ambiguity.
+//
+// Two different MessageExample interfaces exist in @elizaos/core and
+// both reach this barrel:
+//   types/agent           { name: string;  content: Content }
+//   contracts/onboarding  { user: string;  content: MessageExampleContent }
+// Different field names, different content type. types/agent is the
+// canonical agent surface consumed by the Character + Agent types and
+// by downstream eliza-cli / app-core / runtime-boot. The onboarding
+// MessageExample is a narrower shape used only inside the onboarding
+// flow definitions.
+//
+// Explicit named export wins over wildcard re-exports for TS resolution,
+// so this pin selects the agent-canonical interface regardless of
+// wildcard ordering.
+export type { MessageExample } from "./types/agent";
+`;
+
+export function isAliceCoreBrowserOnboardingTypesDisambiguatePatched(source) {
+  return source.includes(coreBrowserOnboardingTypesDisambiguateSentinel);
+}
+
+export function applyAliceCoreBrowserOnboardingTypesDisambiguatePatch({
+  elizaRoot,
+  log = console.log,
+} = {}) {
+  const indexPath = path.join(elizaRoot, coreBrowserIndexRelativePath);
+  if (!existsSync(indexPath)) {
+    log(
+      "[alice-eliza-runtime-patches] eliza core source absent; skipping core-browser onboarding/types disambiguate patch",
+    );
+    return "skipped";
+  }
+  const source = readFileSync(indexPath, "utf8");
+  if (isAliceCoreBrowserOnboardingTypesDisambiguatePatched(source)) {
+    log(
+      "[alice-eliza-runtime-patches] core-browser onboarding/types disambiguate already applied",
+    );
+    return "already-applied";
+  }
+  const next = source.endsWith("\n")
+    ? `${source}\n${coreBrowserOnboardingTypesDisambiguate}`
+    : `${source}\n\n${coreBrowserOnboardingTypesDisambiguate}`;
+  writeFileSync(indexPath, next);
+  log(
+    "[alice-eliza-runtime-patches] patched core index.browser.ts with onboarding/types MessageExample disambiguation epilogue",
+  );
+  return "applied";
+}
+
 const coreBrowserOnboardingReexportSentinel =
   "// [milaidy:core-browser-onboarding-reexport]";
 const coreBrowserOnboardingReexport = `${coreBrowserOnboardingReexportSentinel}
@@ -3137,6 +3190,9 @@ export function applyAliceElizaRuntimePatches({
     applyAliceCoreBrowserSettingsDebugReexportPatch({ elizaRoot, log }),
     applyAliceCoreBrowserCloudTopologyReexportPatch({ elizaRoot, log }),
     applyAliceCoreBrowserSpokenTextReexportPatch({ elizaRoot, log }),
+    // Must run AFTER all the core-browser wildcard re-exports above so the
+    // disambiguation appears last in the file and wins for TS resolution.
+    applyAliceCoreBrowserOnboardingTypesDisambiguatePatch({ elizaRoot, log }),
     applyAliceAppCoreUiCompatReexportPatch({ elizaRoot, log }),
     applyAliceAppCoreUiFullReexportPatch({ elizaRoot, log }),
     applyAliceCoreBuildBrowserExternalsPatch({ elizaRoot, log }),


### PR DESCRIPTION
Deploy #44 got past the missing-import iteration (PR #186's structural ui-bridge cleared the @elizaos/app-core class). The build reached the type-build phase, where eliza/packages/core's `bun run build` failed with:

```
src/index.browser.ts(169,1): error TS2308:
Module "./types" has already exported a member named 'MessageExample'.
Consider explicitly re-exporting to resolve the ambiguity.
```

**Root cause**: PR #173's `applyAliceCoreBrowserOnboardingReexportPatch` appended `export * from "./contracts/onboarding"` to index.browser.ts. onboarding.ts:153 declares its own `export interface MessageExample`. The pre-existing `export * from "./types"` (line ~169) surfaces a different `MessageExample` from `types/agent.ts:17`. TS2308.

**Fix**: same disambiguation pattern as PR #186 (for `ConfigField`/`getPlugins` in app-core/src/index.ts). New patcher `applyAliceCoreBrowserOnboardingTypesDisambiguatePatch` appends `export type { MessageExample } from "./types/agent"` to index.browser.ts. Sentinel `// [milaidy:core-browser-onboarding-types-disambiguate]`. Wired AFTER all core-browser wildcards so it lands last and wins for TypeScript resolution.

**Proactive audit**: cross-referenced 62 onboarding exports against 714 types/* exports via Python set intersection — `MessageExample` is the ONLY collision. Other patchers (runtime-env, settings-debug, cloud-topology, spoken-text) audited too — zero overlap.

After merge → trigger deploy #45.