### PR TITLE
fix(agent): self-heal stale PGlite client lock + orchestrator-compat require

### DIFF
--- a/packages/agent/src/runtime/agent-orchestrator-compat.ts
+++ b/packages/agent/src/runtime/agent-orchestrator-compat.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import type http from "node:http";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import type {
@@ -18,13 +19,22 @@ import type {
 import { installClaudeJsonlCompletionWatcher } from "./claude-jsonl-completion-watcher";
 import { installTaskProgressStreamer } from "./task-progress-streamer";
 
-// Dynamic import: plugin-agent-orchestrator is desktop-only and may be absent
-// in Docker, cloud, or headless environments.
+// plugin-agent-orchestrator is desktop-only and may be absent in Docker, cloud,
+// or headless images. It must be loaded with a synchronous require, NOT a
+// top-level `await import`: this module is itself require()'d by eliza.ts, and
+// a top-level await would make it an async ESM module that require() cannot
+// load (ERR_REQUIRE_ASYNC_MODULE) — silently disabling the entire compat
+// wrapper, including the graceful stub fallback in resolveBasePlugin().
+const nodeRequire = createRequire(import.meta.url);
 let baseModule: Record<string, unknown> = {};
 try {
-  baseModule = await import("@elizaos/plugin-agent-orchestrator");
+  baseModule = nodeRequire("@elizaos/plugin-agent-orchestrator") as Record<
+    string,
+    unknown
+  >;
 } catch {
-  // Package not available — orchestrator features gracefully disabled
+  // Package (or a native dep such as pty-console) unavailable — orchestrator
+  // features gracefully disabled via the stub in resolveBasePlugin().
 }
 
 type AdapterId = "claude" | "codex" | "gemini" | "aider";

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -2034,6 +2034,11 @@ export function applyDatabaseConfigToEnv(config: ElizaConfig): void {
       // PGlite sees the lock and either fails or, with explicit destructive
       // recovery enabled, triggers the resetPgliteDataDir path.
       cleanStalePglitePid(dataDir);
+
+      // Remove a stale eliza-pglite.lock left by @elizaos/plugin-sql when a
+      // prior pod did not release it. Its recorded pid is routinely reused by
+      // the next container, which would otherwise look like an active holder.
+      cleanStalePgliteClientLock(dataDir);
     }
   }
 }
