### PR TITLE
fix(patcher): direct re-export AGENT_EVENT_ALLOWED_STREAMS from plugin-discovery-helpers

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -1153,31 +1153,34 @@ const agentDiscoveryHelpersDirectReexport = `${agentDiscoveryHelpersDirectReexpo
 /* Direct re-export of plugin-discovery-helpers symbols from index.ts,
  * bypassing the indirect chain through ./api/server.ts.
  *
- * Upstream eliza/packages/agent/src/index.ts already declares an indirect
- * re-export of AGENT_EVENT_ALLOWED_STREAMS (and 5 siblings) via
+ * Upstream eliza/packages/agent/src/index.ts re-exports
+ * AGENT_EVENT_ALLOWED_STREAMS, CONFIG_WRITE_ALLOWED_TOP_KEYS,
+ * discoverInstalledPlugins, and discoverPluginsFromManifest via
  * \`export { ... } from "./api/server.ts"\`, which itself re-exports those
- * names from "./api/plugin-discovery-helpers.ts". Under Node + tsx at
- * runtime (the production container), Node fails to surface the
- * AGENT_EVENT_ALLOWED_STREAMS export through that two-hop chain —
- * \`dist/entry.js\` errors at module instantiation with:
+ * names from "./api/plugin-discovery-helpers.ts" — a two-hop indirect
+ * re-export. Under Node + tsx at runtime (the production container),
+ * Node fails to surface AGENT_EVENT_ALLOWED_STREAMS through that two-hop
+ * chain — \`dist/entry.js\` errors at module instantiation with:
  *   SyntaxError: The requested module '@elizaos/agent' does not provide
  *   an export named 'AGENT_EVENT_ALLOWED_STREAMS'
  *
- * Re-exporting the same six names DIRECTLY from helpers.ts adds a
- * one-hop indirect re-export alongside the existing two-hop one. Both
- * resolve to the same binding in helpers.ts, so ESM accepts the
- * duplicate indirect re-export and the importer's name lookup succeeds.
+ * Re-exporting these names DIRECTLY from helpers.ts adds a one-hop
+ * indirect re-export from a DIFFERENT module specifier (helpers.ts)
+ * alongside the existing two-hop one (server.ts). Both resolve to the
+ * same binding in helpers.ts, so ESM accepts the duplicate as an
+ * indirect export resolution and the importer's name lookup succeeds.
  *
- * The names are kept in sync with the \`export { ... } from
- * "./plugin-discovery-helpers.ts"\` block at \`./api/server.ts\` —
- * anything added or removed there should be mirrored here. */
+ * findPrimaryEnvKey and readBundledPluginPackageMetadata — also
+ * re-exported by server.ts from helpers.ts — are intentionally OMITTED
+ * here because upstream's index.ts ALREADY direct-re-exports them from
+ * the same module specifier at \`./api/plugin-discovery-helpers.ts\`
+ * (lines 54-57). Adding them again would be a same-specifier same-name
+ * duplicate export and ESM rejects that at parse time. */
 export {
 \tAGENT_EVENT_ALLOWED_STREAMS,
 \tCONFIG_WRITE_ALLOWED_TOP_KEYS,
 \tdiscoverInstalledPlugins,
 \tdiscoverPluginsFromManifest,
-\tfindPrimaryEnvKey,
-\treadBundledPluginPackageMetadata,
 } from "./api/plugin-discovery-helpers.ts";
 `;
 
