### PR TITLE
chore(deps): coherent @elizaos/* beta.1 pins; eliza upstream bump analysis

### DIFF
--- a/deploy/cloud-agent-template/package.json
+++ b/deploy/cloud-agent-template/package.json
@@ -6,9 +6,9 @@
     "start": "tsx entrypoint.ts"
   },
   "dependencies": {
-    "@elizaos/core": "2.0.0-alpha.115",
-    "@elizaos/plugin-sql": "2.0.0-alpha.18",
-    "@elizaos/plugin-elizacloud": "2.0.0-alpha.7",
+    "@elizaos/core": "2.0.0-beta.1",
+    "@elizaos/plugin-sql": "2.0.0-beta.1",
+    "@elizaos/plugin-elizacloud": "2.0.0-beta.1",
     "tsx": "4.21.0"
   }
 }

--- a/plugins/plugin-bluebubbles/typescript/package.json
+++ b/plugins/plugin-bluebubbles/typescript/package.json
@@ -24,7 +24,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@elizaos/core": "2.0.0-alpha.3",
+		"@elizaos/core": "workspace:*",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/plugins/plugin-signal/typescript/package.json
+++ b/plugins/plugin-signal/typescript/package.json
@@ -45,7 +45,7 @@
     "format:check": "bunx @biomejs/biome format ."
   },
   "dependencies": {
-    "@elizaos/core": "2.0.0-alpha.3",
+    "@elizaos/core": "workspace:*",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -54,7 +54,7 @@
     "@biomejs/biome": "^2.3.11"
   },
   "peerDependencies": {
-    "@elizaos/core": "2.0.0-alpha.3"
+    "@elizaos/core": ">=2.0.0-beta.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Starts the eliza + milady upstream coherence work. Lands the **high-confidence** half (npm/dist-tag coherence so a fresh resolve cannot pull a pre-`addHeader` core and crashloop alice-bot) and documents the **needs-human-review** half (the large eliza submodule develop merge), per a bias-to-correctness / preserve-Alice mandate.

Base branch is `fix/alice-companion-restoration` (where all the Alice work lives), not `main`, so the diff is reviewable against the Alice baseline.

## Root cause of the crashloop (confirmed)

- Default source mode is **`local`** (`DEFAULT_ELIZA_SOURCE_MODE = "local"`): `@elizaos/*` resolves from the `eliza/` submodule, currently on the Alice branch at core **`2.0.0-beta.1`**.
- The submodule's upstream base `30c595e1` is **already at upstream core `2.0.0-beta.1`** and is an ancestor of upstream `origin/main`; the 12 Alice commits sit cleanly on top. So the submodule is on the coherent beta.1 line.
- The incoherence was in **hardcoded npm pins** that disagreed with beta.1:
  - `deploy/cloud-agent-template` declared `@elizaos/core@2.0.0-alpha.115` (pre-`addHeader`), `plugin-sql@2.0.0-alpha.18`, `plugin-elizacloud@2.0.0-alpha.7`. This is the leaked `core@2.0.0-alpha.115` seen in `bun.lock`.
  - `plugin-bluebubbles` / `plugin-signal` (in-repo workspace plugins) declared `@elizaos/core@2.0.0-alpha.3`.

## Latest coherent published set (verified against npm)

- npm `beta` dist-tag = `2.0.0-beta.1` for **both** `@elizaos/core` and `@elizaos/plugin-shell`; `plugin-shell@beta.1` depends on `core@2.0.0-beta.1`.
- `core@2.0.0-beta.1` published 2026-05-10 (newer than `alpha.537` from 2026-05-04), ships `dist/node/index.node.js`, and exports `addHeader` (named export in `dist/node/index.node.js`; `export { addHeader, composePromptFromState, ... }` in the type surface).
- `plugin-sql@2.0.0-beta.1` peerDeps `core@2.0.0-beta.1`; `plugin-elizacloud@2.0.0-beta.1` deps `core@2.0.0-beta.1`. Fully coherent.

## Changes in this PR

- `deploy/cloud-agent-template/package.json`: core/sql/elizacloud → `2.0.0-beta.1`.
- `plugins/plugin-bluebubbles/typescript/package.json`: core → `workspace:*`.
- `plugins/plugin-signal/typescript/package.json`: core dep → `workspace:*`, peer → `>=2.0.0-beta.1`.

## Verification done / not done

- Verified: npm version coherence + `addHeader`/native-binding presence in the published `core@2.0.0-beta.1` tarball; the three edited package.json files are valid JSON; eliza submodule pointer unchanged; no Alice files touched.
- NOT run (environment lacks `node_modules`; full install builds 70+ workspaces + eliza submodule + native deps): `bun install` lockfile regen, `bun run verify` (typecheck/lint), build. **A `bun install` is required** to materialize the deploy-template change into `bun.lock`; the lockfile was intentionally left for CI rather than hand-edited (a partial hand edit would fail `--frozen-lockfile`).

## Eliza submodule upstream bump — deferred to human review

`elizaOS/eliza` `origin/develop` is **~5609 commits** ahead of the Alice base (now core `2.0.3-beta.0`; `main` at `2.0.3`). That merge overlaps **85 of the 134 Alice-touched files**, including the companion/avatar/broadcast stack (`CompanionAppView.tsx`, `CompanionView.tsx`, `CompanionHeader.tsx`), core entries (`index.node.ts`, `index.browser.ts`), and app-core API/runtime (`server.ts`, `eliza.ts`, `auth.ts`). Auto-resolving 85 conflicts without a build would risk dropping Alice features, so it is **not** attempted here. Branch `chore/upstream-eliza-milady-bump` is pushed to the `rndrntwrk` eliza fork as the staging point for that merge.

## Alice features confirmed present (preserved)

`packages/plugin-555stream`, `eliza/plugins/app-companion`, `eliza/plugins/plugin-streaming`, avatar/broadcast assets, `packages/vrm-utils`, the 12 Alice eliza commits, and `scripts/apply-alice-eliza-runtime-patches.mjs` + `scripts/alice-eliza-runtime-patches/*` are all intact and untouched.