@@ -2130,6 +2135,130 @@ export function cleanStalePglitePid(dataDir: string): void {
     reconcilePglitePidFile(dataDir);
   } catch (err) {
     logger.warn(`[eliza] PGlite PID reconciliation failed: ${err}`);
+  }
+}
+
+/**
+ * On Linux, return the wall-clock start time (ms) of process `pid` from
+ * `/proc/<pid>/stat`. Returns null when /proc is unavailable (non-Linux) or the
+ * process is gone. Used to tell a genuine lock holder apart from a reused pid:
+ * container pid namespaces restart from low pids, so a leftover lock's recorded
+ * pid is frequently reused by an unrelated process in the next container.
+ */
+function readProcessStartTimeMs(pid: number): number | null {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf-8");
+    // Field 2 (comm) is paren-wrapped and may contain spaces — parse the
+    // remaining fields after the final ')'. starttime is the 22nd overall
+    // field, i.e. index 19 of the post-comm slice.
+    const postComm = stat
+      .slice(stat.lastIndexOf(")") + 1)
+      .trim()
+      .split(/\s+/);
+    const startTicks = Number(postComm[19]);
+    if (!Number.isFinite(startTicks)) return null;
+    const clockTicksPerSecond = 100; // USER_HZ — 100 on effectively all Linux
+    const bootTimeMs = Date.now() - os.uptime() * 1000;
+    return bootTimeMs + (startTicks / clockTicksPerSecond) * 1000;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reconcile a stale `eliza-pglite.lock` written by @elizaos/plugin-sql's
+ * PGliteClientManager. plugin-sql records its own `process.pid` in this JSON
+ * lock and, on startup, refuses to open the data dir ("already in use") while
+ * that pid is alive. Across container restarts the pid is routinely reused —
+ * pid namespaces start from low numbers — so a leftover lock from a prior pod
+ * looks active and wedges startup. We clear it here, before plugin-sql init,
+ * the same way we already reconcile a stale postmaster.pid.
+ */
+function reconcilePgliteClientLock(dataDir: string): PglitePidFileStatus {
+  const lockPath = path.join(dataDir, "eliza-pglite.lock");
+  if (!existsSync(lockPath)) return "missing";
+
+  let pid: number;
+  try {
+    const parsed = JSON.parse(readFileSync(lockPath, "utf-8")) as {
+      pid?: unknown;
+    };
+    pid = typeof parsed.pid === "number" ? parsed.pid : Number.NaN;
+  } catch {
+    unlinkSync(lockPath);
+    logger.info(
+      "[eliza] Removed unreadable PGlite client lock (eliza-pglite.lock)",
+    );
+    return "cleared-malformed";
+  }
+
+  if (!Number.isInteger(pid) || pid <= 0) {
+    unlinkSync(lockPath);
+    logger.info(
+      "[eliza] Removed malformed PGlite client lock (eliza-pglite.lock)",
+    );
+    return "cleared-malformed";
+  }
+
+  // Exact pid collision with our own process, lock older than our start: a
+  // leftover from a prior container whose low pid we reused.
+  if (isPidFileFromPreviousProcess(lockPath, pid)) {
+    unlinkSync(lockPath);
+    logger.info(
+      `[eliza] Removed stale PGlite client lock from prior container process ${pid}`,
+    );
+    return "cleared-stale";
+  }
+
+  try {
+    process.kill(pid, 0); // signal 0 = existence check, does not kill
+  } catch (killErr: unknown) {
+    const code = (killErr as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") {
+      unlinkSync(lockPath);
+      logger.info(
+        `[eliza] Removed stale PGlite client lock (process ${pid} not running)`,
+      );
+      return "cleared-stale";
+    }
+    logger.warn(
+      `[eliza] Cannot confirm PGlite client lock staleness (${code}) — leaving intact`,
+    );
+    return "active-unconfirmed";
+  }
+
+  // The pid is alive — but an alive pid is not proof the original holder
+  // survived. If that pid's process started after the lock file was written,
+  // it is a different (reused) process and the lock is stale.
+  const holderStartMs = readProcessStartTimeMs(pid);
+  if (holderStartMs !== null) {
+    const lockMtimeMs = statSync(lockPath).mtimeMs;
+    if (holderStartMs > lockMtimeMs + 1000) {
+      unlinkSync(lockPath);
+      logger.info(
+        `[eliza] Removed stale PGlite client lock (pid ${pid} reused — process started after the lock was written)`,
+      );
+      return "cleared-stale";
+    }
+  }
+
+  logger.info(
+    `[eliza] PGlite client lock references running process ${pid} — leaving intact`,
+  );
+  return "active";
+}
+
+/**
+ * Check for and remove a stale eliza-pglite.lock in the PGlite data directory.
+ * Mirrors {@link cleanStalePglitePid} for plugin-sql's own client lock.
+ */
+export function cleanStalePgliteClientLock(dataDir: string): void {
+  try {
+    reconcilePgliteClientLock(dataDir);
+  } catch (err) {
+    logger.warn(
+      `[eliza] PGlite client lock reconciliation failed: ${formatError(err)}`,
+    );
   }
 }
 


### PR DESCRIPTION
Two runtime-robustness fixes in `packages/agent/src/runtime/`, both root-caused while investigating the staging `alice-bot` CrashLoopBackOff after the #196 deploy.

## 1. Self-heal stale `eliza-pglite.lock` across container restarts (commit 1)

**This is what took staging down on the #196 rollout.** `@elizaos/plugin-sql@2.0.0-beta.1`'s `PGliteClientManager` writes a JSON `eliza-pglite.lock` into the data dir recording its own `process.pid`, and on startup refuses to open the dir (`PGlite data dir is already in use`) whenever that pid is alive. Container pid namespaces restart from low pids, so a leftover lock from a prior pod routinely names a pid the **next** container reuses — the new pod sees its own pid in the stale lock and wedges in CrashLoopBackOff. (#195 only avoided this because it was the first boot after a `.elizadb` reset — no prior pod, no stale lock.)

`eliza.ts` already pre-creates the data dir and reconciles a stale `postmaster.pid` before plugin-sql init (`cleanStalePglitePid`). This adds a sibling `cleanStalePgliteClientLock` that reconciles `eliza-pglite.lock` the same way: clears it when the recorded pid is gone, when it collides with our own pid (existing `isPidFileFromPreviousProcess` check), or — via `/proc/<pid>/stat` start time — when the pid is alive but was reused *after* the lock was written. Non-Linux falls back to the kill/collision checks.

## 2. Load `plugin-agent-orchestrator` with `require`, not top-level `await` (commit 2)

`agent-orchestrator-compat.ts` is `require()`'d by `eliza.ts` so it can register in `STATIC_ELIZA_PLUGINS`. Its top-level `await import(...)` made it an async ESM module, which `require()` cannot load (`ERR_REQUIRE_ASYNC_MODULE`) — so the require always threw, the compat wrapper was never registered, and the resolver fell through to loading the real plugin directly. On cloud images (PTY native deps like `pty-console` intentionally absent) that surfaced as a `Failed to load core plugin @elizaos/plugin-agent-orchestrator` error every boot, bypassing the graceful stub the compat wrapper exists to provide. Switched to a synchronous `createRequire`.

## Test plan

- [ ] Deploy to staging; the rollout itself exercises fix #1 — the new pod must clear the lock the outgoing pod leaves and boot clean (no `data dir is already in use`)
- [ ] Confirm `sql-plugin-register:done`, `database:ok`, endpoint healthy
- [ ] Confirm no `Failed to load core plugin @elizaos/plugin-agent-orchestrator` error (stub loads instead)

## Notes

- Typechecked `packages/agent` — no new type errors from either change.
- The orchestrator stub means agent-orchestrator features remain gracefully disabled on cloud (intended; it's desktop-only) instead of erroring.