### PR TITLE
fix: guard eliza ui config before browser auth

### DIFF
--- a/scripts/apply-alice-eliza-runtime-patches.mjs
+++ b/scripts/apply-alice-eliza-runtime-patches.mjs
@@ -45,6 +45,7 @@ const uiOnboardingBootstrapRelativePath =
   "packages/ui/src/state/onboarding-bootstrap.ts";
 const uiAppShellStateRelativePath =
   "packages/ui/src/state/useAppShellState.ts";
+const uiClientAgentRelativePath = "packages/ui/src/api/client-agent.ts";
 const appVincentStateRelativePath = "plugins/app-vincent/src/useVincentState.ts";
 const agentRuntimeRelativePath = "packages/agent/src/runtime/eliza.ts";
 const agentPluginResolverRelativePath =
@@ -4130,6 +4131,56 @@ function patchAliceUseAppShellStateAuthGateSource(source) {
   return next.replace(effectAnchor, effectPatch);
 }
 
+function patchAliceUiClientAgentConfigAuthGateSource(source) {
+  if (source.includes("GET /api/config → skipped auth-gated browser")) {
+    return source;
+  }
+
+  const anchor = `ElizaClient.prototype.getConfig = async function (this: ElizaClient) {
+  logSettingsClient("GET /api/config → start", {
+    baseUrl: this.getBaseUrl(),
+  });
+  const r = (await this.fetch("/api/config")) as Record<string, unknown>;
+  const cloud = r.cloud as Record<string, unknown> | undefined;
+  logSettingsClient("GET /api/config ← ok", {
+    baseUrl: this.getBaseUrl(),
+    topKeys: Object.keys(r).sort(),
+    cloud: settingsDebugCloudSummary(cloud),
+  });
+  return r;
+};
+`;
+  const patch = `ElizaClient.prototype.getConfig = async function (this: ElizaClient) {
+  logSettingsClient("GET /api/config → start", {
+    baseUrl: this.getBaseUrl(),
+  });
+  const auth = await this.getAuthStatus().catch(() => null);
+  if (
+    auth?.required === true &&
+    auth.authenticated === false &&
+    auth.localAccess !== true
+  ) {
+    logSettingsClient("GET /api/config → skipped auth-gated browser", {
+      baseUrl: this.getBaseUrl(),
+    });
+    return {};
+  }
+  const r = (await this.fetch("/api/config")) as Record<string, unknown>;
+  const cloud = r.cloud as Record<string, unknown> | undefined;
+  logSettingsClient("GET /api/config ← ok", {
+    baseUrl: this.getBaseUrl(),
+    topKeys: Object.keys(r).sort(),
+    cloud: settingsDebugCloudSummary(cloud),
+  });
+  return r;
+};
+`;
+  if (!source.includes(anchor)) {
+    throw new Error("ui client-agent config auth gate anchor drifted");
+  }
+  return source.replace(anchor, patch);
+}
+
 function patchAliceUiHooksIndexAuthStatusExportSource(source) {
   if (source.includes('export * from "./useAuthStatus";')) {
     return source;
@@ -4274,6 +4325,7 @@ export function isAliceUiAuthGatedStartupPatched({
   startupPhasePollSource = "",
   startupPhaseRuntimeSource = "",
   appShellStateSource = "",
+  clientAgentSource = "",
   vincentStateSource = "",
 } = {}) {
   return (
@@ -4295,6 +4347,8 @@ export function isAliceUiAuthGatedStartupPatched({
     appSource.includes('authState.phase !== "authenticated"') &&
     appShellStateSource.includes("useAuthStatus({ observeOnly: true })") &&
     appShellStateSource.includes('authState.phase !== "authenticated"') &&
+    clientAgentSource.includes("GET /api/config → skipped auth-gated browser") &&
+    clientAgentSource.includes("this.getAuthStatus().catch") &&
     hooksIndexSource.includes('export * from "./useAuthStatus";') &&
     vincentStateSource.includes("useAuthStatus") &&
     vincentStateSource.includes('const authReady = authState.phase === "authenticated";')
@@ -4319,6 +4373,7 @@ export function applyAliceUiAuthGatedStartupPatch({
       uiStartupPhaseRuntimeRelativePath,
     ),
     appShellStatePath: path.join(elizaRoot, uiAppShellStateRelativePath),
+    clientAgentPath: path.join(elizaRoot, uiClientAgentRelativePath),
     vincentStatePath: path.join(elizaRoot, appVincentStateRelativePath),
   };
 
@@ -4339,6 +4394,7 @@ export function applyAliceUiAuthGatedStartupPatch({
     startupPhasePollSource: readFileSync(paths.startupPhasePollPath, "utf8"),
     startupPhaseRuntimeSource: readFileSync(paths.startupPhaseRuntimePath, "utf8"),
     appShellStateSource: readFileSync(paths.appShellStatePath, "utf8"),
+    clientAgentSource: readFileSync(paths.clientAgentPath, "utf8"),
     vincentStateSource: readFileSync(paths.vincentStatePath, "utf8"),
   };
 
@@ -4366,6 +4422,9 @@ export function applyAliceUiAuthGatedStartupPatch({
     ),
     appShellStateSource: patchAliceUseAppShellStateAuthGateSource(
       before.appShellStateSource,
+    ),
+    clientAgentSource: patchAliceUiClientAgentConfigAuthGateSource(
+      before.clientAgentSource,
     ),
     vincentStateSource: patchAliceVincentStateAuthGateSource(
       before.vincentStateSource,
@@ -4400,6 +4459,7 @@ export function applyAliceUiAuthGatedStartupPatch({
       before.appShellStateSource,
       after.appShellStateSource,
     ],
+    [paths.clientAgentPath, before.clientAgentSource, after.clientAgentSource],
     [paths.vincentStatePath, before.vincentStateSource, after.vincentStateSource],
   ];
   let patchedFiles = 0;

--- a/scripts/apply-alice-eliza-runtime-patches.test.ts
+++ b/scripts/apply-alice-eliza-runtime-patches.test.ts
@@ -503,6 +503,14 @@ describe("Alice Eliza runtime patch contract", () => {
         "state",
         "useAppShellState.ts",
       );
+      const clientAgentPath = path.join(
+        tempDir,
+        "packages",
+        "ui",
+        "src",
+        "api",
+        "client-agent.ts",
+      );
       const vincentStatePath = path.join(
         tempDir,
         "plugins",
@@ -519,6 +527,7 @@ describe("Alice Eliza runtime patch contract", () => {
         startupPhasePollPath,
         startupPhaseRuntimePath,
         appShellStatePath,
+        clientAgentPath,
         vincentStatePath,
       ]) {
         mkdirSync(path.dirname(filePath), { recursive: true });
@@ -736,6 +745,39 @@ describe("Alice Eliza runtime patch contract", () => {
       );
 
       writeFileSync(
+        clientAgentPath,
+        [
+          'import { ElizaClient } from "./client-base";',
+          "",
+          "function logSettingsClient(phase, detail) {",
+          "  return undefined;",
+          "}",
+          "",
+          "function settingsDebugCloudSummary(cloud) {",
+          "  return cloud;",
+          "}",
+          "",
+          "ElizaClient.prototype.getConfig = async function (this: ElizaClient) {",
+          '  logSettingsClient("GET /api/config → start", {',
+          "    baseUrl: this.getBaseUrl(),",
+          "  });",
+          '  const r = (await this.fetch("/api/config")) as Record<string, unknown>;',
+          "  const cloud = r.cloud as Record<string, unknown> | undefined;",
+          '  logSettingsClient("GET /api/config ← ok", {',
+          "    baseUrl: this.getBaseUrl(),",
+          "    topKeys: Object.keys(r).sort(),",
+          "    cloud: settingsDebugCloudSummary(cloud),",
+          "  });",
+          "  return r;",
+          "};",
+          "",
+          "ElizaClient.prototype.getConfigSchema = async function (this: ElizaClient) {",
+          '  return this.fetch("/api/config/schema");',
+          "};",
+        ].join("\n"),
+      );
+
+      writeFileSync(
         hooksIndexPath,
         [
           'export * from "./useActivityEvents";',
@@ -809,6 +851,7 @@ describe("Alice Eliza runtime patch contract", () => {
         startupPhasePollSource: readFileSync(startupPhasePollPath, "utf8"),
         startupPhaseRuntimeSource: readFileSync(startupPhaseRuntimePath, "utf8"),
         appShellStateSource: readFileSync(appShellStatePath, "utf8"),
+        clientAgentSource: readFileSync(clientAgentPath, "utf8"),
         vincentStateSource: readFileSync(vincentStatePath, "utf8"),
       };
 
@@ -844,6 +887,14 @@ describe("Alice Eliza runtime patch contract", () => {
       );
       expect(patchedSources.appShellStateSource).toContain(
         'authState.phase !== "authenticated"',
+      );
+      expect(patchedSources.clientAgentSource).toContain(
+        "GET /api/config → skipped auth-gated browser",
+      );
+      expect(
+        patchedSources.clientAgentSource.indexOf("this.getAuthStatus().catch"),
+      ).toBeLessThan(
+        patchedSources.clientAgentSource.indexOf('this.fetch("/api/config")'),
       );
       expect(patchedSources.vincentStateSource).toContain(
         "if (!authReady) return false;",


### PR DESCRIPTION
## Summary
- patches deploy-time Eliza UI source so ElizaClient.getConfig preflights /api/auth/status
- skips protected /api/config when remote browser auth is required but not authenticated
- extends the Alice runtime patch contract test to cover the Eliza UI client path

## Tests
- source ~/.nvm/nvm.sh && nvm use && bun test scripts/apply-alice-eliza-runtime-patches.test.ts packages/app-core/src/api/client-agent-auth-config.test.ts apps/app/test/main.boot.test.ts
- source ~/.nvm/nvm.sh && nvm use && node --check scripts/apply-alice-eliza-runtime-patches.mjs
- git diff --check