### PR TITLE
revert(patcher): drop agent-index discovery-helpers patch from #189/#190 — no-op against actual runtime

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -32,7 +32,6 @@ const appViteNativeStubRelativePath =
 const agentRuntimeRelativePath = "packages/agent/src/runtime/eliza.ts";
 const agentPluginResolverRelativePath =
   "packages/agent/src/runtime/plugin-resolver.ts";
-const agentIndexRelativePath = "packages/agent/src/index.ts";
 const pluginSqlPgliteManagerRelativePath =
   "plugins/plugin-sql/typescript/pglite/manager.ts";
 const lifeOpsSourceRelativePaths = [
@@ -1143,101 +1142,6 @@ export function applyAliceCoreBrowserOnboardingTypesDisambiguatePatch({
   writeFileSync(indexPath, next);
   log(
     "[alice-eliza-runtime-patches] patched core index.browser.ts with onboarding/types MessageExample disambiguation epilogue",
-  );
-  return "applied";
-}
-
-const agentDiscoveryHelpersDirectReexportSentinel =
-  "// [milaidy:agent-index-discovery-helpers-direct-reexport]";
-const agentDiscoveryHelpersDirectReexport = `${agentDiscoveryHelpersDirectReexportSentinel}
-/* Direct re-export of plugin-discovery-helpers symbols from index.ts.
- *
- * The 4 names below — AGENT_EVENT_ALLOWED_STREAMS, CONFIG_WRITE_ALLOWED_TOP_KEYS,
- * discoverInstalledPlugins, discoverPluginsFromManifest — were originally
- * re-exported by index.ts via \`export { ... } from "./api/server.ts"\`, which
- * itself re-exports those names from "./api/plugin-discovery-helpers.ts".
- * That two-hop indirect re-export chain fails under Node + tsx at runtime
- * (the production container) — \`dist/entry.js\` errors at module instantiation:
- *   SyntaxError: The requested module '@elizaos/agent' does not provide
- *   an export named 'AGENT_EVENT_ALLOWED_STREAMS'
- *
- * The fix is two-part:
- *   1. Remove these 4 names from the original \`from "./api/server.ts"\`
- *      block (handled by the patcher with a sed-style removal).
- *   2. Add a direct one-hop indirect re-export from helpers.ts here.
- *
- * findPrimaryEnvKey and readBundledPluginPackageMetadata are NOT included
- * — upstream's index.ts already direct-re-exports them from
- * \`./api/plugin-discovery-helpers.ts\` at lines 54-57, so a second
- * same-specifier same-name export here would be a parse-time duplicate. */
-export {
-\tAGENT_EVENT_ALLOWED_STREAMS,
-\tCONFIG_WRITE_ALLOWED_TOP_KEYS,
-\tdiscoverInstalledPlugins,
-\tdiscoverPluginsFromManifest,
-} from "./api/plugin-discovery-helpers.ts";
-`;
-
-const agentDiscoveryHelpersTwoHopNames = [
-  "AGENT_EVENT_ALLOWED_STREAMS",
-  "CONFIG_WRITE_ALLOWED_TOP_KEYS",
-  "discoverInstalledPlugins",
-  "discoverPluginsFromManifest",
-];
-
-export function isAliceAgentDiscoveryHelpersDirectReexportPatched(source) {
-  return source.includes(agentDiscoveryHelpersDirectReexportSentinel);
-}
-
-function removeNamesFromAgentServerReexportBlock(source) {
-  // Strip the 4 names from the existing
-  //   \`export { ... } from "./api/server.ts";\`
-  // block at index.ts:64-94, but only the lines that match
-  // \`  <name>,\n\` exactly (the upstream's 2-space indent + trailing
-  // comma + newline). A line that drifted shape (e.g. extra whitespace,
-  // an inline comment) is left alone — the patch loudly fails by leaving
-  // the duplicate in place rather than corrupting the file.
-  let next = source;
-  for (const name of agentDiscoveryHelpersTwoHopNames) {
-    const line = `  ${name},\n`;
-    if (next.includes(line)) {
-      next = next.replace(line, "");
-    }
-  }
-  return next;
-}
-
-export function applyAliceAgentDiscoveryHelpersDirectReexportPatch({
-  elizaRoot,
-  log = console.log,
-} = {}) {
-  const indexPath = path.join(elizaRoot, agentIndexRelativePath);
-  if (!existsSync(indexPath)) {
-    log(
-      "[alice-eliza-runtime-patches] eliza agent source absent; skipping agent-index discovery-helpers direct-reexport patch",
-    );
-    return "skipped";
-  }
-  const source = readFileSync(indexPath, "utf8");
-  if (isAliceAgentDiscoveryHelpersDirectReexportPatched(source)) {
-    log(
-      "[alice-eliza-runtime-patches] agent-index discovery-helpers direct-reexport already applied",
-    );
-    return "already-applied";
-  }
-  // Step 1: remove the 4 names from the upstream two-hop server.ts block,
-  // so they have exactly ONE re-export path (the direct one appended next).
-  const stripped = removeNamesFromAgentServerReexportBlock(source);
-  const removedCount = agentDiscoveryHelpersTwoHopNames.filter(
-    (name) => source.includes(`  ${name},\n`) && !stripped.includes(`  ${name},\n`),
-  ).length;
-  // Step 2: append the direct one-hop re-export from helpers.ts.
-  const next = stripped.endsWith("\n")
-    ? `${stripped}\n${agentDiscoveryHelpersDirectReexport}`
-    : `${stripped}\n\n${agentDiscoveryHelpersDirectReexport}`;
-  writeFileSync(indexPath, next);
-  log(
-    `[alice-eliza-runtime-patches] patched agent/src/index.ts: removed ${removedCount}/4 names from the two-hop ./api/server.ts re-export block and added a direct one-hop re-export from ./api/plugin-discovery-helpers.ts (AGENT_EVENT_ALLOWED_STREAMS + 3 siblings) — fixes Node+tsx chain failure`,
   );
   return "applied";
 }
@@ -3289,7 +3193,6 @@ export function applyAliceElizaRuntimePatches({
     // Must run AFTER all the core-browser wildcard re-exports above so the
     // disambiguation appears last in the file and wins for TS resolution.
     applyAliceCoreBrowserOnboardingTypesDisambiguatePatch({ elizaRoot, log }),
-    applyAliceAgentDiscoveryHelpersDirectReexportPatch({ elizaRoot, log }),
     applyAliceAppCoreUiCompatReexportPatch({ elizaRoot, log }),
     applyAliceAppCoreUiFullReexportPatch({ elizaRoot, log }),
     applyAliceCoreBuildBrowserExternalsPatch({ elizaRoot, log }),


### PR DESCRIPTION
## Summary

Reverts the patcher functions added by PRs #189 and #190. They mutate `eliza/packages/agent/src/index.ts` (upstream submodule) at every deploy, but that file is never the runtime resolution target for `@elizaos/agent`. The deploy script's materialize step explicitly overwrites `node_modules/@elizaos/agent` with milaidy's own `packages/agent` content via:

```
materialize_pkg "@elizaos/agent" "packages/agent" "src/index.ts"
```

So PRs #189/#190 ran every deploy and produced zero runtime effect.

## What this PR removes

- `agentIndexRelativePath` constant
- `agentDiscoveryHelpersDirectReexportSentinel`
- `agentDiscoveryHelpersDirectReexport` template
- `agentDiscoveryHelpersTwoHopNames` array
- `isAliceAgentDiscoveryHelpersDirectReexportPatched` function
- `removeNamesFromAgentServerReexportBlock` helper
- `applyAliceAgentDiscoveryHelpersDirectReexportPatch` function
- Orchestrator wire-up at `applyAliceElizaRuntimePatches`

Net: -97 lines from `scripts/apply-alice-eliza-runtime-patches.mjs`. File still parses (`node --check`), zero residual references.

## What this PR does NOT touch

- **PR #191's wildcard** in `packages/agent/src/api/index.ts` stays. It's a legitimate API completeness fix for `@miladyai/agent`'s own surface, separately useful from this revert.
- The **deploy script materialize line** (the real fix) is being changed directly on the deployer host. The runtime alignment fix is `materialize_pkg "@elizaos/agent" "eliza/packages/agent" "src/index.ts"` — that change isn't part of milaidy's repo.

## Why this is safe to merge

The patcher functions are no-ops at runtime, so reverting them changes nothing the runtime can observe. Build-time `tsdown` already targets upstream eliza's `@elizaos/agent` (via workspace resolution), so the patcher's mutations were neither helping nor hurting either side.

## Test plan

- [x] `node --check` parses
- [x] `grep -c agentDiscoveryHelpers` returns 0
- [ ] Deploy #50 (combined with deployer-side materialize fix) boots the pod