### PR TITLE
fix: suppress config probes before browser auth

### DIFF
--- a/packages/app-core/src/api/client-agent-auth-config.test.ts
+++ b/packages/app-core/src/api/client-agent-auth-config.test.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { MiladyClient } from "./client";
+
+describe("MiladyClient getConfig auth gate", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("skips protected config fetch when the browser is not authenticated", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      calls.push(url);
+      if (url.endsWith("/api/auth/status")) {
+        return new Response(
+          JSON.stringify({
+            required: true,
+            authenticated: false,
+            localAccess: false,
+            pairingEnabled: true,
+            expiresAt: 123,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.endsWith("/api/config")) {
+        throw new Error("config should not be requested before auth");
+      }
+      throw new Error(`unexpected request ${url}`);
+    }) as typeof fetch;
+
+    const client = new MiladyClient("https://staging-alice.example");
+
+    await expect(client.getConfig()).resolves.toEqual({});
+    expect(calls).toEqual(["https://staging-alice.example/api/auth/status"]);
+  });
+
+  it("fetches config after the browser is authenticated", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      calls.push(url);
+      if (url.endsWith("/api/auth/status")) {
+        return new Response(
+          JSON.stringify({
+            required: true,
+            authenticated: true,
+            localAccess: false,
+            pairingEnabled: true,
+            expiresAt: 123,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.endsWith("/api/config")) {
+        return new Response(JSON.stringify({ ui: { avatarIndex: 2 } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected request ${url}`);
+    }) as typeof fetch;
+
+    const client = new MiladyClient("https://staging-alice.example");
+
+    await expect(client.getConfig()).resolves.toEqual({
+      ui: { avatarIndex: 2 },
+    });
+    expect(calls).toEqual([
+      "https://staging-alice.example/api/auth/status",
+      "https://staging-alice.example/api/config",
+    ]);
+  });
+
+  it("keeps the split client-agent implementation on the same auth gate", () => {
+    const source = fs.readFileSync(
+      path.resolve(import.meta.dirname, "client-agent.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain("auth?.required === true");
+    expect(source).toContain("auth.authenticated === false");
+    expect(source).toContain("auth.localAccess !== true");
+    expect(source.indexOf("this.getAuthStatus().catch")).toBeLessThan(
+      source.indexOf('this.fetch("/api/config")'),
+    );
+  });
+});

--- a/packages/app-core/src/api/client-agent.ts
+++ b/packages/app-core/src/api/client-agent.ts
@@ -222,6 +222,10 @@ declare module "./client-base" {
     }>;
     getAuthStatus(): Promise<{
       required: boolean;
+      authenticated?: boolean;
+      localAccess?: boolean;
+      loginRequired?: boolean;
+      passwordConfigured?: boolean;
       pairingEnabled: boolean;
       expiresAt: number | null;
     }>;
@@ -1012,6 +1016,17 @@ MiladyClient.prototype.getConfig = async function (this: MiladyClient) {
   logSettingsClient("GET /api/config → start", {
     baseUrl: this.getBaseUrl(),
   });
+  const auth = await this.getAuthStatus().catch(() => null);
+  if (
+    auth?.required === true &&
+    auth.authenticated === false &&
+    auth.localAccess !== true
+  ) {
+    logSettingsClient("GET /api/config → skipped auth-gated browser", {
+      baseUrl: this.getBaseUrl(),
+    });
+    return {};
+  }
   const r = (await this.fetch("/api/config")) as Record<string, unknown>;
   const cloud = r.cloud as Record<string, unknown> | undefined;
   logSettingsClient("GET /api/config ← ok", {

--- a/packages/app-core/src/api/client.ts
+++ b/packages/app-core/src/api/client.ts
@@ -2775,6 +2775,10 @@ export class MiladyClient {
 
   async getAuthStatus(): Promise<{
     required: boolean;
+    authenticated?: boolean;
+    localAccess?: boolean;
+    loginRequired?: boolean;
+    passwordConfigured?: boolean;
     pairingEnabled: boolean;
     expiresAt: number | null;
   }> {
@@ -3055,6 +3059,17 @@ export class MiladyClient {
     logSettingsClient("GET /api/config → start", {
       baseUrl: this.getBaseUrl(),
     });
+    const auth = await this.getAuthStatus().catch(() => null);
+    if (
+      auth?.required === true &&
+      auth.authenticated === false &&
+      auth.localAccess !== true
+    ) {
+      logSettingsClient("GET /api/config → skipped auth-gated browser", {
+        baseUrl: this.getBaseUrl(),
+      });
+      return {};
+    }
     const r = (await this.fetch("/api/config")) as Record<string, unknown>;
     const cloud = r.cloud as Record<string, unknown> | undefined;
     logSettingsClient("GET /api/config ← ok", {


### PR DESCRIPTION
## Summary
- gate getConfig behind /api/auth/status when browser auth is required and the current browser is unauthenticated
- keep authenticated sessions fetching the real config
- cover the monolithic and split client-agent implementations with regression tests

## Tests
- source ~/.nvm/nvm.sh && nvm use && bun test packages/app-core/src/api/client-agent-auth-config.test.ts apps/app/test/main.boot.test.ts scripts/apply-alice-eliza-runtime-patches.test.ts
- git diff --check