### PR TITLE
fix(alice): bridge dashboard fallback route auth

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -148,6 +148,48 @@ const agentStatusAuthBridgeSource = `import type http from "node:http";
 import { ensureRouteAuthorized, getCompatApiToken } from "./auth.ts";
 import type { CompatRuntimeState } from "./compat-route-shared";
 
+function shouldBridgeAgentFallbackAuth(method: string, pathname: string): boolean {
+  if (method === "GET" && pathname === "/api/status") return true;
+
+  if (pathname === "/api/apps/favorites") {
+    return method === "GET" || method === "PUT";
+  }
+  if (
+    method === "POST" &&
+    (pathname === "/api/apps/favorites/replace" ||
+      pathname === "/api/apps/overlay-presence")
+  ) {
+    return true;
+  }
+  if (
+    method === "GET" &&
+    (pathname === "/api/apps/search" ||
+      pathname === "/api/apps/installed" ||
+      pathname === "/api/apps/runs" ||
+      pathname.startsWith("/api/apps/hero/"))
+  ) {
+    return true;
+  }
+  if (pathname.startsWith("/api/apps/runs/")) return true;
+
+  if (pathname.startsWith("/api/vincent/")) return true;
+
+  if (
+    pathname === "/api/computer-use/approvals" ||
+    pathname === "/api/computer-use/approvals/stream"
+  ) {
+    return method === "GET";
+  }
+  if (pathname === "/api/computer-use/approval-mode") {
+    return method === "POST";
+  }
+  if (method === "POST" && /^\\/api\\/computer-use\\/approvals\\/[^/]+$/.test(pathname)) {
+    return true;
+  }
+
+  return false;
+}
+
 export async function authorizeAgentStatusFallback(
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -155,7 +197,7 @@ export async function authorizeAgentStatusFallback(
 ): Promise<boolean> {
   const method = (req.method ?? "GET").toUpperCase();
   const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
-  if (method !== "GET" || pathname !== "/api/status") return true;
+  if (!shouldBridgeAgentFallbackAuth(method, pathname)) return true;
 
   if (!(await ensureRouteAuthorized(req, res, state))) return false;
 

--- a/scripts/apply-alice-eliza-runtime-patches.test.ts
+++ b/scripts/apply-alice-eliza-runtime-patches.test.ts
@@ -289,7 +289,7 @@ describe("Alice Eliza runtime patch contract", () => {
     }
   });
 
-  it("patches source-mode app-core to bridge app-core sessions into legacy /api/status auth", () => {
+  it("patches source-mode app-core to bridge app-core sessions into legacy fallback auth", () => {
     const tempDir = mkdtempSync(
       path.join(os.tmpdir(), "alice-status-auth-bridge-"),
     );
@@ -348,7 +348,18 @@ describe("Alice Eliza runtime patch contract", () => {
       expect(patchedServer).toContain(
         "if (!(await authorizeAgentStatusFallback(req, res, state)))",
       );
-      expect(bridgeSource).toContain('pathname !== "/api/status"');
+      expect(bridgeSource).toContain(
+        "function shouldBridgeAgentFallbackAuth",
+      );
+      expect(bridgeSource).toContain('pathname === "/api/status"');
+      expect(bridgeSource).toContain('pathname === "/api/apps/favorites"');
+      expect(bridgeSource).toContain(
+        'pathname === "/api/apps/overlay-presence"',
+      );
+      expect(bridgeSource).toContain('pathname.startsWith("/api/vincent/")');
+      expect(bridgeSource).toContain(
+        'pathname === "/api/computer-use/approvals"',
+      );
       expect(bridgeSource).toContain("req.headers.authorization");
 
       expect(


### PR DESCRIPTION
## Summary
- extend the Alice app-core fallback auth bridge beyond /api/status to dashboard routes still owned by the legacy agent/runtime plugin dispatcher
- keep app-core browser session and CSRF enforcement as the front gate, then inject the internal bearer token only for explicit fallback paths
- cover app favorites, overlay presence, app run helpers, Vincent, and computer-use approval routes

## Verification
- node --check scripts/apply-alice-eliza-runtime-patches.mjs
- bun test scripts/apply-alice-eliza-runtime-patches.test.ts