@@ -1208,7 +1211,7 @@ export function applyAliceAgentDiscoveryHelpersDirectReexportPatch({
     : `${source}\n\n${agentDiscoveryHelpersDirectReexport}`;
   writeFileSync(indexPath, next);
   log(
-    "[alice-eliza-runtime-patches] patched agent/src/index.ts with direct re-export of plugin-discovery-helpers (AGENT_EVENT_ALLOWED_STREAMS + 5 siblings) to bypass two-hop chain failure under Node+tsx",
+    "[alice-eliza-runtime-patches] patched agent/src/index.ts with direct re-export of plugin-discovery-helpers (AGENT_EVENT_ALLOWED_STREAMS + 3 siblings via two-hop chain through server.ts) to bypass Node+tsx chain failure",
   );
   return "applied";
 }

--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -32,6 +32,7 @@ const appViteNativeStubRelativePath =
 const agentRuntimeRelativePath = "packages/agent/src/runtime/eliza.ts";
 const agentPluginResolverRelativePath =
   "packages/agent/src/runtime/plugin-resolver.ts";
+const agentIndexRelativePath = "packages/agent/src/index.ts";
 const pluginSqlPgliteManagerRelativePath =
   "plugins/plugin-sql/typescript/pglite/manager.ts";
 const lifeOpsSourceRelativePaths = [
@@ -1142,6 +1143,72 @@ export function applyAliceCoreBrowserOnboardingTypesDisambiguatePatch({
   writeFileSync(indexPath, next);
   log(
     "[alice-eliza-runtime-patches] patched core index.browser.ts with onboarding/types MessageExample disambiguation epilogue",
+  );
+  return "applied";
+}
+
+const agentDiscoveryHelpersDirectReexportSentinel =
+  "// [milaidy:agent-index-discovery-helpers-direct-reexport]";
+const agentDiscoveryHelpersDirectReexport = `${agentDiscoveryHelpersDirectReexportSentinel}
+/* Direct re-export of plugin-discovery-helpers symbols from index.ts,
+ * bypassing the indirect chain through ./api/server.ts.
+ *
+ * Upstream eliza/packages/agent/src/index.ts already declares an indirect
+ * re-export of AGENT_EVENT_ALLOWED_STREAMS (and 5 siblings) via
+ * \`export { ... } from "./api/server.ts"\`, which itself re-exports those
+ * names from "./api/plugin-discovery-helpers.ts". Under Node + tsx at
+ * runtime (the production container), Node fails to surface the
+ * AGENT_EVENT_ALLOWED_STREAMS export through that two-hop chain —
+ * \`dist/entry.js\` errors at module instantiation with:
+ *   SyntaxError: The requested module '@elizaos/agent' does not provide
+ *   an export named 'AGENT_EVENT_ALLOWED_STREAMS'
+ *
+ * Re-exporting the same six names DIRECTLY from helpers.ts adds a
+ * one-hop indirect re-export alongside the existing two-hop one. Both
+ * resolve to the same binding in helpers.ts, so ESM accepts the
+ * duplicate indirect re-export and the importer's name lookup succeeds.
+ *
+ * The names are kept in sync with the \`export { ... } from
+ * "./plugin-discovery-helpers.ts"\` block at \`./api/server.ts\` —
+ * anything added or removed there should be mirrored here. */
+export {
+\tAGENT_EVENT_ALLOWED_STREAMS,
+\tCONFIG_WRITE_ALLOWED_TOP_KEYS,
+\tdiscoverInstalledPlugins,
+\tdiscoverPluginsFromManifest,
+\tfindPrimaryEnvKey,
+\treadBundledPluginPackageMetadata,
+} from "./api/plugin-discovery-helpers.ts";
+`;
+
+export function isAliceAgentDiscoveryHelpersDirectReexportPatched(source) {
+  return source.includes(agentDiscoveryHelpersDirectReexportSentinel);
+}
+
+export function applyAliceAgentDiscoveryHelpersDirectReexportPatch({
+  elizaRoot,
+  log = console.log,
+} = {}) {
+  const indexPath = path.join(elizaRoot, agentIndexRelativePath);
+  if (!existsSync(indexPath)) {
+    log(
+      "[alice-eliza-runtime-patches] eliza agent source absent; skipping agent-index discovery-helpers direct-reexport patch",
+    );
+    return "skipped";
+  }
+  const source = readFileSync(indexPath, "utf8");
+  if (isAliceAgentDiscoveryHelpersDirectReexportPatched(source)) {
+    log(
+      "[alice-eliza-runtime-patches] agent-index discovery-helpers direct-reexport already applied",
+    );
+    return "already-applied";
+  }
+  const next = source.endsWith("\n")
+    ? `${source}\n${agentDiscoveryHelpersDirectReexport}`
+    : `${source}\n\n${agentDiscoveryHelpersDirectReexport}`;
+  writeFileSync(indexPath, next);
+  log(
+    "[alice-eliza-runtime-patches] patched agent/src/index.ts with direct re-export of plugin-discovery-helpers (AGENT_EVENT_ALLOWED_STREAMS + 5 siblings) to bypass two-hop chain failure under Node+tsx",
   );
   return "applied";
 }
@@ -3193,6 +3260,7 @@ export function applyAliceElizaRuntimePatches({
     // Must run AFTER all the core-browser wildcard re-exports above so the
     // disambiguation appears last in the file and wins for TS resolution.
     applyAliceCoreBrowserOnboardingTypesDisambiguatePatch({ elizaRoot, log }),
+    applyAliceAgentDiscoveryHelpersDirectReexportPatch({ elizaRoot, log }),
     applyAliceAppCoreUiCompatReexportPatch({ elizaRoot, log }),
     applyAliceAppCoreUiFullReexportPatch({ elizaRoot, log }),
     applyAliceCoreBuildBrowserExternalsPatch({ elizaRoot, log }),


### PR DESCRIPTION
## Summary

- Pod crashes at startup with `SyntaxError: The requested module '@elizaos/agent' does not provide an export named 'AGENT_EVENT_ALLOWED_STREAMS'`
- Upstream re-exports the name via a two-hop chain (`index.ts` → `./api/server.ts` → `./api/plugin-discovery-helpers.ts`) but Node+tsx fails to surface it through that chain at runtime
- Patcher now appends a direct one-hop re-export of `AGENT_EVENT_ALLOWED_STREAMS` and 5 sibling names (`CONFIG_WRITE_ALLOWED_TOP_KEYS`, `discoverInstalledPlugins`, `discoverPluginsFromManifest`, `findPrimaryEnvKey`, `readBundledPluginPackageMetadata`) from `plugin-discovery-helpers.ts` directly to `eliza/packages/agent/src/index.ts`
- ESM allows the duplicate indirect re-export since both resolve to the same binding

## Context

Deploy #46 made it through every prior blocker — vite SPA build, package materialization, runtime image guard parse fix, ECR push, EKS rollout. The image now boots, but the eliza source-mode ESM chain failure surfaces at module instantiation. This patch is the last known blocker keeping the alice pod in CrashLoopBackOff.

## Test plan

- [x] `node --check scripts/apply-alice-eliza-runtime-patches.mjs` parses
- [x] Local dry-apply: patcher writes the sentinel-guarded block to `eliza/packages/agent/src/index.ts`
- [x] Idempotence: re-running returns `already-applied`
- [ ] Deploy #47 boots the pod (verify via `kubectl get pods` and curl staging URL)