### PR TITLE
fix(deps): bump @electric-sql/pglite ^0.3.16 -> ^0.4.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@ai-sdk/provider-utils": "^4.0.19",
         "@bufbuild/protobuf": "^2.11.0",
         "@clack/prompts": "^1.1.0",
-        "@electric-sql/pglite": "^0.3.16",
+        "@electric-sql/pglite": "^0.4.5",
         "@elizaos-plugins/client-telegram-account": "workspace:*",
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-agent-orchestrator": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
     "@ai-sdk/provider-utils": "^4.0.19",
     "@bufbuild/protobuf": "^2.11.0",
     "@clack/prompts": "^1.1.0",
-    "@electric-sql/pglite": "^0.3.16",
+    "@electric-sql/pglite": "^0.4.5",
     "@elizaos/core": "workspace:*",
     "@elizaos/plugin-agent-orchestrator": "workspace:*",
     "@elizaos/plugin-agent-skills": "workspace:*",


### PR DESCRIPTION
## Summary

- `@elizaos/plugin-sql@2.0.0-beta.1` (from the eliza submodule) writes `eliza-pglite.lock` **into the PGlite data dir before** running `initdb`, and requires `@electric-sql/pglite ^0.4.0`.
- PGlite **0.4.x tolerates** a pre-existing file in the data dir; **0.3.16's `initdb` refuses a non-empty directory** → the WASM postgres `exit(1)`s → `@elizaos/plugin-sql` init crashes → the agent runtime crashes. This is the staging `alice-bot` CrashLoopBackOff.
- alice's root `package.json` still pinned `^0.3.16`, so the build hoisted `0.3.16` to the top level and `plugin-sql` resolved the incompatible version. `eliza/package.json` already pins `^0.4.5` — this aligns the alice root to match upstream.

## Root-cause evidence

Reproduced inside the deployed image (`sha-d5e8f7e-milaidy-5ece745`), calling PGlite exactly as `plugin-sql` does (`vector` + `fuzzystrmatch` extensions):

```
0.3.16  empty data dir:                 OK
0.3.16  data dir w/ eliza-pglite.lock:  FAILED -> Program terminated with exit(1)   <- exact runtime error
0.4.5   empty data dir:                 OK
0.4.5   data dir w/ eliza-pglite.lock:  OK
```

Ruled out along the way: data corruption (fails on a fresh empty dir too), data-dir permissions, the EBS PVC, pod memory/env limits, PGlite install integrity, and the `tsx` loader.

## Test plan

- [ ] Deploy to staging; confirm `alice-bot` boots past `sql-plugin-register` with no `Program terminated with exit(1)`
- [ ] Confirm PGlite initializes and the runtime reaches healthy
- [ ] `staging-alice.rndrntwrk.com` returns healthy (not 503)

## Notes

- `bun.lock`'s resolved entry for `@electric-sql/pglite` is already `0.4.5`; this PR only updates the root workspace spec (`package.json` + the `bun.lock` mirror) so they are consistent.
- `bun.lock` has a pre-existing, unrelated malformation (duplicate `@ai-sdk/openai` key) — left untouched, out of scope here.