### PR TITLE
fix: keep Alice browser auth probes gated

### DIFF
--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -70,7 +70,7 @@ import {
   type DeviceBridgeClient,
 } from "@elizaos/capacitor-llama";
 import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
+import { createRoot, type Root } from "react-dom/client";
 import { CompanionShell } from "@elizaos/app-companion/ui";
 import {
   createVectorBrowserRenderer,
@@ -158,6 +158,8 @@ declare global {
     __ELIZA_API_BASE__?: string;
     __ELIZAOS_APP_BOOT_CONFIG__?: AppBootConfig;
     __ELIZA_APP_BOOT_CONFIG__?: AppBootConfig;
+    __MILADY_REACT_ROOT__?: Root;
+    __MILADY_APP_BOOT_PROMISE__?: Promise<void>;
   }
 }
 
@@ -175,6 +177,8 @@ type AppCompatWindow = Window &
     __ELIZA_API_BASE__?: string;
     __ELIZAOS_APP_BOOT_CONFIG__?: AppBootConfig;
     __ELIZA_APP_BOOT_CONFIG__?: AppBootConfig;
+    __MILADY_REACT_ROOT__?: Root;
+    __MILADY_APP_BOOT_PROMISE__?: Promise<void>;
   };
 
 function getAppWindow(): AppCompatWindow {
@@ -429,6 +433,11 @@ function logNativePluginUnavailable(pluginName: string, error: unknown): void {
 
 async function initializeAgent(): Promise<void> {
   try {
+    const auth = await client.getAuthStatus().catch(() => null);
+    if (auth?.required && !auth.localAccess && !auth.authenticated) {
+      return;
+    }
+
     const status = await Agent.getStatus();
     dispatchAppEvent(AGENT_READY_EVENT, status);
   } catch (err) {
@@ -735,7 +744,9 @@ function mountReactApp(): void {
   const detachedShell = isDetachedWindowShell(windowShellRoute);
   const appWindowSlug = detachedShell ? null : resolveAppWindowSlug();
 
-  createRoot(rootEl).render(
+  const reactRoot = window.__MILADY_REACT_ROOT__ ?? createRoot(rootEl);
+  window.__MILADY_REACT_ROOT__ = reactRoot;
+  reactRoot.render(
     <ErrorBoundary>
       <StrictMode>
         <AppProvider branding={APP_BRANDING}>
@@ -1034,10 +1045,18 @@ async function main(): Promise<void> {
   await initializePlatform();
 }
 
+function bootMain(): void {
+  if (window.__MILADY_APP_BOOT_PROMISE__) return;
+  window.__MILADY_APP_BOOT_PROMISE__ = main().catch((err) => {
+    window.__MILADY_APP_BOOT_PROMISE__ = undefined;
+    throw err;
+  });
+}
+
 if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", main);
+  document.addEventListener("DOMContentLoaded", bootMain, { once: true });
 } else {
-  main();
+  bootMain();
 }
 
 export { isAndroid, isDesktopPlatform as isDesktop, isIOS, isNative, platform };

--- a/apps/app/test/main.boot.test.ts
+++ b/apps/app/test/main.boot.test.ts
@@ -16,4 +16,20 @@ describe("renderer boot guard", () => {
     expect(source).toContain("window.__MILADY_REACT_ROOT__ ?? createRoot(rootEl)");
     expect(source).toContain("if (window.__MILADY_APP_BOOT_PROMISE__)");
   });
+
+  it("defers the eager Agent status probe while browser auth is required", () => {
+    const testDir = path.dirname(fileURLToPath(import.meta.url));
+    const source = fs.readFileSync(
+      path.resolve(testDir, "../src/main.tsx"),
+      "utf-8",
+    );
+
+    expect(source).toContain("const auth = await client.getAuthStatus()");
+    expect(source).toContain(
+      "if (auth?.required && !auth.localAccess && !auth.authenticated)",
+    );
+    expect(source.indexOf("client.getAuthStatus")).toBeLessThan(
+      source.indexOf("Agent.getStatus()"),
+    );
+  });
 });

--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -41,6 +41,8 @@ const uiStartupPhasePollRelativePath =
   "packages/ui/src/state/startup-phase-poll.ts";
 const uiStartupPhaseRuntimeRelativePath =
   "packages/ui/src/state/startup-phase-runtime.ts";
+const uiOnboardingBootstrapRelativePath =
+  "packages/ui/src/state/onboarding-bootstrap.ts";
 const uiAppShellStateRelativePath =
   "packages/ui/src/state/useAppShellState.ts";
 const appVincentStateRelativePath = "plugins/app-vincent/src/useVincentState.ts";
@@ -3712,6 +3714,71 @@ function patchAliceStartupPhaseRuntimeAuthGateSource(source) {
   return source.replace(anchor, patch);
 }
 
+function patchAliceOnboardingBootstrapAuthProbeSource(source) {
+  if (
+    source.includes(
+      "Auth-gated origins must not run protected onboarding probes before a browser session exists",
+    )
+  ) {
+    return source;
+  }
+
+  let next = source;
+  const interfaceAnchor = `export interface ExistingOnboardingProbeClient {
+  apiAvailable: boolean;
+  getOnboardingStatus: () => Promise<{ complete: boolean }>;
+  getConfig: () => Promise<Record<string, unknown> | null | undefined>;
+}
+`;
+  const interfacePatch = `export interface ExistingOnboardingProbeClient {
+  apiAvailable: boolean;
+  getAuthStatus?: () => Promise<{
+    required?: boolean;
+    authenticated?: boolean;
+    localAccess?: boolean;
+    passwordConfigured?: boolean;
+  }>;
+  hasToken?: () => boolean;
+  getOnboardingStatus: () => Promise<{ complete: boolean }>;
+  getConfig: () => Promise<Record<string, unknown> | null | undefined>;
+}
+`;
+  if (!next.includes(interfaceAnchor)) {
+    throw new Error("ui onboarding bootstrap auth interface anchor drifted");
+  }
+  next = next.replace(interfaceAnchor, interfacePatch);
+
+  const probeAnchor = `  if (!args.client.apiAvailable) {
+    return null;
+  }
+
+  const timeoutToken = Symbol("onboarding-bootstrap-timeout");
+`;
+  const probePatch = `  if (!args.client.apiAvailable) {
+    return null;
+  }
+
+  const auth = await args.client.getAuthStatus?.().catch(() => null);
+  const protectedSessionPending =
+    auth &&
+    auth.localAccess !== true &&
+    ((auth.required === true && auth.authenticated !== true) ||
+      (auth.passwordConfigured === true && args.client.hasToken?.() === true));
+  if (protectedSessionPending) {
+    // Auth-gated origins must not run protected onboarding probes before a browser session exists.
+    // /api/onboarding/status and /api/config are intentionally protected, so
+    // probing them here only creates noisy 401s and can trip auth rate limits.
+    return null;
+  }
+
+  const timeoutToken = Symbol("onboarding-bootstrap-timeout");
+`;
+  if (!next.includes(probeAnchor)) {
+    throw new Error("ui onboarding bootstrap protected-probe anchor drifted");
+  }
+  return next.replace(probeAnchor, probePatch);
+}
+
 function patchAliceStartupPhasePollAuthGateSource(source) {
   if (
     source.includes(
@@ -4202,6 +4269,7 @@ function patchAliceVincentStateAuthGateSource(source) {
 export function isAliceUiAuthGatedStartupPatched({
   appSource = "",
   hooksIndexSource = "",
+  onboardingBootstrapSource = "",
   startupShellSource = "",
   startupPhasePollSource = "",
   startupPhaseRuntimeSource = "",
@@ -4213,6 +4281,9 @@ export function isAliceUiAuthGatedStartupPatched({
       "Remote password/session auth stays behind the startup auth gate",
     ) &&
     startupPhaseRuntimeSource.includes('dispatch({ type: "BACKEND_AUTH_REQUIRED" });') &&
+    onboardingBootstrapSource.includes(
+      "Auth-gated origins must not run protected onboarding probes before a browser session exists",
+    ) &&
     startupPhasePollSource.includes(
       "Token holders with password/session auth still pending stay behind the startup auth gate",
     ) &&
@@ -4237,6 +4308,10 @@ export function applyAliceUiAuthGatedStartupPatch({
   const paths = {
     appPath: path.join(elizaRoot, uiAppRelativePath),
     hooksIndexPath: path.join(elizaRoot, uiHooksIndexRelativePath),
+    onboardingBootstrapPath: path.join(
+      elizaRoot,
+      uiOnboardingBootstrapRelativePath,
+    ),
     startupShellPath: path.join(elizaRoot, uiStartupShellRelativePath),
     startupPhasePollPath: path.join(elizaRoot, uiStartupPhasePollRelativePath),
     startupPhaseRuntimePath: path.join(
@@ -4256,6 +4331,10 @@ export function applyAliceUiAuthGatedStartupPatch({
   const before = {
     appSource: readFileSync(paths.appPath, "utf8"),
     hooksIndexSource: readFileSync(paths.hooksIndexPath, "utf8"),
+    onboardingBootstrapSource: readFileSync(
+      paths.onboardingBootstrapPath,
+      "utf8",
+    ),
     startupShellSource: readFileSync(paths.startupShellPath, "utf8"),
     startupPhasePollSource: readFileSync(paths.startupPhasePollPath, "utf8"),
     startupPhaseRuntimeSource: readFileSync(paths.startupPhaseRuntimePath, "utf8"),
@@ -4272,6 +4351,9 @@ export function applyAliceUiAuthGatedStartupPatch({
     appSource: patchAliceUiAppAuthGateSource(before.appSource),
     hooksIndexSource: patchAliceUiHooksIndexAuthStatusExportSource(
       before.hooksIndexSource,
+    ),
+    onboardingBootstrapSource: patchAliceOnboardingBootstrapAuthProbeSource(
+      before.onboardingBootstrapSource,
     ),
     startupShellSource: patchAliceStartupShellAuthGateSource(
       before.startupShellSource,
@@ -4297,6 +4379,11 @@ export function applyAliceUiAuthGatedStartupPatch({
   const writes = [
     [paths.appPath, before.appSource, after.appSource],
     [paths.hooksIndexPath, before.hooksIndexSource, after.hooksIndexSource],
+    [
+      paths.onboardingBootstrapPath,
+      before.onboardingBootstrapSource,
+      after.onboardingBootstrapSource,
+    ],
     [paths.startupShellPath, before.startupShellSource, after.startupShellSource],
     [
       paths.startupPhasePollPath,

--- a/scripts/apply-alice-eliza-runtime-patches.test.ts
+++ b/scripts/apply-alice-eliza-runtime-patches.test.ts
@@ -479,6 +479,14 @@ describe("Alice Eliza runtime patch contract", () => {
         "state",
         "startup-phase-poll.ts",
       );
+      const onboardingBootstrapPath = path.join(
+        tempDir,
+        "packages",
+        "ui",
+        "src",
+        "state",
+        "onboarding-bootstrap.ts",
+      );
       const startupPhaseRuntimePath = path.join(
         tempDir,
         "packages",
@@ -506,6 +514,7 @@ describe("Alice Eliza runtime patch contract", () => {
       for (const filePath of [
         appPath,
         hooksIndexPath,
+        onboardingBootstrapPath,
         startupShellPath,
         startupPhasePollPath,
         startupPhaseRuntimePath,
@@ -514,6 +523,32 @@ describe("Alice Eliza runtime patch contract", () => {
       ]) {
         mkdirSync(path.dirname(filePath), { recursive: true });
       }
+
+      writeFileSync(
+        onboardingBootstrapPath,
+        [
+          "export interface ExistingOnboardingProbeClient {",
+          "  apiAvailable: boolean;",
+          "  getOnboardingStatus: () => Promise<{ complete: boolean }>;",
+          "  getConfig: () => Promise<Record<string, unknown> | null | undefined>;",
+          "}",
+          "",
+          "export async function detectExistingOnboardingConnection(args: {",
+          "  client: ExistingOnboardingProbeClient;",
+          "  timeoutMs: number;",
+          "}) {",
+          "  if (!args.client.apiAvailable) {",
+          "    return null;",
+          "  }",
+          "",
+          '  const timeoutToken = Symbol("onboarding-bootstrap-timeout");',
+          "  const status = await args.client.getOnboardingStatus().catch(() => null);",
+          "  if (!status) return null;",
+          "  const config = await args.client.getConfig().catch(() => null);",
+          "  return config ? { detectedExistingInstall: true } : null;",
+          "}",
+        ].join("\n"),
+      );
 
       writeFileSync(
         startupPhaseRuntimePath,
@@ -766,6 +801,10 @@ describe("Alice Eliza runtime patch contract", () => {
       const patchedSources = {
         appSource: readFileSync(appPath, "utf8"),
         hooksIndexSource: readFileSync(hooksIndexPath, "utf8"),
+        onboardingBootstrapSource: readFileSync(
+          onboardingBootstrapPath,
+          "utf8",
+        ),
         startupShellSource: readFileSync(startupShellPath, "utf8"),
         startupPhasePollSource: readFileSync(startupPhasePollPath, "utf8"),
         startupPhaseRuntimeSource: readFileSync(startupPhaseRuntimePath, "utf8"),
@@ -776,6 +815,22 @@ describe("Alice Eliza runtime patch contract", () => {
       expect(isAliceUiAuthGatedStartupPatched(patchedSources)).toBe(true);
       expect(patchedSources.startupPhaseRuntimeSource).toContain(
         'dispatch({ type: "BACKEND_AUTH_REQUIRED" });',
+      );
+      expect(patchedSources.onboardingBootstrapSource).toContain(
+        "getAuthStatus?: () => Promise",
+      );
+      expect(patchedSources.onboardingBootstrapSource).toContain(
+        "Auth-gated origins must not run protected onboarding probes before a browser session exists.",
+      );
+      expect(patchedSources.onboardingBootstrapSource).toContain(
+        "args.client.hasToken?.() === true",
+      );
+      expect(
+        patchedSources.onboardingBootstrapSource.indexOf("getAuthStatus"),
+      ).toBeLessThan(
+        patchedSources.onboardingBootstrapSource.indexOf(
+          "getOnboardingStatus",
+        ),
       );
       expect(patchedSources.startupPhaseRuntimeSource).not.toContain(
         "Advance to ready so the auth gate",


### PR DESCRIPTION
## Summary
- defer the eager app Agent.getStatus probe while browser auth is required so unauthenticated staging does not hit /api/status before login
- extend Alice's eliza source-mode patch to skip protected onboarding/config probes until a browser session exists
- preserve the existing renderer boot idempotency contract covered by the app boot test

## Tests
- source ~/.nvm/nvm.sh && nvm use && node --check scripts/apply-alice-eliza-runtime-patches.mjs && bun test scripts/apply-alice-eliza-runtime-patches.test.ts apps/app/test/main.boot.test.ts
- git diff --check

## Note
- apps/app TypeScript check is currently blocked by the repo-local tsconfig/tooling state: missing bun-types and TS5103 ignoreDeprecations value.