### PR TITLE
fix(patcher): add 10 explicit subpath exports to eliza/packages/agent/package.json

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -1146,6 +1146,114 @@ export function applyAliceCoreBrowserOnboardingTypesDisambiguatePatch({
   return "applied";
 }
 
+// eliza/packages/agent/package.json ships subpath exports for a handful of
+// public-by-convention paths (`./config/plugin-auto-enable`, `./services/*`
+// via wildcard, etc.) but omits explicit literal-key entries for ten more
+// subpaths that alice's own packages/app-core code imports from
+// `@elizaos/agent/<subpath>`:
+//
+//   ./api/config-env
+//   ./auth/account-storage
+//   ./auth/credentials
+//   ./auth/types
+//   ./config/config
+//   ./config/paths
+//   ./runtime/operations/types
+//   ./runtime/operations/vault-bridge
+//   ./services/permissions/probers/index
+//   ./services/permissions/register-probers
+//
+// Upstream's `./*` wildcard maps to `./dist/*.js`, but the eliza submodule
+// SHA alice pins (30c595e10e) does not ship a `dist/` directory, so the
+// wildcard does not resolve under Node + tsx at runtime. The runtime image
+// guard also does literal-key lookup (`agentPackage.exports[subpath]`),
+// which the wildcards never match.
+//
+// All ten target files exist as `.ts` under `eliza/packages/agent/src/`.
+// Add explicit subpath exports pointing at each `./src/<subpath>.ts`,
+// matching the pattern upstream already uses for `./config/plugin-auto-enable`
+// (a flat-string export — Node + tsx resolves the `.ts` source directly).
+const agentPackageRelativePath = "packages/agent/package.json";
+const agentPackageSubpathExportsSentinelKey =
+  "x-alice-elizaos-agent-subpath-exports";
+const agentPackageSubpathExports = {
+  "./api/config-env": "./src/api/config-env.ts",
+  "./auth/account-storage": "./src/auth/account-storage.ts",
+  "./auth/credentials": "./src/auth/credentials.ts",
+  "./auth/types": "./src/auth/types.ts",
+  "./config/config": "./src/config/config.ts",
+  "./config/paths": "./src/config/paths.ts",
+  "./runtime/operations/types": "./src/runtime/operations/types.ts",
+  "./runtime/operations/vault-bridge": "./src/runtime/operations/vault-bridge.ts",
+  "./services/permissions/probers/index":
+    "./src/services/permissions/probers/index.ts",
+  "./services/permissions/register-probers":
+    "./src/services/permissions/register-probers.ts",
+};
+
+export function isAliceElizaAgentPackageSubpathExportsPatched(packageJson) {
+  return (
+    packageJson &&
+    typeof packageJson === "object" &&
+    packageJson[agentPackageSubpathExportsSentinelKey] === "v1"
+  );
+}
+
+export function applyAliceElizaAgentPackageSubpathExportsPatch({
+  elizaRoot,
+  log = console.log,
+} = {}) {
+  const packageJsonPath = path.join(elizaRoot, agentPackageRelativePath);
+  if (!existsSync(packageJsonPath)) {
+    log(
+      "[alice-eliza-runtime-patches] eliza agent package.json absent; skipping subpath exports patch",
+    );
+    return "skipped";
+  }
+  const source = readFileSync(packageJsonPath, "utf8");
+  const packageJson = JSON.parse(source);
+  if (isAliceElizaAgentPackageSubpathExportsPatched(packageJson)) {
+    log(
+      "[alice-eliza-runtime-patches] eliza agent package.json subpath exports already applied",
+    );
+    return "already-applied";
+  }
+  // Every target source file must exist; bail loudly if upstream drift has
+  // removed any of them so we ship a debuggable build error instead of a
+  // silent runtime SyntaxError 15 minutes later.
+  for (const [subpath, srcRelative] of Object.entries(agentPackageSubpathExports)) {
+    const srcPath = path.join(
+      elizaRoot,
+      "packages/agent",
+      srcRelative.replace(/^\.\//, ""),
+    );
+    if (!existsSync(srcPath)) {
+      throw new Error(
+        `[alice-eliza-runtime-patches] eliza agent subpath exports patch: ` +
+          `target source file ${srcPath} (for export ${subpath}) does not exist`,
+      );
+    }
+  }
+  const nextExports = { ...(packageJson.exports || {}) };
+  let addedCount = 0;
+  for (const [subpath, srcRelative] of Object.entries(agentPackageSubpathExports)) {
+    if (!Object.prototype.hasOwnProperty.call(nextExports, subpath)) {
+      nextExports[subpath] = srcRelative;
+      addedCount += 1;
+    }
+  }
+  const nextPackageJson = {
+    ...packageJson,
+    exports: nextExports,
+    [agentPackageSubpathExportsSentinelKey]: "v1",
+  };
+  writeFileSync(packageJsonPath, `${JSON.stringify(nextPackageJson, null, 2)}\n`);
+  log(
+    `[alice-eliza-runtime-patches] patched eliza/packages/agent/package.json: added ${addedCount}/10 explicit subpath exports (api/config-env, auth/*, config/*, runtime/operations/*, services/permissions/*) pointing at ./src/<subpath>.ts — required for Node+tsx runtime resolution and for the runtime image guard's literal-key checks`,
+  );
+  return "applied";
+}
+
 const coreBrowserOnboardingReexportSentinel =
   "// [milaidy:core-browser-onboarding-reexport]";
 const coreBrowserOnboardingReexport = `${coreBrowserOnboardingReexportSentinel}
@@ -3193,6 +3301,7 @@ export function applyAliceElizaRuntimePatches({
     // Must run AFTER all the core-browser wildcard re-exports above so the
     // disambiguation appears last in the file and wins for TS resolution.
     applyAliceCoreBrowserOnboardingTypesDisambiguatePatch({ elizaRoot, log }),
+    applyAliceElizaAgentPackageSubpathExportsPatch({ elizaRoot, log }),
     applyAliceAppCoreUiCompatReexportPatch({ elizaRoot, log }),
     applyAliceAppCoreUiFullReexportPatch({ elizaRoot, log }),
     applyAliceCoreBuildBrowserExternalsPatch({ elizaRoot, log }),

--- a/scripts/apply-alice-eliza-runtime-patches.test.ts
+++ b/scripts/apply-alice-eliza-runtime-patches.test.ts
@@ -24,6 +24,8 @@ import {
   isAliceAppPluginRegisterExportPatched,
   applyAliceBrowserBridgeWorkspaceStubPatch,
   isAliceBrowserBridgeWorkspaceStubPatched,
+  applyAliceElizaAgentPackageSubpathExportsPatch,
+  isAliceElizaAgentPackageSubpathExportsPatched,
   applyAliceTelegramAccountAuthResolverPatch,
   applyAliceTelegramSourcePackageJsonExportPatch,
   isAliceTelegramSourcePackageJsonExportPatched,
@@ -866,6 +868,161 @@ describe("Alice Eliza runtime patch contract", () => {
           log: () => undefined,
         }),
       ).toBe("skipped");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("adds 10 explicit subpath exports to eliza/packages/agent/package.json", () => {
+    const tempDir = mkdtempSync(
+      path.join(os.tmpdir(), "alice-elizaos-agent-subpath-exports-"),
+    );
+    try {
+      const agentDir = path.join(tempDir, "packages", "agent");
+      mkdirSync(agentDir, { recursive: true });
+      const packageJsonPath = path.join(agentDir, "package.json");
+      writeFileSync(
+        packageJsonPath,
+        `${JSON.stringify(
+          {
+            name: "@elizaos/agent",
+            main: "src/index.ts",
+            type: "module",
+            exports: {
+              ".": "./src/index.ts",
+              "./package.json": "./package.json",
+              "./config/plugin-auto-enable": "./src/config/plugin-auto-enable.ts",
+              "./services/*": {
+                import: "./dist/services/*.js",
+                default: "./dist/services/*.js",
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      // Create every target source file the patcher's pre-condition expects.
+      const subpathTargets = [
+        "src/api/config-env.ts",
+        "src/auth/account-storage.ts",
+        "src/auth/credentials.ts",
+        "src/auth/types.ts",
+        "src/config/config.ts",
+        "src/config/paths.ts",
+        "src/runtime/operations/types.ts",
+        "src/runtime/operations/vault-bridge.ts",
+        "src/services/permissions/probers/index.ts",
+        "src/services/permissions/register-probers.ts",
+      ];
+      for (const rel of subpathTargets) {
+        const target = path.join(agentDir, rel);
+        mkdirSync(path.dirname(target), { recursive: true });
+        writeFileSync(target, "export const placeholder = true;\n");
+      }
+
+      expect(
+        applyAliceElizaAgentPackageSubpathExportsPatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("applied");
+
+      const patched = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+      expect(isAliceElizaAgentPackageSubpathExportsPatched(patched)).toBe(true);
+
+      // All 10 new explicit subpath exports present and pointing at src/<subpath>.ts.
+      expect(patched.exports["./api/config-env"]).toBe("./src/api/config-env.ts");
+      expect(patched.exports["./auth/account-storage"]).toBe(
+        "./src/auth/account-storage.ts",
+      );
+      expect(patched.exports["./auth/credentials"]).toBe(
+        "./src/auth/credentials.ts",
+      );
+      expect(patched.exports["./auth/types"]).toBe("./src/auth/types.ts");
+      expect(patched.exports["./config/config"]).toBe("./src/config/config.ts");
+      expect(patched.exports["./config/paths"]).toBe("./src/config/paths.ts");
+      expect(patched.exports["./runtime/operations/types"]).toBe(
+        "./src/runtime/operations/types.ts",
+      );
+      expect(patched.exports["./runtime/operations/vault-bridge"]).toBe(
+        "./src/runtime/operations/vault-bridge.ts",
+      );
+      expect(patched.exports["./services/permissions/probers/index"]).toBe(
+        "./src/services/permissions/probers/index.ts",
+      );
+      expect(patched.exports["./services/permissions/register-probers"]).toBe(
+        "./src/services/permissions/register-probers.ts",
+      );
+
+      // Pre-existing entries are preserved.
+      expect(patched.exports["."]).toBe("./src/index.ts");
+      expect(patched.exports["./package.json"]).toBe("./package.json");
+      expect(patched.exports["./config/plugin-auto-enable"]).toBe(
+        "./src/config/plugin-auto-enable.ts",
+      );
+      expect(patched.exports["./services/*"]).toEqual({
+        import: "./dist/services/*.js",
+        default: "./dist/services/*.js",
+      });
+
+      // Idempotent: re-running on a patched file returns already-applied
+      // and does not double-write.
+      expect(
+        applyAliceElizaAgentPackageSubpathExportsPatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("already-applied");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips the eliza agent subpath exports patch when the file is absent", () => {
+    const tempDir = mkdtempSync(
+      path.join(os.tmpdir(), "alice-elizaos-agent-subpath-exports-absent-"),
+    );
+    try {
+      expect(
+        applyAliceElizaAgentPackageSubpathExportsPatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toBe("skipped");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws if a target source file is missing when applying the eliza agent subpath exports patch", () => {
+    const tempDir = mkdtempSync(
+      path.join(os.tmpdir(), "alice-elizaos-agent-subpath-exports-missing-"),
+    );
+    try {
+      const agentDir = path.join(tempDir, "packages", "agent");
+      mkdirSync(agentDir, { recursive: true });
+      writeFileSync(
+        path.join(agentDir, "package.json"),
+        `${JSON.stringify(
+          {
+            name: "@elizaos/agent",
+            main: "src/index.ts",
+            type: "module",
+            exports: { ".": "./src/index.ts" },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      // Intentionally do NOT create any of the target src files.
+      expect(() =>
+        applyAliceElizaAgentPackageSubpathExportsPatch({
+          elizaRoot: tempDir,
+          log: () => undefined,
+        }),
+      ).toThrow(/target source file .* does not exist/);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Final piece of the alice runtime resolution fix. After yesterday's deployer-side change to materialize \`@elizaos/agent\` from \`eliza/packages/agent\` (matching upstream milady's reference design), 10 subpath imports in alice's \`packages/app-core\` code still fail to resolve because upstream eliza's \`package.json\` exposes those subpaths only via a \`./*\` wildcard pointing at \`./dist/*.js\` — but alice's pinned eliza submodule SHA (\`30c595e10e\`) doesn't ship a \`dist/\` directory.

The runtime image guard additionally does literal-key lookup for six of those subpaths, so it fires fail() without the explicit entries even when the source files exist.

## What this PR does

Adds \`applyAliceElizaAgentPackageSubpathExportsPatch\` (sentinel-guarded, idempotent) that augments \`eliza/packages/agent/package.json\` to declare 10 explicit subpath exports:

| Subpath | Target | Consumer |
|---|---|---|
| \`./api/config-env\` | \`./src/api/config-env.ts\` | \`packages/app-core/src/services/vault-bootstrap.ts:19\` |
| \`./auth/account-storage\` | \`./src/auth/account-storage.ts\` | \`packages/app-core/src/services/account-pool.ts:32\` |
| \`./auth/credentials\` | \`./src/auth/credentials.ts\` | \`packages/app-core/src/services/account-pool.ts:36\` |
| \`./auth/types\` | \`./src/auth/types.ts\` | \`packages/app-core/src/services/account-pool.ts:44\` |
| \`./config/config\` | \`./src/config/config.ts\` | (source consumer) |
| \`./config/paths\` | \`./src/config/paths.ts\` | (source consumer) |
| \`./runtime/operations/types\` | \`./src/runtime/operations/types.ts\` | (guard literal-key check) |
| \`./runtime/operations/vault-bridge\` | \`./src/runtime/operations/vault-bridge.ts\` | \`packages/app-core/src/services/vault-bootstrap.ts:29\` |
| \`./services/permissions/probers/index\` | \`./src/services/permissions/probers/index.ts\` | (source consumer) |
| \`./services/permissions/register-probers\` | \`./src/services/permissions/register-probers.ts\` | (source consumer) |

The pattern matches upstream's existing flat-string export for \`./config/plugin-auto-enable\`. Node + tsx loads the \`.ts\` source directly.

## Why this is not a hack

The 10 subpaths are imported by intentional alice consumer code against source files that exist in upstream eliza. Declaring them as explicit exports describes the surface alice already uses. Not a workaround — a declarative fix.

## Idempotence + safety

- Sentinel field \`x-alice-elizaos-agent-subpath-exports: "v1"\` on the package.json; re-runs return \`already-applied\` without rewriting.
- Pre-condition check: every target source file must exist. The patcher throws a build-time Error if upstream drift removes any of them, surfacing a debuggable failure during the build rather than a silent runtime SyntaxError later in the pod's startup chain.
- Pre-existing upstream entries (\`.\`, \`./config/plugin-auto-enable\`, \`./services/*\`, \`./services/app-session-gate\`, \`./package.json\`, \`./*\`, etc.) are preserved by spreading the existing exports object.

## Test plan

- [x] \`node --check\` parses
- [x] Local dry-apply: 10/10 added, sentinel present, pre-existing entries preserved
- [x] Idempotence: re-apply on patched file returns \`already-applied\`
- [ ] Deploy #51 — runtime image guard passes, pod boots without SyntaxError

## Out of scope

Deleting alice's vestigial \`packages/agent\` and dropping \`@miladyai/agent\` per upstream milady's design — substantial refactor, separate PR after staging is verified green.