### PR TITLE
fix(packages/agent): re-export plugin-discovery-helpers from api/index — actual root cause

### DIFF
--- a/packages/agent/src/api/index.ts
+++ b/packages/agent/src/api/index.ts
@@ -39,6 +39,7 @@ export * from "./nft-verify.js";
 export * from "./og-tracker.js";
 export * from "./parse-action-block.js";
 export * from "./permissions-routes.js";
+export * from "./plugin-discovery-helpers.js";
 export * from "./plugin-validation.js";
 export * from "./provider-switch-config.js";
 export * from "./registry-routes.js";


### PR DESCRIPTION
## Summary

The runtime `@elizaos/agent` resolution surface — not the upstream eliza submodule — is missing `AGENT_EVENT_ALLOWED_STREAMS` and its 3 siblings. Root cause traced via container inspection of deploy #48's image (`sha-be08622-milaidy-5f0fecb-build-4f1f549e`):

- **`/app/milaidy/node_modules/@elizaos/agent/`** is milaidy's own `packages/agent` (its `package.json` literally says `"name": "@miladyai/agent"`), NOT the upstream eliza submodule.
- Milaidy's `packages/agent/src/index.ts` is an 18-line wildcard chain (`export * from "./api/index.js"` etc.) and does NOT surface `plugin-discovery-helpers`.
- At BUILD time, tsdown resolves `@elizaos/agent` to upstream eliza's long index.ts (which has the names) — so the build succeeds and `dist/entry.js` ships with `import { AGENT_EVENT_ALLOWED_STREAMS, ... } from "@elizaos/agent"`.
- At RUNTIME, Node resolves `@elizaos/agent` to milaidy's own package — the names aren't there → `SyntaxError: The requested module '@elizaos/agent' does not provide an export named 'AGENT_EVENT_ALLOWED_STREAMS'`.

This is why PRs #189 and #190 (which patched the upstream eliza submodule's `eliza/packages/agent/src/index.ts`) didn't fix the crash — the patcher targeted the wrong file.

## Change

Add one line to `packages/agent/src/api/index.ts`:

```diff
+export * from "./plugin-discovery-helpers.js";
```

The wildcard surfaces all of `plugin-discovery-helpers.ts`'s exports — `AGENT_EVENT_ALLOWED_STREAMS`, `CONFIG_WRITE_ALLOWED_TOP_KEYS`, `discoverInstalledPlugins`, `discoverPluginsFromManifest`, `findPrimaryEnvKey`, `readBundledPluginPackageMetadata`, plus ~28 sibling helpers — through `./api/index.js → ./index.ts` to the top-level `@miladyai/agent` (and therefore the node_modules/@elizaos/agent the runtime resolves).

## Why a wildcard

The pattern is already used throughout `api/index.ts` — most siblings (`agent-admin-routes`, `apps-routes`, `auth-routes`, …) come in via `export * from`. Wildcards are the established pattern in this file. And the runtime evidence is unambiguous: `ACCOUNT_CREDENTIAL_PROVIDER_IDS` (the FIRST name in dist/entry.js's import list) DOES resolve correctly — it travels through a wildcard re-export chain. So wildcards work; named-through-named two-hop chains don't (which is why PR #189/#190's patching of upstream's `from "./api/server.ts"` chain wasn't load-bearing).

## What happens to PRs #189 and #190

They remain in the patcher script as defensive infrastructure for the case where the runtime resolution flips back to upstream eliza (e.g. if the materialize step changes), but they are not the load-bearing fix and can be reverted later if cleanup is desired.

## Test plan

- [x] Single-line change in an already-wildcard-heavy file — minimal blast radius
- [ ] Deploy #49 boots the pod without `AGENT_EVENT_ALLOWED_STREAMS` error
- [ ] If a NEXT name fails (e.g. one of the dist/entry.js imports that comes from a different file not re-exported by milaidy's api/index), iterate with another wildcard