### PR TITLE
fix(deps): pin @electric-sql/pglite ^0.4.5 in overrides (match upstream)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2668,6 +2668,7 @@
   },
   "overrides": {
     "@ai-sdk/groq": "3.0.31",
+    "@electric-sql/pglite": "^0.4.5",
     "@elizaos/config": "1.7.3-alpha.4",
     "@elizaos/core": "workspace:*",
     "@elizaos/plugin-cli": "2.0.0-alpha.9",

--- a/package.json
+++ b/package.json
@@ -393,6 +393,7 @@
     "vitest": "^4.1.0"
   },
   "overrides": {
+    "@electric-sql/pglite": "^0.4.5",
     "@elizaos/plugin-cli": "2.0.0-alpha.9",
     "@elizaos/core": "workspace:*",
     "@elizaos/plugin-discord": "workspace:*",


### PR DESCRIPTION
## Summary

Follow-up to [#195](https://github.com/rndrntwrk/milaidy/pull/195), which bumped `@electric-sql/pglite` `^0.3.16` → `^0.4.5` in `dependencies` and cleared the staging PGlite `Program terminated with exit(1)` CrashLoopBackOff.

Upstream `milady-ai/milady` pins `@electric-sql/pglite` in **`overrides`** as well as `dependencies`. alice's `overrides` block was missing it. This PR adds it.

## Why the override matters

- `dependencies: ^0.4.5` (from #195) anchors the **top-level** `node_modules/@electric-sql/pglite` to `0.4.x` — which is what `@elizaos/plugin-sql@2.0.0-beta.1` resolves, so it's enough to clear the crash (confirmed: staging `alice-bot` is healthy on the #195 deploy).
- But other packages (`drizzle-orm`, etc.) declare `^0.3.x` ranges, so without an override bun can still install nested `0.3.x` copies. The build runs `rm -f bun.lock && bun install` on every deploy — a fresh resolution each time — so relying on hoisting alone is fragile.
- The `overrides` entry forces `0.4.5` everywhere, making resolution deterministic and preventing the `0.3.16` skew from re-creeping in transitively. This is exactly why upstream pins it there.

## Test plan

- [ ] Deploy to staging; confirm `alice-bot` still boots healthy (`sql-plugin-register:done`, `database:ok`)
- [ ] Confirm only one `@electric-sql/pglite` version resolves in the built image

## Notes

- `bun.lock`'s `overrides` mirror updated alongside `package.json` for consistency (the build regenerates the lockfile regardless).